### PR TITLE
Removing caption from non-runestone multiple-choice (attempt 2)

### DIFF
--- a/bases/rsptx/interactives/runestone/common/js/runestonebase.js
+++ b/bases/rsptx/interactives/runestone/common/js/runestonebase.js
@@ -428,19 +428,11 @@ export default class RunestoneBase {
         if (!this.isTimed) {
             var capDiv = document.createElement("p");
             if (this.question_label) {
-                // Display caption based on whether Runestone services have been detected
-                this.caption = eBookConfig.useRunestoneServices
-                    ? `Activity: ${this.question_label} ${this.caption}  <span class="runestone_caption_divid">(${this.divid})</span>`
-                    : `Activity: ${this.question_label} ${this.caption}`; // Without runestone
+                this.caption = `Activity: ${this.question_label} ${this.caption}  <span class="runestone_caption_divid">(${this.divid})</span>`;
                 $(capDiv).html(this.caption);
                 $(capDiv).addClass(`${elType}_caption`);
             } else {
-                // Display caption based on whether Runestone services have been detected
-                $(capDiv).html(
-                    eBookConfig.useRunestoneServices
-                        ? this.caption + " (" + this.divid + ")"
-                        : this.caption
-                ); // Without runestone
+                $(capDiv).html( this.caption + " (" + this.divid + ")" );
                 $(capDiv).addClass(`${elType}_caption`);
                 $(capDiv).addClass(`${elType}_caption_text`);
             }

--- a/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
+++ b/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
@@ -45,7 +45,10 @@ export default class MultipleChoice extends RunestoneBase {
         this.findFeedbacks();
         this.createCorrectList();
         this.createMCForm();
-        this.addCaption("runestone");
+        // Display caption if using Runestone services
+        if (this.useRunestoneServices) {
+            this.addCaption("runestone");
+        }
         this.checkServer("mChoice", true);
         // https://docs.mathjax.org/en/latest/options/startup/startup.html
         // https://docs.mathjax.org/en/latest/web/configuration.html#startup-action


### PR DESCRIPTION
After testing the updated code, the previous PR #380 didn't completely remove the captions from the non-runestone interactives.  After digging into the code a bit more, I believe checking for the runestone services to suppress the caption should happen at the interactive object level. 

This PR, reverts the changes made to the `addCaption` method in `runestonebase.js` and updates the `MultipleChoice` constructor in `mchoice.js`. I figured I would start with just one interactive and see if this PR produces the desired result before submitting a PR for the rest of them.

Also, if I understand the `addCaption` method, it appears to just append a `<p>` element to the bottom of a `runestone-component-ready` `<div>` element, so it seems safe to skip the `addCaption` call completely if runestone services are not detected.