### PR TITLE
Add navbar item to copy canonical href to clipboard.

### DIFF
--- a/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -1178,28 +1178,3 @@ margin-right: 3px;
   float:right;
   padding-left: 4px;
 }
-
-/* Give some indication that the click is doing something. */
-
-#canonical_permalink {
-  text-decoration: none !important;
-}
-
-#canonical_permalink:active {
-  transform: scale(0.85);
-}
-
-#canonical_permalink::after {
-  content: " Copied!";
-  display: inline-block;
-  opacity: 0;
-  padding-left: 5px;
-  width: 0;
-  transition: opacity 1s, width 1s;
-}
-
-#canonical_permalink:active::after {
-  opacity: 1;
-  width: 30px;
-  transition: opacity 0s, width 0s;
-}

--- a/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -1180,10 +1180,26 @@ margin-right: 3px;
 }
 
 /* Give some indication that the click is doing something. */
+
+#canonical_permalink {
+  text-decoration: none !important;
+}
+
 #canonical_permalink:active {
   transform: scale(0.85);
 }
 
-#canonical_permalink:active::after {
+#canonical_permalink::after {
   content: " Copied!";
+  display: inline-block;
+  opacity: 0;
+  padding-left: 5px;
+  width: 0;
+  transition: opacity 1s, width 1s;
+}
+
+#canonical_permalink:active::after {
+  opacity: 1;
+  width: 30px;
+  transition: opacity 0s, width 0s;
 }

--- a/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -1178,3 +1178,12 @@ margin-right: 3px;
   float:right;
   padding-left: 4px;
 }
+
+/* Give some indication that the click is doing something. */
+#canonical_permalink:active {
+  transform: scale(0.85);
+}
+
+#canonical_permalink:active::after {
+  content: " Copied!";
+}

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -153,6 +153,8 @@
           <li id="scratch_ac_link" class="dropdown"><a href="javascript:runestoneComponents.popupScratchAC()">
               <i class="glyphicon glyphicon-pencil" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Scratch Activecode" >Scratch Activecode</span></i></a></li>
         <!-- </li> -->
+          <li class="dropdown"><a id="canonical_permalink">
+              <i class="glyphicon glyphicon-link" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Shareable link" >Shareable link</span></i></a></li>
 
         <li class="divider-vertical"></li>
 
@@ -203,7 +205,7 @@
 {% endif %}
 
 {% raw %}
-<link rel="canonical" href="https://{{canonical_host}}{{new_server_prefix}}/books/published/{{base_course}}/{{pagepath}}" />
+<link rel="canonical" href="//{{canonical_host}}{{new_server_prefix}}/books/published/{{base_course}}/{{pagepath}}" />
 {% endraw %}
 
 <script>
@@ -398,6 +400,15 @@
   window.addEventListener('load', (event) => {
     runestoneComponents.getSwitch();
   });
+</script>
+
+<script>
+  // Make the permalink icon do it's thing, copying the canonical href to the
+  // clipboard.
+  document.getElementById('canonical_permalink').onclick = async () => {
+    const link = (document.querySelector('link[rel="canonical"]') || {}).href;
+    if (link) await navigator.clipboard.writeText(link);
+  };
 </script>
 
 {% endblock %}

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -118,7 +118,7 @@
           <ul class="dropdown-menu user-menu">
             <li><span class='loggedinuser'></span></li>
             <li class="divider"></li>
-            <li><a href='/ns/course/index'>Course Home</a></li>            
+            <li><a href='/ns/course/index'>Course Home</a></li>
             <li><a href='/assignment/student/chooseAssignment'>Assignments</a></li>
             <li><a href='/{{appname}}/assignments/practice'>Practice</a></li>
             <li id="inst_peer_link"><a href='/{{appname}}/peer/instructor.html'>Peer Instruction (Instructor)</a></li>
@@ -404,9 +404,9 @@
 <script>
   // Make the permalink icon do it's thing, copying the canonical href to the
   // clipboard.
-  document.getElementById('canonical_permalink').onclick = async () => {
-    const link = (document.querySelector('link[rel="canonical"]') || {}).href;
-    if (link) await navigator.clipboard.writeText(link);
+  document.getElementById('canonical_permalink').onclick = () => {
+    const link = document.querySelector('link[rel="canonical"]')?.href;
+    if (link) navigator.clipboard.writeText(link);
   };
 </script>
 

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -154,7 +154,7 @@
               <i class="glyphicon glyphicon-pencil" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Scratch Activecode" >Scratch Activecode</span></i></a></li>
         <!-- </li> -->
           <li class="dropdown"><a id="canonical_permalink">
-              <i class="glyphicon glyphicon-link" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Shareable link" >Shareable link</span></i></a></li>
+              <i class="glyphicon glyphicon-link" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Copy shareable link" >Copy shareable link</span></i></a></li>
 
         <li class="divider-vertical"></li>
 

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -129,6 +129,7 @@
 			      <li class="divider"></li>
             <li id="ip_dropdown_link"><a href='/{{appname}}/admin/index'>Instructor's Page</a></li>
             {% endif %}
+            <li><a id="canonical_permalink">Copy base course link</a></li>
             <li><a href='/{{appname}}/dashboard/studentreport'>Progress Page</a></li>
             <li class="divider"></li>
             {% if minimal_outside_links != 'True' %}
@@ -153,8 +154,6 @@
           <li id="scratch_ac_link" class="dropdown"><a href="javascript:runestoneComponents.popupScratchAC()">
               <i class="glyphicon glyphicon-pencil" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Scratch Activecode" >Scratch Activecode</span></i></a></li>
         <!-- </li> -->
-          <li class="dropdown"><a id="canonical_permalink">
-              <i class="glyphicon glyphicon-link" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Copy shareable link" >Copy shareable link</span></i></a></li>
 
         <li class="divider-vertical"></li>
 


### PR DESCRIPTION
This PR adds a very useful (to me, anyway) feature to make it easy to copy the canonical link to any page you're looking at in any book just by clicking the link icon I added to the navbar. We could make this an instructor only feature but I think it might be useful for students to who might want to send links to friends in other sections of the same class. So I made it available to everyone.

(I also changed the definition of the `<link rel="canonical">` to inherit the protocol from the current page rather than always being `https` to make it easier to test locally.)