### PR TITLE
Add --with=dev in a few more places in docs.

### DIFF
--- a/docs/source/developing.rst
+++ b/docs/source/developing.rst
@@ -235,7 +235,7 @@ Each project has a Dockerfile for building an image. These images should
 be push-able to our docker container registry and or the public docker
 container registry
 
-To build all of the docker containers and bring them up together.  You can run the ``build.py`` script in the top level directory. The dependencies for the build.py script are included in the top level ``pyproject.toml`` file.  ``poetry install`` will install everything you need and then you may will want to start up a poetry shell. The ``build.py`` script will build all of the Python wheels and Docker images, when that completes run ``docker-compose up``.  You can also run ``docker-compose up`` directly if you have already built the images.  
+To build all of the docker containers and bring them up together.  You can run the ``build.py`` script in the top level directory. The dependencies for the build.py script are included in the top level ``pyproject.toml`` file.  ``poetry install --with=dev`` will install everything you need and then you may will want to start up a poetry shell. The ``build.py`` script will build all of the Python wheels and Docker images, when that completes run ``docker-compose up``.  You can also run ``docker-compose up`` directly if you have already built the images.  
 
 When developing and you need multiple servers running
 =====================================================
@@ -294,7 +294,7 @@ The following is what you need to do to work on the javascript for a component t
 
 1. Make a branch in your clone of ``https://github.com/RunestoneInteractive/rs``
 2. Work on the javascript for the component in ``bases/rsptx/interactives/runestone/...``
-3. Run ``poetry install`` in the root folder of your clone of ``rs``
+3. Run ``poetry install --with=dev`` in the root folder of your clone of ``rs``
 4. Start up a ``poetry shell`` in the root folder of your clone of ``rs``
 5. From ``bases/rsptx/interactives`` run ``npm run build`` → results in ``runestone/dist``
 6. From ``bases/rsptx/interactives`` run ``python ./scripts/dist2xml.py test`` → creates webpack_static_imports.xml and sets up for the files to be in ``_static/test`` in the resulting local build of your PreTeXt book.


### PR DESCRIPTION
I think these are both right. I lost some time because I was following one of these and just did `poetry install` rather than `poetry install --with=dev`.