### PR TITLE
Try to stop the progress bars from overflowing.

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/modules/db_dashboard.py
+++ b/bases/rsptx/web2py_server/applications/runestone/modules/db_dashboard.py
@@ -448,7 +448,13 @@ class SubChapterActivity(object):
         return "{0:.2f}%".format(float(self.started) / self.total_users * 100)
 
     def get_not_started_percent(self):
-        return "{0:.2f}%".format(float(self.not_started) / self.total_users * 100)
+        # We compute this one from the other two rather than pulling it directly
+        # from not_started in order to ensure the sum of the three doesn't go
+        # over 100.00 because when it does and these percentages are used as
+        # widths of sections of the bar, it overflows.
+        started = round(self.started / self.total_users * 100, 2)
+        completed = round(self.completed / self.total_users * 100, 2)
+        return "{0:.2f}%".format(100 - (started + completed))
 
     def get_completed_percent(self):
         return "{0:.2f}%".format(float(self.completed) / self.total_users * 100)


### PR DESCRIPTION
When looking at the actual student progress page for one of my current classes I noticed one of the rows getting weirdly indented.

![2023-08-20 at 1 54 PM](https://github.com/RunestoneInteractive/rs/assets/250053/6f6d7fd1-368d-4c05-89a5-dd534163ed95)

Poking around a bit it seems that the problem is the percentages of the preceding row, each rounded to two decimal places as they are to set the widths of each segment of the progress bar, add up to 100.01 and thus overflow the enclosing div. This patch tries to fix it. I couldn't figure out a good way to test it on my local cluster without creating 27 fake students, etc. but the page still at least works.