### PR TITLE
Tidying up sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,48 +1,45 @@
 # Copy this file to .env docker-compose will read and use the values from here.
-# The build.py script is also aware of this file
+# The build.py script is also aware of this file and if you run `poetry self add
+# poetry-dotenv-plugin` when you run `poetry shell` it will also pick up these
+# variables and add them to your environment.
 
 # Where is the runestone app located (inside the container)
 RUNESTONE_PATH = /usr/local/lib/python3.10/site-packages/rsptx/web2py_server/applications/runestone
 
-# Database URLs
-# You may want to have a couple of different environment variables set up that essentially point
-# to the same database.  Therefore we have two variables. DEV_DBURL and DC_DEV_DBURL. The DC variant 
-# should only be set in this file for use with docker-compose.  But if you don't set it and you
-# have a DEV_DBURL variable set in your shell compose will use that as a back up.  In My development
-# environment I have:
-# DEV_DBURL= postgresql://user:pass@localhost/runestone_dev
-# DC_DEV_DBURL=postgresql://runestone:runestone@host.docker.internal/runestone_dev
+# Database URLs: You may want to have a couple of different environment
+# variables set up that essentially point to the same database. Therefore we use
+# one set of variables for use within docker, prefixed with DC_ and another pair
+# for use outside of docker. The DC variants should only be set in this file for
+# use with docker-compose. (If you don't set the DC_ variables, docker compose
+# will fall back to the other pair.)
 
-# Uncomment one or more of these.  If you run a database on the host then the DEV_DBURL uses 
-# a nice docker trick to connect to it.
-# DBURL = postgresql://username:password@production_host/runestone
-# TEST_DBURL=postgresql://runestone:runestone@host.docker.internal/runestone_test
-DC_DEV_DBURL=postgresql://runestone:runestone@host.docker.internal/runestone_dev
-DC_DBURL=postgresql://runestone:runestone@host.docker.internal/runestone
+DBURL = postgresql://runestone:runestone@localhost/runestone
+DC_DBURL = postgresql://runestone:runestone@host.docker.internal/runestone
+
+DEV_DBURL = postgresql://runestone:runestone@localhost/runestone_dev
+DC_DEV_DBURL = postgresql://runestone:runestone@host.docker.internal/runestone_dev
 
 # Server configuration (production, development, or test)
-# You should not set this to test as that is for our testing framework, not for 
+# You should not set these to test as that is for our testing framework, not for
 # people who are just testing out Runestone.
 SERVER_CONFIG=development
-WEB2PY_CONFIG=$SERVER_CONFIG
+WEB2PY_CONFIG=development
 
 # The path to runestone books (on the host) In the container is set to /books
-export BOOK_PATH=~/Runestone/books
-
+BOOK_PATH=~/Runestone/books
 
 ## !! change these !!
 # This replaces the private/auth.key file for web2py
-WEB2PY_PRIVATE_KEY=sha512:24c4e0f1-df85-44cf-87b9-67fc714f5653
+WEB2PY_PRIVATE_KEY = sha512:24c4e0f1-df85-44cf-87b9-67fc714f5653
 # This is the secret key for the javascript web token
 JWT_SECRET = supersecret
 
 # Set up host names
 # localhost is ok for development, but you should set this to the real hostname
 # if running a remote development server or definitely for production
-RUNESTONE_HOST=localhost
+RUNESTONE_HOST = localhost
 # for production where you run a front end load balancer
-LOAD_BALANCER_HOST=localhost 
+LOAD_BALANCER_HOST = localhost
 
 # If you want nginx to install a certificate
-# CERTBOT_EMAIL=myemail@foo.com
-
+# CERTBOT_EMAIL = myemail@foo.com


### PR DESCRIPTION
I think `.env` files don't actually support variable expansion so I fixed that and removed a stray `export`. And I added a comment about running `poetry self add poetry-dotenv-plugin` which is actually the real point of this PR.

I don't know if the default values I gave for the four `DBURL` variables are right but they work for me in both the docker composed server and when building the book in the shell created by `poetry shell`. 