### PR TITLE
Only target code elements inside sortable-code with float code so cod…

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/css/parsons.css
+++ b/bases/rsptx/interactives/runestone/parsons/css/parsons.css
@@ -198,15 +198,10 @@
     /*background-color: transparent;*/
 }
 
-.parsons code {
-    display: inline-block;
+.parsons .sortable-code code {
     clear: both;
     float: left;
     background-color: transparent;
-}
-
-.parsons-text code {
-    float: none;
 }
 
 .parsons .block p {


### PR DESCRIPTION
Fix parsons styling removing background from code that is part of problems statement. Turns this:
![image](https://github.com/RunestoneInteractive/rs/assets/7787413/436521b9-cab3-424d-bcd5-aca60386bc2e)

Into:
![image](https://github.com/RunestoneInteractive/rs/assets/7787413/5df8c4d6-d60b-4134-ab61-efb6f78d577a)
