### PR TITLE
Add a gradebook button in the grading tab

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/views/admin/grading.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/admin/grading.html
@@ -51,17 +51,22 @@
       <p style="visibility: hidden">This paragraph takes up some space to deal with a funky display issue of the right side lumping over onto the left</p>
 
 
-      <div id="autogradingform" style="text-align: center; visibility: hidden;">
+      <div id="autogradingform" style="text-align: center; visibility: visible;">
         <form>
           <fieldset>
-            <input id="enforceDeadline" type="checkbox" name="enforceDeadline" value="enforceDeadline" class="big-checkbox" checked />
+            <input id="enforceDeadline" type="checkbox" name="enforceDeadline" value="enforceDeadline" class="big-checkbox" checked="">
             <label for="enforceDeadline">Only check work submitted before</label>
-            <span id="dl_disp"></span>
+            <span id="dl_disp">Wed Jan 31 2024 09:20:00 GMT-0500 (Eastern Standard Time)</span>
           </fieldset>
-          <input id="autogradesubmit" type="submit" class="btn btn-primary" value="Autograde and Display Totals" />
+          <input id="autogradesubmit" type="submit" class="btn btn-primary" value="Autograde and Display Totals">
           <!--<button id="autogradebutton"  class="list-group-item" onclick="function(event){event.preventDefault(); autoGrade(event);}">Autograde</button>-->
         </form>
-        <strong>Warning</strong> Autograde does not support multiple selections yet.
+      <p>  <strong>Warning</strong> Autograde does not support multiple selections yet.</p>
+    <a id="gradebookLink" class="btn btn-primary" href="/runestone/dashboard/grades">
+        <p style="text-align: center" class="list-group-item-heading">Grade Book</p>
+        
+    </a>
+    <button id="releasebutton" style="text-align: center; visibility: visible;" class="btn btn-primary btn-sm" onclick="toggle_release_grades();">Hide Grades</button>
       </div>
 
       <div>


### PR DESCRIPTION
fix #12 : 
**Problem**: Previously, instructors had to navigate to the admin page to view their students' grades. This process was not user-friendly and created unnecessary steps for instructors.

**Solution**: With this update, instructors can now view their students' grades directly on the instructor page, specifically while they are grading student work. This enhancement streamlines the grading process and improves overall usability.

**Before**: 
![image](https://github.com/RunestoneInteractive/rs/assets/117699634/b9d30a5f-0ccc-49bb-a616-fbc59c4791de)

**After**: 
![image](https://github.com/RunestoneInteractive/rs/assets/117699634/6849621f-b4c3-45e3-a7c1-2add87a1dbbc)




