### PR TITLE
Fix: Update allowed CodeChat version which is compatible with Sphinx 5.

### DIFF
--- a/projects/interactives/pyproject.toml
+++ b/projects/interactives/pyproject.toml
@@ -99,7 +99,8 @@ packages = [
 python = "^3.10"
 cogapp = ">=2.5"
 click = "~8"
-CodeChat = "<1.9.4"
+# Newer CodeChat only supports Sphinx > 5, while Runestone requires Sphinx < 6.
+CodeChat = "==1.9.2"
 jinja2 = "<3.1.0"
 Paver = ">=1.2.4"
 six = ">1.12"

--- a/projects/w2p_login_assign_grade/pyproject.toml
+++ b/projects/w2p_login_assign_grade/pyproject.toml
@@ -53,7 +53,8 @@ gunicorn = "^21.0.0"
 # These are for testing and development.
 [tool.poetry.group.dev.dependencies]
 black = "~= 22.0"
-CodeChat = "^1.0.0"
+# Newer CodeChat only supports Sphinx > 5, while Runestone requires Sphinx < 6.
+CodeChat = "==1.9.2"
 contextlib2 = "^0.6.0"
 coverage = "^6.0.0"
 coveralls = "^3.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,8 @@ pycryptodome = "^3.18.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "~= 22.0"
-CodeChat = "^1.0.0"
+# Newer CodeChat only supports Sphinx > 5, while Runestone requires Sphinx < 6.
+CodeChat = "==1.9.2"
 contextlib2 = "^0.6.0"
 coverage = "^6.0.0"
 coveralls = "^3.0.0"


### PR DESCRIPTION
Fixes https://github.com/bjones1/CodeChat/issues/20.

A question: the Sphinx version specified in various parts of polylith is inconsistent. Is that OK? 

- `pyproject.toml` has `Sphinx = "> 4.1.0,<6.0"`
- `projects/interactives/pyproject.toml` has `Sphinx = ">=4.4.0,<6.0.0"`
- `projects/w2p_login_assign_grade/pyproject.toml` has `Sphinx = "> 4.1.0"`.

I'd be happy to submit a PR to make all the Sphinx dependencies be `Sphinx = ">=4.4.0,<6.0.0"` if that would help.
