### PR TITLE
Fix for python 3.11

### DIFF
--- a/bases/rsptx/interactives/runestone/__init__.py
+++ b/bases/rsptx/interactives/runestone/__init__.py
@@ -118,14 +118,11 @@ def setup(app):
     # This should save some configuration headaches as we transition from RST to PTX
     app.set_html_assets_policy("always")
     # Include JS and CSS produced by webpack. See `webpack static imports <webpack_static_imports>`_.
-    with open(
-        importlib.resources.path("runestone.dist", "webpack_static_imports.json"),
-        "r",
-        encoding="utf-8",
-    ) as f:
-        wb_imports = json.load(f)
-        script_files = wb_imports["js"]
-        _css_files = css_files + wb_imports["css"]
+    with importlib.resources.path("runestone.dist", "webpack_static_imports.json") as p:
+        with open(p) as f:
+            wb_imports = json.load(f)
+            script_files = wb_imports["js"]
+            _css_files = css_files + wb_imports["css"]
 
     for jsfile in script_files:
         try:

--- a/bases/rsptx/interactives/runestone/__main__.py
+++ b/bases/rsptx/interactives/runestone/__main__.py
@@ -159,15 +159,14 @@ def build(all, wd):
     else:
         os.chdir(findProjectRoot())
     sys.path.insert(0, os.getcwd())
-    if not pathlib.Path(
-        importlib.resources.path("runestone.dist", "webpack_static_imports.json")
-    ).exists():
-        click.echo(
-            "Error -- you are missing webpack_static_imports.json.  Please make sure"
-        )
-        click.echo("you have Runestone installed correctly.")
-        click.echo("In a development environment, execute npm run build.")
-        sys.exit(-1)
+    with importlib.resources.path("runestone.dist", "webpack_static_imports.json") as p:
+        if not pathlib.Path(p).exists():
+            click.echo(
+                "Error -- you are missing webpack_static_imports.json.  Please make sure"
+            )
+            click.echo("you have Runestone installed correctly.")
+            click.echo("In a development environment, execute npm run build.")
+            sys.exit(-1)
 
     version = importlib.metadata.version("runestone")
     print("Building with Runestone {}".format(version))


### PR DESCRIPTION
I'm actually confused why this is needed. The `path` method is deprecated as of 3.11 but the description of what it does is the same as in 3.10. But with this change I can run `python -m runestone build` under both 3.10 and 3.11 while without it it explodes under 3.11. 