### PR TITLE
Don't remove specified defer attributes from custom js files.

### DIFF
--- a/bases/rsptx/interactives/runestone/__init__.py
+++ b/bases/rsptx/interactives/runestone/__init__.py
@@ -86,7 +86,10 @@ def runestone_extensions():
 def setup_js_defer(app, pagename, templatexname, context, doctree):
 
     filename_pat = re.compile("_static/(.*?)(?:\?.*)?$")
-    custom_js_files = { js["file"] if isinstance(js, dict) else js for js in setup.custom_js_files }
+    if hasattr(setup, 'custom_js_files'):
+        custom_js_files = { js["file"] if isinstance(js, dict) else js for js in setup.custom_js_files }
+    else:
+        custom_js_files = []
 
     def js_defer(script_files):
         for js in sorted(script_files):

--- a/bases/rsptx/interactives/runestone/__init__.py
+++ b/bases/rsptx/interactives/runestone/__init__.py
@@ -86,7 +86,7 @@ def runestone_extensions():
 def setup_js_defer(app, pagename, templatexname, context, doctree):
 
     filename_pat = re.compile("_static/(.*?)(?:\?.*)?$")
-    custom_js_files = { js["file"] for js in setup.custom_js_files }
+    custom_js_files = { js["file"] if isinstance(js, dict) else js for js in setup.custom_js_files }
 
     def js_defer(script_files):
         for js in sorted(script_files):

--- a/bases/rsptx/interactives/runestone/hparsons/test/conf.py
+++ b/bases/rsptx/interactives/runestone/hparsons/test/conf.py
@@ -229,7 +229,7 @@ html_static_path = ["_sources/_static"] + runestone_static_dirs()
 #   in which case file should have the file name and other key/value pairs are used as attrs
 #   on the script tag. The sample below will set sample2.js's script tag to have the defer attr
 # Files must be on a path contained in html_static_path
-#setup.custom_js_files = ["sample.css", {"file": "sample2.js", "defer": ""}]
+#setup.custom_js_files = ["sample.js", {"file": "sample2.js", "defer": ""}]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
So it turns out the reason none of my defer attributes were making it through is because there's some code that strips them all late in the game if `html_defer_js` is not `True`!

This patches leaves that basic mechanism alone as I don't understand quite what it's for but it carves out an exception for files specified via `setup.custom_js_files` so we can specify a `defer` attribute if we want.