### PR TITLE
Switch to byte-base64 to encode uploaded files.

### DIFF
--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "-": "0.0.1",
                 "bootstrap": "3.4.1",
+                "byte-base64": "^1.1.0",
                 "codemirror": "^5.59.4",
                 "handsontable": "7.2.2",
                 "jexcel": "^3.9.1",
@@ -747,6 +748,11 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
+        },
+        "node_modules/byte-base64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/byte-base64/-/byte-base64-1.1.0.tgz",
+            "integrity": "sha512-56cXelkJrVMdCY9V/3RfDxTh4VfMFCQ5km7B7GkIGfo4bcPL9aACyJLB0Ms3Ezu5rsHmLB2suis96z4fLM03DA=="
         },
         "node_modules/camel-case": {
             "version": "4.1.2",
@@ -6509,6 +6515,11 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
+        },
+        "byte-base64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/byte-base64/-/byte-base64-1.1.0.tgz",
+            "integrity": "sha512-56cXelkJrVMdCY9V/3RfDxTh4VfMFCQ5km7B7GkIGfo4bcPL9aACyJLB0Ms3Ezu5rsHmLB2suis96z4fLM03DA=="
         },
         "camel-case": {
             "version": "4.1.2",

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "-": "0.0.1",
         "bootstrap": "3.4.1",
+        "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",
         "jexcel": "^3.9.1",

--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -2,6 +2,7 @@ import { ActiveCode } from "./activecode.js";
 import MD5 from "./md5.js";
 import JUnitTestParser from "./extractUnitResults.js";
 import "../../codelens/js/pytutor-embed.bundle.js";
+import { base64encode } from "byte-base64";
 
 export default class LiveCode extends ActiveCode {
     constructor(opts) {
@@ -451,7 +452,7 @@ export default class LiveCode extends ActiveCode {
         var extensions = ["jar", "zip", "png", "jpg", "jpeg"];
         var contentsb64;
         if (extensions.indexOf(extension) === -1) {
-            contentsb64 = btoa(contents);
+            contentsb64 = base64encode(contents);
         } else {
             contentsb64 = contents;
         }


### PR DESCRIPTION
@bhoffman0 was running into problems with a new lesson that includes some file uploads when the files were not straight ASCII text because `btoa` was choking on them. This patch fixes that.