### PR TITLE
for WeBWorK, store student_value with MC exercises

### DIFF
--- a/bases/rsptx/interactives/runestone/webwork/js/webwork.js
+++ b/bases/rsptx/interactives/runestone/webwork/js/webwork.js
@@ -96,12 +96,16 @@ class WebWork extends RunestoneBase {
             if (data.rh_result.answers[k].score == 1) {
                 correctCount += 1;
             }
+            // mostly grab original_student_ans, but grab student_value for MC exercises
+            let student_ans = ['Value (parserRadioButtons)', 'Value (PopUp)', 'Value (CheckboxList)'].includes(data.rh_result.answers[k].type)
+                ? data.rh_result.answers[k].student_value
+                : data.rh_result.answers[k].original_student_ans;
             this.answerObj.answers[
                 k
-            ] = `${data.rh_result.answers[k].original_student_ans}`;
+            ] = `${student_ans}`;
             let mqKey = `MaThQuIlL_${k}`;
             this.answerObj.mqAnswers[mqKey] = data.inputs_ref[mqKey];
-            actString += `actual:${data.rh_result.answers[k].original_student_ans}:expected:${data.rh_result.answers[k].correct_value}:`;
+            actString += `actual:${student_ans}:expected:${data.rh_result.answers[k].correct_value}:`;
         }
         let pct = correctCount / qCount;
         // If this.percent is set, then runestonebase will transmit it as part of


### PR DESCRIPTION
This should make it so that with MC questions, RS stores the actual value(s) of the input element(s) with MC exercises, instead of text strings associated with those input elements. 

I have not tested this at all because I don't know how I would go about doing that. Does the code look like it makes sense? If so, then the next thing to do is look at what gets saved for the exercises @Tanaquil18 listed in #373 (near the bottom of the thread at present) and see that this is indeed grabbing "values" and not strings that are unhelpful for identifying which items to select when restoring previous answers.

After this is in, I will have follow-up work in `pretext-webwork.js` to actually make use of what will now be saved. And it should (fingers crossed) put #373 to bed.