### PR TITLE
Fix display of a numbered list in developing.rst

### DIFF
--- a/docs/source/developing.rst
+++ b/docs/source/developing.rst
@@ -359,6 +359,7 @@ Getting a Server Started
 ------------------------
 
 This assumes that you have already followed the instructions for installing postgresql, poetry and the plugins as well as Docker.
+
 1. copy ``sample.env`` to ``.env`` and edit the file.
 2. Run ``poetry install --with=dev`` from the top level directory.  This will install all of the dependencies for the project.  When that completes run ``poetry shell`` to start a poetry shell.  You can verify that this worked correctly by running ``rsmanage env``.  You should see a list of environment variables that are set.  If you do not see them then you may need to run ``poetry shell`` again.  If you get an error message that you cannot interpret you can ask for help in the ``#developer`` channel on the Runestone discord server.
 3.  Create a new database for your class or book.  You can do this by running ``createdb -O runestone <dbname>``.  You can also do this in the psql command line interface by running ``create database <dbname> owner runestone;``  You may have to become the postgres user in order to run that command.  If you have already created a database you can skip this one.


### PR DESCRIPTION
This section currently displays in the docs as a big block of text because markdown is silly and requires an extra newline to work right in this case.

<img width="903" alt="Screenshot 2023-09-18 at 3 20 07 PM" src="https://github.com/RunestoneInteractive/rs/assets/365366/5fafdd1f-2567-455f-8a07-73a4c341ad2e">

Here is the github preview of the file after the change:
<img width="1094" alt="Screenshot 2023-09-18 at 3 23 04 PM" src="https://github.com/RunestoneInteractive/rs/assets/365366/b4d3c0f4-7f1b-4961-911b-32c30fda3f6d">
