### PR TITLE
Move the new runestone-sphinx class up to the HTML element.

### DIFF
--- a/bases/rsptx/interactives/ptxrs-bootstrap.less
+++ b/bases/rsptx/interactives/ptxrs-bootstrap.less
@@ -52,7 +52,3 @@
     --componentBorderColor: #939090;
     --questionBgColor: rgb(23, 85, 93);    
 }
-
-body.runestone-sphinx {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-}

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -19,6 +19,11 @@
 <!DOCTYPE html>
 {%- endblock %}
 
+<!-- Add an extra class to the root to help differentiate runestone classic from pretext+runestone -->
+{%- set html_tag -%}
+<html {% if not html5_doctype %} xmlns="http://www.w3.org/1999/xhtml"{% endif %}{% if language is not none %} lang="{{ language }}"{% endif %} class="runestone-sphinx">
+{%- endset %}
+
 {%- block scripts %}
 {# Override the scripts block from sphinx so we can force loading of jquery/underscore/doctools js files #}
 {{ js_defer(script_files) }}
@@ -227,8 +232,6 @@
 {% endmacro %}
 
 {%- block extrahead %}
-<!-- Add an extra class to the root to help differentiate runestone classic from pretext+runestone -->
-{%- block body_tag %}<body class="runestone-sphinx">{% endblock %}
 
   {% if not favicon %}
 <link rel="shortcut icon" href="/{{appname}}/static/favicon.ico" type="image/ico" />


### PR DESCRIPTION
I think with `runestone-sphinx` added at the body it wasn't quite workin because the styles coming from Bootstrap included styles on `body` itself. By moving the class to the `html` element, those styles apply again.

With this change, custom CSS from the book will need to be changed to use, e.g. `.runestone-sphinx h1` rather than just `h1` but this at least brings back the styling of the body such as the smaller `font-size` and larger `line-height`.