### PR TITLE
Add "Reformat" button to activecode elements.

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.css
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.css
@@ -36,7 +36,8 @@
 }
 
 .ac_actions {
-    text-align: center;
+    display: flex;
+    justify-content: center;
 }
 
 .ac_sep {

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.en.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.en.js
@@ -11,6 +11,7 @@ $.i18n().load({
         msg_activecode_show_codelens: "Show CodeLens",
         msg_activecode_show_in_codelens: "Show in CodeLens",
         msg_activecode_hide_codelens: "Hide Codelens",
+        msg_activecode_reformat: "Reformat",
 
         msg_activecode_parse_error:
             "A parse error means that Python does not understand the syntax on the line the error message points out. Common examples are forgetting commas beteween arguments or forgetting a : on a for statement",

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.pt-br.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.pt-br.js
@@ -11,6 +11,7 @@ $.i18n().load({
         msg_activecode_show_codelens: "Mostrar CodeLens",
         msg_activecode_show_in_codelens: "Mostrar em CodeLens",
         msg_activecode_hide_codelens: "Ocultar Codelens",
+        msg_activecode_reformat: "Reformatar",
 
         msg_activecode_parse_error:
             "Um erro de Parse significa que Python não entende a sintaxe da linha que a mensagem de erro aponta. Exemplos comuns são esquecer vírgulas entre argumentos ou esquecer ':' em um comando for.",

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.sr-Cyrl.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.sr-Cyrl.js
@@ -11,6 +11,7 @@ $.i18n().load({
         msg_activecode_show_codelens: "Корак по корак",
         msg_activecode_show_in_codelens: "Корак по корак",
         msg_activecode_hide_codelens: "Затвори корак по корак",
+        msg_activecode_reformat: "Реформат",
 
         msg_sctivecode_parse_error:
             "Синтаксна грешка (parse error) значи да Пајтон не разуме синтаксу у линији кога на коју порука о грешци указује. Типични примери овакве грешке су заборавлјена двотачка код 'if' или 'for' исказа или заборављена запета између аргумената код позива функције",

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -36,6 +36,9 @@ import embed from "vega-embed";
 // Adapt for use outside webpack -- see https://github.com/vega/vega-embed.
 window.vegaEmbed = embed;
 
+//import { prettier } from "prettier";
+
+
 var isMouseDown = false;
 var stopExecution = false;
 
@@ -247,6 +250,7 @@ export class ActiveCode extends RunestoneBase {
                 editor.acEditEvent = true;
             }.bind(this)
         ); // use bind to preserve *this* inside the on handler.
+
         //Solving Keyboard Trap of ActiveCode: If user use tab for navigation outside of ActiveCode, then change tab behavior in ActiveCode to enable tab user to tab out of the textarea
         $(window).keydown(function (e) {
             var code = e.keyCode ? e.keyCode : e.which;
@@ -929,6 +933,13 @@ export class ActiveCode extends RunestoneBase {
             act: "view",
             div_id: this.divid,
         });
+    }
+
+    async reformat() {
+        const current = this.editor.getValue();
+        //const reformatted = prettier.format(current, { semi: true, parser: "babel" });
+        const reformatted = current.replace(/\s+/g, ' ');
+        this.editor.setValue(reformatted);
     }
 
     toggleEditorVisibility() {}

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -423,7 +423,7 @@ export class ActiveCode extends RunestoneBase {
     enableReformat(ctrlDiv) {
         let butt = document.createElement("button");
         $(butt).addClass("ac_opt btn btn-default");
-        $(butt).text("Reformat"); // FIXME add to i18n
+        $(butt).text($.i18n("msg_activecode_reformat"));
         $(butt).css("margin-left", "10px");
         this.reformatButton = butt;
         ctrlDiv.appendChild(butt);

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -324,7 +324,9 @@ export class ActiveCode extends RunestoneBase {
         }
 
         // Code reformatting
-        this.enableReformat(ctrlDiv)
+        if (reformatable.has(this.language)) {
+            this.enableReformat(ctrlDiv);
+        }
 
         // Audio Tour
         if ($(this.origElem).data("audio")) {
@@ -1471,6 +1473,15 @@ var languageExtensions = {
     sql: "sql",
     octave: "m",
 };
+
+// Languages that get a "Reformat" button. Probably works fine for any curly
+// brace language but better not to add them until someone actually checks a
+// book using that language. Definitely works badly for Python since it will
+// indent anything after an `if` to be part of the if.
+var reformatable = new Set([
+    "java",
+]);
+
 
 var errorText = {};
 

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -321,6 +321,10 @@ export class ActiveCode extends RunestoneBase {
         if ($(this.origElem).data("codelens") && !this.graderactive) {
             this.enableCodeLens(ctrlDiv);
         }
+
+        // Code reformatting
+        this.enableReformat(ctrlDiv)
+
         // Audio Tour
         if ($(this.origElem).data("audio")) {
             this.enableAudioTours(ctrlDiv);
@@ -413,6 +417,16 @@ export class ActiveCode extends RunestoneBase {
         this.clButton = butt;
         ctrlDiv.appendChild(butt);
         $(butt).click(this.showCodelens.bind(this));
+    }
+
+    enableReformat(ctrlDiv) {
+        let butt = document.createElement("button");
+        $(butt).addClass("ac_opt btn btn-default");
+        $(butt).text("Reformat"); // FIXME add to i18n
+        $(butt).css("margin-left", "10px");
+        this.reformatButton = butt;
+        ctrlDiv.appendChild(butt);
+        $(butt).click(this.reformat.bind(this));
     }
 
     enableAudioTours(ctrlDiv) {

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -933,82 +933,11 @@ export class ActiveCode extends RunestoneBase {
     }
 
     async reformat() {
-        const current = this.editor.getValue();
-        // We just do a quick and dirty reindentation based on braces since
-        // CodeMirror doesn't do anything smarter when you hit tab but insert
-        // four spaces. Walk through the string and each time we hit an open {
-        // increment the indent amount and each time we hit a } decrease it.
-        // Then after each newline, insert an appropriate number of spaces and
-        // skip any actual spaces in the text. The only tricky bit to be
-        // actually correct is we need to also keep track of when we're in
-        // string and character literals and comments so we ignore {}s in those
-        // contexts.
-
-        current.replace(/\r/g, '');
-
-        let indent = 0;
-        let reformatted = '';
-        let i = 0;
-        while (i < current.length) {
-            const c = current[i++];
-            if (c === '\n') {
-                // Emit the newline.
-                reformatted += '\n';
-
-                // Skip current indentation
-                while (i < current.length && current[i] === ' ') {
-                    i++;
-                }
-
-                if (i < current.length) {
-                    const next = current[i];
-                    if (next === '\n') {
-                        // Let it get handles the next time around
-                        continue;
-                    } else {
-                        if (next === '}') {
-                            // Gotta check this so we decrease the indentation
-                            // before we emit the close brace.
-                            indent--;
-                        }
-                        // Emit new indentation
-                        console.log(`Emitting ${indent} levels of indentation`);
-                        for (let j = 0; j < indent * 4; j++) {
-                            reformatted += ' ';
-                        }
-
-                        if (next === '{') {
-                            console.log(`Increasing indent to ${indent}`);
-                            indent++;
-                        }
-
-                        // Can emit all other characters here since they don't
-                        // require special handling.
-                        reformatted += next;
-                        i++;
-                    }
-                }
-            } else if (c === '{') {
-                console.log(`Increasing indent to ${indent}`);
-                indent++;
-                reformatted += c;
-            } else if (c === '}') {
-                // If we get here it means the } is not after a newline. In that
-                // case, we want to emit a newlne and the appropriate
-                // indentation (decreased because of the }) and then the }.
-                console.log(`Hit weirdly placed } at ${i}`);
-                indent--;
-                reformatted += '\n';
-                // Emit new indentation
-                for (let j = 0; j < indent * 4; j++) {
-                    reformatted += ' ';
-                }
-                reformatted += '}'
-            } else {
-                reformatted += c;
-            }
+        const first = this.editor.firstLine();
+        const last = this.editor.lastLine();
+        for (let i = first; i <= last; i++) {
+            this.editor.indentLine(i);
         }
-        this.editor.setValue(reformatted);
     }
 
     toggleEditorVisibility() {}

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -938,6 +938,7 @@ export class ActiveCode extends RunestoneBase {
         for (let i = first; i <= last; i++) {
             this.editor.indentLine(i);
         }
+        this.reformatButton.blur();
     }
 
     toggleEditorVisibility() {}

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -932,7 +932,7 @@ export class ActiveCode extends RunestoneBase {
         });
     }
 
-    async reformat() {
+    reformat() {
         const first = this.editor.firstLine();
         const last = this.editor.lastLine();
         for (let i = first; i <= last; i++) {


### PR DESCRIPTION
Turns out CodeMirror has an API for indenting lines which is good since that way the formatting will be consistent with what you get by hitting tab and shift-tab while editing code. So this was actually quite simple to add.