### PR TITLE
minor CSS problem

### DIFF
--- a/bases/rsptx/interactives/runestone/common/css/user-highlights.css
+++ b/bases/rsptx/interactives/runestone/common/css/user-highlights.css
@@ -60,8 +60,6 @@ list-style-image: url('active.png');
     border-radius: 5px 5px 5px 5px;
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
     display: none;
-    float: left;
-    left: 0;
     list-style: none outside none;
     margin: 1px 0 0;
     min-width: 160px;


### PR DESCRIPTION
I see this when I am in an Assignment page and use the dropdown menu:

<img width="600" alt="Screenshot 2023-10-09 at 4 42 55 PM" src="https://github.com/RunestoneInteractive/rs/assets/4732672/53c2ef29-209b-4186-a075-71523ad7b2b2">

where the menu content spills over. If I remove the float CSS as in this PR, it becomes:

<img width="600" alt="Screenshot 2023-10-09 at 4 44 37 PM" src="https://github.com/RunestoneInteractive/rs/assets/4732672/55a3f983-5f64-4308-8e65-44b225d59350">

I'm not sure if the float CSS was in there for a reason, but I couldn't identify a reason to keep it. (However in testing, I found an issue with this page on small screens that I will report separately.)


This is also me testing the waters for submitting a PR to Runestone. Is it helpful to work this way instead of just reporting the issue? Like is this too small of a thing, and I should gather together other small things to package in one PR? Differnet projects have different customs, and I want to do whatever is helpful for RA.
