### PR TITLE
issue#31 Report the language employed by a Scratch ActiveCode Window

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -118,6 +118,7 @@ export default class ACFactory {
         const languageNames = {
             'cpp': 'C++',
             'c': 'C',
+            'html':'HTML',
             'htmlmixed': 'HTML',
             'java': 'Java',
             'javascript': 'JavaScript',

--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -112,16 +112,27 @@ export default class ACFactory {
         var lang = eBookConfig.acDefaultLanguage
             ? eBookConfig.acDefaultLanguage
             : "python";
-
-        const languageNames = {
-            'cpp': 'C++',
-            'java': 'Java',
-            'python3': 'Python 3',
-            'python': 'Python'
-        };
-        if (Object.keys(languageNames).includes(lang)) {
+        if (lang === "java" || lang === "cpp" || lang === "python3") {
             stdin = `data-stdin="text for stdin"`;
         }
+        const languageNames = {
+            'cpp': 'C++',
+            'c': 'C',
+            'htmlmixed': 'HTML',
+            'java': 'Java',
+            'javascript': 'JavaScript',
+            'js':'JavaScript',
+            'octave': 'Octave',
+            'python': 'Python',
+            'py2':'Python 2',
+            'python2': 'Python 2',
+            'py3':'Python 3',
+            'py3anaconda': 'Python 3 with Anaconda',
+            'python3': 'Python 3',
+            'ruby': 'Ruby',
+            'sql': 'SQL',
+            'ts': 'TypeScript'
+        };
 
         // generate the HTML
         var html = `<div class="ptx-runestone-container"><div id="ac_modal_${divid}" class="modal fade">

--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -118,7 +118,7 @@ export default class ACFactory {
         const languageNames = {
             'cpp': 'C++',
             'c': 'C',
-            'html':'HTML',
+            'html': 'HTML',
             'htmlmixed': 'HTML',
             'java': 'Java',
             'javascript': 'JavaScript',
@@ -141,7 +141,7 @@ export default class ACFactory {
                 <div class="modal-content">
                   <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">Scratch ActiveCode (${languageNames[lang.toLowerCase()]})</h4>
+                    <h4 class="modal-title">Scratch ActiveCode (${languageNames[lang.toLowerCase()] || lang})</h4>
                   </div>
                   <div class="modal-body">
                   <div data-component="activecode" id=${divid}>
@@ -156,6 +156,12 @@ export default class ACFactory {
             </div>`;
         var el = $(html);
         $("body").append(el);
+        el.on("shown.bs.modal", function(){
+            // default lang isn't in dictionary of known programming languages
+            if (!languageNames[lang.toLowerCase()]) {
+                alert(`${lang} is a known language. Please report this`)
+            }
+        });
         el.on("shown.bs.modal show.bs.modal", function () {
             el.find(".CodeMirror").each(function (i, e) {
                 e.CodeMirror.refresh();

--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -112,25 +112,29 @@ export default class ACFactory {
         var lang = eBookConfig.acDefaultLanguage
             ? eBookConfig.acDefaultLanguage
             : "python";
-        if (lang === "java" || lang === "cpp" || lang === "python3") {
+
+        const languageNames = {
+            'cpp': 'C++',
+            'java': 'Java',
+            'python3': 'Python 3',
+            'python': 'Python'
+        };
+        if (Object.keys(languageNames).includes(lang)) {
             stdin = `data-stdin="text for stdin"`;
         }
+
         // generate the HTML
         var html = `<div class="ptx-runestone-container"><div id="ac_modal_${divid}" class="modal fade">
               <div class="modal-dialog scratch-ac-modal">
                 <div class="modal-content">
                   <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">Scratch ActiveCode</h4>
+                    <h4 class="modal-title">Scratch ActiveCode (${languageNames[lang.toLowerCase()]})</h4>
                   </div>
                   <div class="modal-body">
                   <div data-component="activecode" id=${divid}>
                   <div id=${divid}_question class="ac_question"><p>Use this area for writing code or taking notes.</p></div>
                   <textarea data-codelens="true" data-lang="${lang}" ${stdin}>
-
-
-
-
                   </textarea>
                   </div>
                   </div>


### PR DESCRIPTION
fix #31 
### Issue 31
With Scratch ActiveCode allowing multiple possible languages, it might help to inform a reader what language is being interpreted. I couldn't see it anywhere.

### My change does the following

- State present language being interpreted. 
e.g for a cpp course --> Scratch ActiveCode (C++)
- Refactor code that sets the stdin string. Now makes use of the languageNames dictionary.  

#### Before

<img width="855" alt="before" src="https://github.com/RunestoneInteractive/rs/assets/89226977/d1921dac-dec5-464c-80ff-07b265236981">

#### After 
<img width="859" alt="after" src="https://github.com/RunestoneInteractive/rs/assets/89226977/9eb1b12a-cdef-4e84-9f12-c17656142738">

