### PR TITLE
Fix clarity in readme. issue396

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ are used to orchestrate the servers.
 Docs
 ----
 
-See `Our Read the Docs page <https://runestone-monorepo.readthedocs.io/en/latest/index.html>`_ for more complete documentation.  The `developing <https://runestone-monorepo.readthedocs.io/en/latest/developing.html>`_ section is especially useful if you are interested in contributing to the project.
+See `Our Read the Docs page <https://runestone-monorepo.readthedocs.io/en/latest/index.html>`_ for more complete documentation. After reading the whole page, please continue to the `Contributing Guide <https://runestone-monorepo.readthedocs.io/en/latest/contributing.html>`_.
  
 
 Development Roadmap


### PR DESCRIPTION
Issue: The ReadMe was a little confusing because new contributors were directed to two different pages, the developing section of the documentation and the contributing section of the documentation to get started,

Fix: Changed link from developing section of the documentation to contributing section of the documentation. Additionally, reminded readers to finish reading the readme before moving on.

Test: Built readme in branch and ensured proper formatting.

Fix #396

