### PR TITLE
Fix: Move to a Windows-friendly subprocess approach.

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,19 +1,28 @@
 #!/usr/bin/env python3
-
-import os
+#
+# `build.py` - Build the wheels and Docker containers needed for this application
+# ===============================================================================
+#
+# Imports
+# -------
+import asyncio
+import io
 import locale
-from shutil import copyfile
+import os
 import subprocess
 import sys
+from shutil import copyfile
+from typing import Any
 
 # use python-dotenv >= 0.21.0
 from dotenv import load_dotenv
 from rich.console import Console
-from rich.table import Table
 from rich.live import Live
+from rich.table import Table
 from rsptx.cl_utils.core import pushd
-import sh
 
+# Check environment variables
+# ---------------------------
 print("Checking your environment")
 if not os.path.exists(".env"):
     print("No .env file found.  Please copy sample.env to .env and edit it.")
@@ -24,6 +33,7 @@ if "--verbose" in sys.argv:
 else:
     VERBOSE = False
 
+# Per the [docs](https://pypi.org/project/python-dotenv/), load `.env` into environment variables.
 load_dotenv()
 console = Console()
 table = Table(title="Environment Variables")
@@ -67,13 +77,11 @@ else:
     print("DC_DEV_DBURL set.  Using it instead of DEV_DBURL")
 
 if not os.path.isfile("bases/rsptx/web2py_server/applications/runestone/models/1.py"):
-    # copy 1.py.prototype to 1.py
     print("Copying 1.py.prototype to 1.py")
     copyfile(
         "bases/rsptx/web2py_server/applications/runestone/models/1.py.prototype",
         "bases/rsptx/web2py_server/applications/runestone/models/1.py",
     )
-
 
 if finish:
     print(
@@ -92,10 +100,14 @@ if finish:
 #           return codecs.charmap_encode(input,self.errors,encoding_table)[0]
 #       UnicodeEncodeError: 'charmap' codec can't encode characters in position 55319-55358: character maps to <undefined>
 try:
-    stdout_err_encoding = locale.getencoding()
+    # Since this isn't defined on all Python versions, tell mypy to ignore the following error.
+    stdout_err_encoding = locale.getencoding()  # type: ignore[attr-defined]
 except AttributeError:
     stdout_err_encoding = locale.getpreferredencoding()
 
+
+# Build wheels
+# ------------
 table = Table(title="Build Wheels")
 table.add_column("Project", justify="right", style="cyan", no_wrap=True)
 table.add_column("Built", style="magenta")
@@ -118,35 +130,60 @@ with Live(table, refresh_per_second=4):
                                 f.write(res.stderr.decode(stdout_err_encoding))
 
 
-# When using subprocess there is no nice way to try (short of threads) to capture the output and send
-# it to the console while also capturing it to a file.  So we use sh instead.
-# https://amoffat.github.io/sh/index.html
-# sh "knows" about all of the commands on your PATH
+# Build Docker containers
+# -----------------------
+# The following code is based on a post on [SO](https://stackoverflow.com/a/66400096/16038919).
+## {
+# Given an input and output(s), copy from one to the other(s).
+async def output_stream(input_stream: asyncio.StreamReader, *output_stream: io.IOBase):
+    while not input_stream.at_eof():
+        output = await input_stream.readline()
+        for _os in output_stream:
+            _os.write(output)
+            _os.flush()
 
-# define a function that will take the output from the background process
-# if it matches a pattern we are looking for, print it to the console
-def process_output(line, stdin, process):
-    if "naming to docker.io" in line and "done" in line:
-        print(line[line.rindex("/") + 1 :].replace("done", "").strip())
+
+# Run a subprocess and stream the output while it runs. Return the process' return code.
+async def run_command(*command: str, **kwargs: Any) -> int:
+    # Start the subprocess.
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        **kwargs,
+    )
+    # Since we passed `PIPE` for these, they should be available.
+    assert process.stderr is not None
+    assert process.stdout is not None
+
+    # Stream stdout and stderr while it runs. Save all stdout to a file.
+    with open("build.log", "ab") as f:
+        # Note that the asyncio subprocess `stderr` and `stdout` produces bytes only, not text. So, we need to write to `sys.stdout/err` as binary. Therefore, use [.buffer](https://docs.python.org/3/library/io.html#io.TextIOBase.buffer).
+        await asyncio.gather(
+            output_stream(process.stderr, sys.stderr.buffer),
+            output_stream(process.stdout, sys.stdout.buffer, f),
+        )
+
+    # Terminate it nicely.
+    #
+    # `process.communicate()` will have no data to read but will close the
+    # pipes that are implemented in C, whereas `process.wait()`` will not.
+    stdout_data, stderr_data = await process.communicate()
+    assert not stdout_data and not stderr_data
+
+    assert process.returncode is not None
+    return process.returncode
+
+
+## }
 
 
 print("Building docker images...")
-# res = subprocess.run(["docker", "compose", "build"], capture_output=True)
-
-try:
-    # such a cool way to run "docker compose build" and capture the output
-    res = sh.docker.compose.build(
-        "--progress", "plain", _out=process_output, _bg=True, _tee=True
-    )
-    res.wait()
+ret = asyncio.run(run_command("docker", "compose", "build"))
+if ret == 0:
     print("Docker images built successfully")
-    with open("build.log", "a") as f:
-        f.write(res.stdout.decode(stdout_err_encoding))
-except sh.ErrorReturnCode:
+else:
     print(
         "Docker images failed to build, see build.log for details (or run with --verbose)"
     )
-    print(res.stderr.decode(stdout_err_encoding))
-    with open("build.log", "a") as f:
-        f.write(res.stderr.decode(stdout_err_encoding))
     exit(1)

--- a/build.py
+++ b/build.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python3
 #
-# `build.py` - Build the wheels and Docker containers needed for this application
-# ===============================================================================
+# `build.py` - Build the wheels and Docker containers needed for this
+# application
+# ===================================================================
 #
 # Imports
 # -------
-import asyncio
-import io
 import locale
 import os
 import subprocess
 import sys
 from shutil import copyfile
-from typing import Any
 
 # use python-dotenv >= 0.21.0
 from dotenv import load_dotenv
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
-from rsptx.cl_utils.core import pushd
+from rsptx.cl_utils.core import pushd, stream_command, subprocess_streamer
 
 # Check environment variables
 # ---------------------------
@@ -33,7 +31,8 @@ if "--verbose" in sys.argv:
 else:
     VERBOSE = False
 
-# Per the [docs](https://pypi.org/project/python-dotenv/), load `.env` into environment variables.
+# Per the [docs](https://pypi.org/project/python-dotenv/), load `.env` into
+# environment variables.
 load_dotenv()
 console = Console()
 table = Table(title="Environment Variables")
@@ -89,7 +88,11 @@ if finish:
     )
     exit(1)
 
-# Attempt to determine the encoding of data returned from stdout/stderr of subprocesses. This is non-trivial. See the discussion at [Python's sys.stdout](https://docs.python.org/3/library/sys.html#sys.stdout). First, try `locale.getencoding()` (requires >= 3.11), with a fallback to `locale.getpreferredencoding()`.
+# Attempt to determine the encoding of data returned from stdout/stderr of
+# subprocesses. This is non-trivial. See the discussion at [Python's
+# sys.stdout](https://docs.python.org/3/library/sys.html#sys.stdout). First, try
+# `locale.getencoding()` (requires >= 3.11), with a fallback to
+# `locale.getpreferredencoding()`.
 #
 # This is motivated by errors on Windows under Python 3.10:
 #
@@ -100,7 +103,8 @@ if finish:
 #           return codecs.charmap_encode(input,self.errors,encoding_table)[0]
 #       UnicodeEncodeError: 'charmap' codec can't encode characters in position 55319-55358: character maps to <undefined>
 try:
-    # Since this isn't defined on all Python versions, tell mypy to ignore the following error.
+    # Since this isn't defined on all Python versions, tell mypy to ignore the
+    # following error.
     stdout_err_encoding = locale.getencoding()  # type: ignore[attr-defined]
 except AttributeError:
     stdout_err_encoding = locale.getpreferredencoding()
@@ -132,54 +136,30 @@ with Live(table, refresh_per_second=4):
 
 # Build Docker containers
 # -----------------------
-# The following code is based on a post on [SO](https://stackoverflow.com/a/66400096/16038919).
-## {
-# Given an input and output(s), copy from one to the other(s).
-async def output_stream(input_stream: asyncio.StreamReader, *output_stream: io.IOBase):
-    while not input_stream.at_eof():
-        output = await input_stream.readline()
-        for _os in output_stream:
-            _os.write(output)
-            _os.flush()
-
-
-# Run a subprocess and stream the output while it runs. Return the process' return code.
-async def run_command(*command: str, **kwargs: Any) -> int:
-    # Start the subprocess.
-    process = await asyncio.create_subprocess_exec(
-        *command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        **kwargs,
+print("Building docker images (see build.log for detailed progress)...")
+with open("build.log", "ab") as f:
+    ret = stream_command(
+        "docker",
+        "compose",
+        "build",
+        # For stdout, stream only high points of the build to stdout; save
+        # *everything* to the log file.
+        stdout_streamer=subprocess_streamer(
+            sys.stdout.buffer,
+            f,
+            filter=lambda line: (
+                # Only show lines to stdout like `#18 naming to
+                # docker.io/library/rs-jobe 0.2s done`; just report the
+                # container name for brevity.
+                line[line.rindex(b"/") + 1 :].replace(b" done", b"").strip() + b"\n"
+                if b"naming to docker.io" in line and b"done" in line
+                else b"",
+                # Save everything to the file.
+                line,
+            ),
+        ),
+        stderr_streamer=subprocess_streamer(sys.stderr.buffer, f),
     )
-    # Since we passed `PIPE` for these, they should be available.
-    assert process.stderr is not None
-    assert process.stdout is not None
-
-    # Stream stdout and stderr while it runs. Save all stdout to a file.
-    with open("build.log", "ab") as f:
-        # Note that the asyncio subprocess `stderr` and `stdout` produces bytes only, not text. So, we need to write to `sys.stdout/err` as binary. Therefore, use [.buffer](https://docs.python.org/3/library/io.html#io.TextIOBase.buffer).
-        await asyncio.gather(
-            output_stream(process.stderr, sys.stderr.buffer),
-            output_stream(process.stdout, sys.stdout.buffer, f),
-        )
-
-    # Terminate it nicely.
-    #
-    # `process.communicate()` will have no data to read but will close the
-    # pipes that are implemented in C, whereas `process.wait()`` will not.
-    stdout_data, stderr_data = await process.communicate()
-    assert not stdout_data and not stderr_data
-
-    assert process.returncode is not None
-    return process.returncode
-
-
-## }
-
-
-print("Building docker images...")
-ret = asyncio.run(run_command("docker", "compose", "build"))
 if ret == 0:
     print("Docker images built successfully")
 else:

--- a/components/rsptx/cl_utils/core.py
+++ b/components/rsptx/cl_utils/core.py
@@ -1,67 +1,73 @@
-# ***************************************************************
-# ci_utils.py - Utilities supporting continuous integration tests
-# ***************************************************************
+# `core.py` - Utilities supporting continuous integration tests
+# ===============================================================
 #
 # Imports
-# =======
-# These are listed in the order prescribed by `PEP 8
-# <http://www.python.org/dev/peps/pep-0008/#imports>`_.
+# -------
+# These are listed in the order prescribed by [PEP
+# 8](http://www.python.org/dev/peps/pep-0008/#imports).
 #
-# Standard library
-# ----------------
+# ### Standard library
+import asyncio
+import io
 import os
-from pathlib import Path
 import subprocess
 import sys
-from typing import Any
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Literal, Sequence, cast
+
+# ### Local imports
 from dotenv import load_dotenv
 
 # OS detection
-# ============
-# This follows the `Python recommendations <https://docs.python.org/3/library/sys.html#sys.platform>`_.
+# ------------
+# This follows the [Python
+# recommendations](https://docs.python.org/3/library/sys.html#sys.platform).
 is_win = sys.platform == "win32"
 is_linux = sys.platform.startswith("linux")
 is_darwin = sys.platform == "darwin"
 
-# Copied from https://docs.python.org/3.5/library/platform.html#cross-platform.
+# Copied from the [Python
+# docs](https://docs.python.org/3.5/library/platform.html#cross-platform).
 is_64bits = sys.maxsize > 2**32
 
 
 # Support code
-# ============
-# xqt
-# ---
+# ------------
+# ### xqt
 # Pronounced "execute": provides a simple way to execute a system command.
 def xqt(
-    # Commands to run. For example, ``'foo -param firstArg secondArg', 'bar |
-    # grep alpha'``.
-    *cmds,
-    # This is passed directly to ``subprocess.run``.
-    check=True,
-    # This is passed directly to ``subprocess.run``.
-    shell=True,
-    # Optional keyword arguments to pass on to `subprocess.run <https://docs.python.org/3/library/subprocess.html#subprocess.run>`_.
-    **kwargs,
-):
-
+    # Commands to run. For example, `'foo -param firstArg secondArg', 'bar |
+    # grep alpha'`.
+    *cmds: list[str],
+    # This is passed directly to `subprocess.run`.
+    check: bool = True,
+    # This is passed directly to `subprocess.run`.
+    shell: bool = True,
+    # Optional keyword arguments to pass on to
+    # [subprocess.run](https://docs.python.org/3/library/subprocess.html#subprocess.run).
+    **kwargs: Any,
+) -> subprocess.CompletedProcess | list[subprocess.CompletedProcess]:
     ret = []
-    # Although https://docs.python.org/3/library/subprocess.html#subprocess.Popen
-    # states, "The only time you need to specify ``shell=True`` on Windows is
-    # when the command you wish to execute is built into the shell (e.g.
-    # **dir** or **copy**). You do not need ``shell=True`` to run a batch file
-    # or console-based executable.", use ``shell=True`` to both allow shell
-    # commands and to support simple redirection (such as ``blah > nul``,
-    # instead of passing ``stdout=subprocess.DEVNULL`` to ``check_call``).
+    # Although the
+    # [docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen)
+    # state, "The only time you need to specify `shell=True` on Windows is when
+    # the command you wish to execute is built into the shell (e.g. **dir** or
+    # **copy**). You do not need `shell=True` to run a batch file or
+    # console-based executable.", use `shell=True` to both allow shell commands
+    # and to support simple redirection (such as `blah > nul`, instead of
+    # passing `stdout=subprocess.DEVNULL` to `check_call`).
     for cmd in cmds:
-        # Per http://stackoverflow.com/questions/15931526/why-subprocess-stdout-to-a-file-is-written-out-of-order,
-        # the ``run`` below will flush stdout and stderr, causing all
-        # the subprocess output to appear first, followed by all the Python
-        # output (such as the print statement above). So, flush the buffers to
-        # avoid this.
+        # Per
+        # [SO](http://stackoverflow.com/questions/15931526/why-subprocess-stdout-to-a-file-is-written-out-of-order),
+        # the `run` below will flush stdout and stderr, causing all the
+        # subprocess output to appear first, followed by all the Python output
+        # (such as the print statement above). So, flush the buffers to avoid
+        # this.
         wd = kwargs.get("cwd", os.getcwd())
         flush_print(f"{wd}$ {cmd}")
-        # Use bash instead of sh, so that ``source`` and other bash syntax
-        # works. See https://docs.python.org/3/library/subprocess.html#subprocess.Popen.
+        # Use bash instead of sh, so that `source` and other bash syntax works.
+        # See
+        # [subprocess.popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen).
         executable = "/bin/bash" if is_linux or is_darwin else None
         try:
             cp = subprocess.run(
@@ -76,11 +82,11 @@ def xqt(
     return ret[0] if len(ret) == 1 else ret
 
 
-# env
-# ---
-# Transforms ``os.environ["ENV_VAR"]`` to the more compact ``env.ENV_VAR``. Returns ``None`` if the env var doesn't exist.
+# ### env
+# Transforms `os.environ["ENV_VAR"]` to the more compact `env.ENV_VAR`. Returns
+# `None` if the env var doesn't exist.
 class EnvType(type):
-    def __getattr__(cls, name: str):
+    def __getattr__(cls, name: str) -> str | None:
         return os.environ.get(name)
 
     def __setattr__(cls, name: str, value: Any) -> None:
@@ -91,48 +97,40 @@ class env(metaclass=EnvType):
     pass
 
 
-# pushd
-# -----
+# ### pushd
 # A context manager for pushd.
 class pushd:
     def __init__(
         self,
         # The path to change to upon entering the context manager.
-        path,
+        path: str | Path,
     ):
-
         self.path = path
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         flush_print("pushd {}".format(self.path))
         self.cwd = os.getcwd()
         os.chdir(str(self.path))
 
-    def __exit__(self, type_, value, traceback):
+    def __exit__(self, type_, value, traceback) -> Literal[False]:
         flush_print("popd - returning to {}.".format(self.cwd))
         os.chdir(str(self.cwd))
         return False
 
 
-# Common tools
-# ============
-#
-# chdir
-# -----
-def chdir(path):
+# ### chdir
+def chdir(path: str | Path) -> None:
     flush_print(f"cd {path}")
     os.chdir(str(path))
 
 
-# mkdir
-# -----
-def mkdir(path, *args, **kwargs):
+# ### mkdir
+def mkdir(path: str | Path, *args, **kwargs) -> None:
     flush_print(f"mkdir {path}")
     Path(path).mkdir(*args, **kwargs)
 
 
-# load .env file
-# --------------
+# ### load .env file
 def load_project_dotenv(dotenv_path=None):
     if Path(".env").exists():
         load_dotenv()
@@ -144,29 +142,137 @@ def load_project_dotenv(dotenv_path=None):
             print(f"Loaded .env file from {os.environ['RUNESTONE_PATH']}")
 
 
-# flush_print
-# -----------
-# Anything sent to ``print`` won't be printed until Python flushes its buffers,
+# ### flush_print
+# Anything sent to `print` won't be printed until Python flushes its buffers,
 # which means what CI logs report may be reflect what's actually being executed
 # -- until the buffers are flushed.
-def flush_print(*args, **kwargs):
+def flush_print(*args: Any, **kwargs: Any) -> None:
     print(*args, **kwargs)
-    # Flush both buffers, just in case there's something in ``stdout``.
+    # Flush both buffers, just in case there's something in either one.
     sys.stdout.flush()
     sys.stderr.flush()
 
 
-# isfile
-# ------
-def isfile(f):
+# ### isfile
+def isfile(f: str | Path) -> bool:
     _ = Path(f).is_file()
     flush_print(f"File {f} {'exists' if _ else 'does not exist'}.")
     return _
 
 
-# isdir
-# -----
-def isdir(f):
+# ### isdir
+def isdir(f: str | Path) -> bool:
     _ = Path(f).is_dir()
     flush_print(f"Directory {f} {'exists' if _ else 'does not exist'}.")
     return _
+
+
+# This defines the type of an `async` function passed to `stream_command`.
+SubprocessStreamerType = Callable[
+    # It takes one argument: an stream produced by the subprocess (either
+    # `process.stdout` or `process.stderr`). See the [docs](https://docs.python.org/3/library/asyncio-stream.html#streamreader).
+    [asyncio.StreamReader],
+    # It produces no output, but must be an `async`` function.
+    Awaitable[None]]
+
+
+# ### Subprocess streaming
+# The following code was originally based on a post on
+# [SO](https://stackoverflow.com/a/66400096/16038919).
+## {
+# This is for use with `stream_command`: provide it with output(s) and an
+# (optional) filter, and it will stream data from from the subprocess's
+# stdout/stderr to the `output_stream`(s) given below.
+def subprocess_streamer(
+    # Where to stream the data; typically, `sys.stdout.buffer` or
+    # `sys.stderr.buffer`. Note that the asyncio subprocess `stderr` and
+    # `stdout` produces bytes only, not text. So, we need to write to
+    # `sys.stdout/err` as binary. Therefore, use
+    # [.buffer](https://docs.python.org/3/library/io.html#io.TextIOBase.buffer).
+    *output_stream: io.IOBase,
+    # This optional function filters which input should be written to the
+    # output(s). If not specified, all input is written to the output(s).
+    filter: Callable[
+        # The function takes one parameter: the line read from the process.
+        [bytes],
+        # It produces one output: either
+        #
+        # - The line to write to each `output_stream`, or
+        # - a sequence of lines to write to each `output_stream`; the first
+        #   element of the list is written to the first `output_stream`, etc.
+        bytes | Sequence[bytes],
+    ] = lambda line: line,
+) -> SubprocessStreamerType:
+    async def _output_stream(
+        # `async_run_command` will call this with either `process.stdout` or
+        # `process.stderr`.
+        input_stream: asyncio.StreamReader,
+    ) -> None:
+        while not input_stream.at_eof():
+            output = await input_stream.readline()
+            filtered_output = filter(output)
+            if filtered_output:
+                for index, _os in enumerate(output_stream):
+                    _os.write(
+                        filtered_output
+                        if isinstance(filtered_output, bytes)
+                        else filtered_output[index]
+                    )
+                    _os.flush()
+
+    return _output_stream
+
+
+# Run a subprocess and stream the output while it runs. Return the process'
+# return code. This is typically called by `stream_command`.
+async def async_stream_command(
+    # The command to execute; same as the arguments to `subprocess`.
+    *command: str,
+    # Functions which stream the stdout/stderr produced as the command executes.
+    # See the `SubprocessStreamerType` documentation above for more details.
+    stdout_streamer: SubprocessStreamerType = subprocess_streamer(
+        cast(io.IOBase, sys.stdout.buffer)
+    ),
+    stderr_streamer: SubprocessStreamerType = subprocess_streamer(
+        cast(io.IOBase, sys.stderr.buffer)
+    ),
+    # These are passed directly to the underlying `subprocess` call.
+    **kwargs: Any,
+    # The return code produced when the subprocess exits.
+) -> int:
+    # Add stdout/stderr destinations if they aren't specified.
+    kwargs.setdefault("stdout", asyncio.subprocess.PIPE)
+    kwargs.setdefault("stderr", asyncio.subprocess.PIPE)
+
+    # Start the subprocess.
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        **kwargs,
+    )
+    # Determine what to stream.
+    stream = []
+    if process.stdout is not None:
+        stream.append(stdout_streamer(process.stdout))
+    if process.stderr is not None:
+        stream.append(stderr_streamer(process.stderr))
+
+    # Stream stdout and stderr while it runs.
+    await asyncio.gather(*stream)
+
+    # Terminate it nicely.
+    #
+    # `process.communicate()` will have no data to read but will close the pipes
+    # that are implemented in C, whereas `process.wait()` will not.
+    stdout_data, stderr_data = await process.communicate()
+    assert not stdout_data and not stderr_data
+
+    assert process.returncode is not None
+    return process.returncode
+
+
+# The primary function to call, which runs the above function in `asyncio`.
+def stream_command(*args: str, **kwargs: Any) -> int:
+    return asyncio.run(async_stream_command(*args, **kwargs))
+
+
+## }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 # This is the Root pyproject.toml
+# ===============================
 #
+# Poetry configuration
+# --------------------
 [tool.poetry]
 name = "rs"
 version = "0.1.0"
@@ -21,7 +24,7 @@ packages = [
     {include = "rsptx/validation", from = "components"},
     {include = "rsptx/templates", from = "components"},
     {include = "rsptx/cl_utils", from = "components"},
-    {include = "runestone", from = "bases/rsptx/interactives"},    
+    {include = "runestone", from = "bases/rsptx/interactives"},
     {include = "rsptx/author_server_api", from = "bases"},
     {include = "rsptx/book_server_api", from = "bases"},
     {include = "rsptx/web2py_server", from = "bases"},
@@ -88,7 +91,6 @@ sphinxcontrib-paverutils = "^1.17.0"
 cogapp = "^3.3.0"
 asyncclick = "^8.1.3.4"
 pgcli = "^3.5.0"
-sh = "^2.0.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "~= 22.0"
@@ -98,8 +100,10 @@ coverage = "^6.0.0"
 coveralls = "^3.0.0"
 flake8 = "^4.0.0"
 html5validator = "^0.3.0"
+isort = "^5"
 locust = "^1.0.0"
 mock = "^4.0.0"
+mypy = "^1"
 # For the plugin.
 polling2 = "^0.5.0"
 pytest = "^7.0.0"
@@ -116,3 +120,10 @@ json2xml = "^3.21.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+# isort configuration
+# -------------------
+# See the [docs](https://pycqa.github.io/isort/docs/configuration/black_compatibility.html).
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This removed the filtering that was added earlier. I didn't fully understand why the filter only accepted those strings, and also think seeing all output is helpful for a person watching the output. The old filter was:

``` Python
    if "naming to docker.io" in line and "done" in line:
        print(line[line.rindex("/") + 1 :].replace("done", "").strip())
```