### PR TITLE
Beginning Contributions to Add 'Registration Locked'

### DIFF
--- a/bases/rsptx/author_server_api/main.py
+++ b/bases/rsptx/author_server_api/main.py
@@ -100,6 +100,7 @@ async def create_book_entry(author: str, document_id: str, github: str):
         institution="Runestone",
         courselevel="",
         downloads_enabled="F",
+        registration_locked="F",
         allow_pairs="F",
         new_server="T",
     )

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -222,7 +222,8 @@
     eBookConfig.readings = {{ readings|safe}};
     eBookConfig.activities = {{ activity_info|safe }}
     eBookConfig.downloadsEnabled = {{downloads_enabled}};
-    eBookConfig.allow_pairs = {{allow_pairs}}
+    eBookConfig.allow_pairs = {{allow_pairs}};
+    eBookConfig.registration_locked = {{registration_locked}};
     eBookConfig.enableCompareMe = {{enable_compare_me}};
     // _`new_server_prefix`: Defined by the server to be the path to the new server.
     eBookConfig.new_server_prefix = '{{ new_server_prefix }}';

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/admin.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/admin.py
@@ -2722,6 +2722,10 @@ def update_course():
                 attr="groupsize",
                 value=request.vars.groupsize,
             )
+        if "registration_locked" in request.vars:
+            db(db.courses.id == thecourse.id).update(
+                registration_locked=(request.vars["registration_locked"] == "true")
+            )
         return json.dumps(dict(status="success"))
 
     return json.dumps(dict(status="failed"))

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/admin.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/admin.py
@@ -620,6 +620,7 @@ def admin():
     base_course_id = base_course_id.id
     curr_start_date = course.term_start_date.strftime("%m/%d/%Y")
     downloads_enabled = "true" if sidQuery.downloads_enabled else "false"
+    registration_locked = "true" if hasattr(sidQuery, 'registration_locked') and sidQuery.registration_locked else "false"
     allow_pairs = "true" if sidQuery.allow_pairs else "false"
     keys = (
         db(
@@ -677,6 +678,7 @@ def admin():
         course=sidQuery,
         downloads_enabled=downloads_enabled,
         allow_pairs=allow_pairs,
+        registration_locked=registration_locked,
         instructor_course_list=instructor_course_list,
         motd=motd,
         consumer=consumer,

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
@@ -623,6 +623,11 @@ def enroll():
         session.flash = f"You are already registered for {request.vars.course_name}"
         redirect(URL("default", "courses"))
 
+    # Check if registration is locked
+    if course and course.registration_locked:
+        session.flash = "Registration is locked for this course."
+        redirect(URL("default", "courses"))
+
     db.user_courses.insert(user_id=auth.user.id, course_id=course.id)
     db(db.auth_user.id == auth.user.id).update(course_id=course.id, active="T")
     db(db.auth_user.id == auth.user.id).update(course_name=request.vars.course_name)

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
@@ -608,8 +608,11 @@ def delete():
 
 @auth.requires_login()
 def enroll():
+    print("00000000000000000000")
     logger.debug(f"Request to login for {request.vars.course_name}")
     course = db(db.courses.course_name == request.vars.course_name).select().first()
+    print("--------", course)
+    print(course.registration_locked)
     # is the user already registered for this course?
     res = (
         db(
@@ -624,14 +627,17 @@ def enroll():
         redirect(URL("default", "courses"))
 
     # Check if registration is locked
+    print("111111111111111111111")
     if course and course.registration_locked:
+        print("2222222222222222222")
         session.flash = "Registration is locked for this course."
         redirect(URL("default", "courses"))
 
-    db.user_courses.insert(user_id=auth.user.id, course_id=course.id)
-    db(db.auth_user.id == auth.user.id).update(course_id=course.id, active="T")
-    db(db.auth_user.id == auth.user.id).update(course_name=request.vars.course_name)
-    auth.user.update(course_name=request.course_name)
-    auth.user.update(course_id=course.id)
+    else:
+        db.user_courses.insert(user_id=auth.user.id, course_id=course.id)
+        db(db.auth_user.id == auth.user.id).update(course_id=course.id, active="T")
+        db(db.auth_user.id == auth.user.id).update(course_name=request.vars.course_name)
+        auth.user.update(course_name=request.course_name)
+        auth.user.update(course_id=course.id)
+        redirect(URL("default", "donate"))
 
-    redirect(URL("default", "donate"))

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
@@ -608,11 +608,9 @@ def delete():
 
 @auth.requires_login()
 def enroll():
-    print("00000000000000000000")
     logger.debug(f"Request to login for {request.vars.course_name}")
     course = db(db.courses.course_name == request.vars.course_name).select().first()
-    print("--------", course)
-    print(course.registration_locked)
+ 
     # is the user already registered for this course?
     res = (
         db(
@@ -627,9 +625,7 @@ def enroll():
         redirect(URL("default", "courses"))
 
     # Check if registration is locked
-    print("111111111111111111111")
     if course and course.registration_locked:
-        print("2222222222222222222")
         session.flash = "Registration is locked for this course."
         redirect(URL("default", "courses"))
 

--- a/bases/rsptx/web2py_server/applications/runestone/models/db.py
+++ b/bases/rsptx/web2py_server/applications/runestone/models/db.py
@@ -595,7 +595,6 @@ def createUser(username, password, fname, lname, email, course_name, instructor=
 
 def _validateUser(username, password, fname, lname, email, course_name, line):
     errors = []
-    print(course.registration_locked)
     if course.registration_locked:
         errors.append(f"This course's registration is locked.")
     if auth.user.course_name != course_name:

--- a/bases/rsptx/web2py_server/applications/runestone/models/db.py
+++ b/bases/rsptx/web2py_server/applications/runestone/models/db.py
@@ -595,7 +595,9 @@ def createUser(username, password, fname, lname, email, course_name, instructor=
 
 def _validateUser(username, password, fname, lname, email, course_name, line):
     errors = []
-
+    print(course.registration_locked)
+    if course.registration_locked:
+        errors.append(f"This course's registration is locked.")
     if auth.user.course_name != course_name:
         errors.append(f"Course name does not match your course on line {line}")
     cinfo = db(db.courses.course_name == course_name).select().first()

--- a/bases/rsptx/web2py_server/applications/runestone/models/db.py
+++ b/bases/rsptx/web2py_server/applications/runestone/models/db.py
@@ -160,6 +160,7 @@ db.define_table(
     Field("login_required", type="boolean", default=True),
     Field("allow_pairs", type="boolean", default=False),
     Field("student_price", type="integer"),
+    Field("registration_locked", type="boolean", default=False),
     Field("downloads_enabled", type="boolean", default=False),
     Field("courselevel", type="string"),
     Field("new_server", type="boolean", default=False),

--- a/bases/rsptx/web2py_server/applications/runestone/static/js/admin.js
+++ b/bases/rsptx/web2py_server/applications/runestone/static/js/admin.js
@@ -2404,7 +2404,8 @@ function updateCourse(widget, attr) {
         attr == "downloads_enabled" ||
         attr == "allow_pairs" ||
         attr == "enable_compare_me" ||
-        attr == "show_points"
+        attr == "show_points" ||
+        attr == "registration_locked"
     ) {
         data[attr] = widget.checked;
     }

--- a/bases/rsptx/web2py_server/applications/runestone/views/admin/admin.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/admin/admin.html
@@ -91,6 +91,14 @@
             onchange="updateCourse(this,'allow_pairs')">
             </div>
             <div class="settingsbox">
+                <label for="lockedReg">Registration Locked</label>
+                <input type="checkbox" id="lockedReg"
+                {{ if registration_locked == "true": }}
+                  checked
+                {{ pass }}
+                onchange="updateCourse(this,'registration_locked')">
+                </div>
+            <div class="settingsbox">
                 <label for="pairs">Enable Compare Me Button</label>
                 <input type="checkbox" id="compare_me"
                 {{ if "enable_compare_me" not in globals() or enable_compare_me == "true": }}

--- a/components/rsptx/db/crud.py
+++ b/components/rsptx/db/crud.py
@@ -902,6 +902,7 @@ async def create_initial_courses_users():
             term_start_date=datetime.date(2000, 1, 1),
             login_required=False,
             allow_pairs=False,
+            registration_locked=False,
             downloads_enabled=False,
             courselevel="",
             institution="",

--- a/components/rsptx/db/models.py
+++ b/components/rsptx/db/models.py
@@ -375,6 +375,7 @@ class Courses(Base, IdMixin):
     python3 = Column(Web2PyBoolean, default=True)
     login_required = Column(Web2PyBoolean, nullable=False)
     allow_pairs = Column(Web2PyBoolean, nullable=False)
+    registration_locked = Column(Web2PyBoolean, nullable=False)
     student_price = Column(Integer)
     downloads_enabled = Column(Web2PyBoolean, nullable=False)
     courselevel = Column(String, nullable=False)


### PR DESCRIPTION
### Description
This is a draft PR introducing a new feature called 'Registration Locked,' which enables course administrators to lock enrollment in their courses. @conderp and I collaborated on this issue, but unfortunately, we were unable to complete it entirely. However, we are submitting this draft PR in case someone would like to pick up the issue from here.

In its current state, there is a 'Registration locked' checkbox in the Course Settings that will save changes when clicked on. The only part of this issue that remains incomplete is the actual validation that checks whether the registration is locked. We suspect that there is deprecated validation code that we may have tampered with, and there is more updated validation code that needs to be implemented for this feature.

---

![image](https://github.com/RunestoneInteractive/rs/assets/97637517/7ecd0aa9-782c-433f-92ec-0834c7efd664)