### PR TITLE
Remove html level font-size change in rsptx .less

### DIFF
--- a/bases/rsptx/interactives/ptxrs-bootstrap.less
+++ b/bases/rsptx/interactives/ptxrs-bootstrap.less
@@ -52,7 +52,3 @@
     --componentBorderColor: #939090;
     --questionBgColor: rgb(23, 85, 93);    
 }
-
-html {
-    font-size: 10pt;
-}


### PR DESCRIPTION
The purged code adds a font-size to the HTML element of any pretext book that makes use of runestone components.

At a bit of a loss for why it is injected into the CSS. Purging it does not appear to break any runestone components.

If it does serve a purpose, there must be a better way to achieve the goal than to change entire page's base font size. Happy to tinker with that if you can point me to what this is trying to do.