### PR TITLE
Fix $1 $2

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.en.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.en.js
@@ -104,7 +104,7 @@ $.i18n().load({
         msg_activecode_were_compiling_err:
             "There were errors compiling your code. See below.",
         msg_activecode_time_limit_exc: "Time Limit Exceeded on your program",
-        msg_activecode_server_err: "A server error occurred: $1 $2",
+        msg_activecode_server_err: "A server error occurred",
         msg_activecode_compiling_running:
             "Compiling and Running your Code Now...",
         msg_activecode_server_comm_err: "Error communicating with the server.",

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.pt-br.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode-i18n.pt-br.js
@@ -104,7 +104,7 @@ $.i18n().load({
         msg_activecode_were_compiling_err:
             "Houveram erros ao compilar seu código. Veja abaixo.",
         msg_activecode_time_limit_exc: "Limite de tempo excedido no seu programa",
-        msg_activecode_server_err: "Um erro de servidor ocorreu: $1 $2",
+        msg_activecode_server_err: "Um erro de servidor ocorreu",
         msg_activecode_compiling_running:
             "Compilando e executando seu código...",
         msg_activecode_server_comm_err: "Erro ao comunicar com o servidor.",

--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -115,7 +115,7 @@ export default class LiveCode extends ActiveCode {
                 import java.io.*;
                 ` + this.suffix;
             }
-            let classMatch = new RegExp(/public class\s+(\w+)[\s+{]/);
+            let classMatch = new RegExp(/public\s+class\s+(\w+)/);
             source = await this.buildProg(false);
             let m = source.match(classMatch);
             if (m) {


### PR DESCRIPTION
One of the more cryptic error message students using CSAwesome get from Runestone is the enigmatic:

```
A server error occurred: $1 $2
```

The main way to trigger that error is by adding a `;` immediately after the class name in an active code exercise. This PR fixes two things: it makes the regex that tries to find the name of the class more forgiving so

```
public class Foo;
{

}
```

will still be understood as trying to write a class named `Foo`.

The second is I've changed the error messages to not contain `$1 $2` since the only place that message is used it is not passed arguments.