### PR TITLE
Fix: remove internal scrollbar on course assignment list

### DIFF
--- a/components/rsptx/templates/staticAssets/course.css
+++ b/components/rsptx/templates/staticAssets/course.css
@@ -1,9 +1,3 @@
-.assignment_chooser {
-    max-height: 400px;
-    overflow-y: scroll;
-    margin-bottom: 20px;
-}
-
 .course_page {
     width: 90%;
     margin-left: auto;


### PR DESCRIPTION
Now that the course change dropdown moved up, you no longer need the height and scrollbar on the assignment list. Right now, there is a double scroll bar and the scrollbar appears even if there are no assignments.
<img width="951" alt="image" src="https://github.com/RunestoneInteractive/rs/assets/4571962/bb314fac-f391-41f7-9414-e24692f909e9">
When there are no assignments:
<img width="942" alt="image" src="https://github.com/RunestoneInteractive/rs/assets/4571962/20c89970-2b2c-432f-a62f-f78a9a04db3d">
