### PR TITLE
React Fixes

### DIFF
--- a/bases/rsptx/interactives/runestone/common/js/renderComponent.js
+++ b/bases/rsptx/interactives/runestone/common/js/renderComponent.js
@@ -126,6 +126,10 @@ export function createTimedComponent(componentSrc, moreOpts) {
 export async function renderOneComponent(rsDiv) {
     // Find the actual component inside the runestone component.
     let component = rsDiv.querySelector("[data-component]");
+    if (component == null) {
+        console.log("Render was called for a component, but now [data-component] attribute is present. This may mean the component has already been rendered.")
+        return;
+    }
     let componentKind = component.dataset.component;
     await runestone_import(componentKind);
     if ($(this).closest("[data-component=timedAssessment]").length == 0) {


### PR DESCRIPTION
When React requests that several components render at once, there is a webpack error relating to importing various Runestone components. Though the exact cause of the error is unclear, it is a race condition of some sort.

This PR adds a queuing system to imports. All imports requested by Runestone within 10ms of each other are queued. They are all imported together and then control is passed back to Runestone.