### PR TITLE
Add dev environment that removes the need to rebuild containers

### DIFF
--- a/bases/rsptx/web2py_server/gluon/main.py
+++ b/bases/rsptx/web2py_server/gluon/main.py
@@ -23,6 +23,7 @@ import signal
 import socket
 import random
 import string
+import traceback
 
 from gluon._compat import Cookie, urllib_quote
 # from thread import allocate_lock
@@ -495,6 +496,7 @@ def wsgibase(environ, responder):
                 ticket = None
 
             except RestrictedError as e:
+                logger.error(''.join(traceback.format_exception(type(e), e, e.__traceback__)))
 
                 if request.body:
                     request.body.close()
@@ -520,7 +522,8 @@ def wsgibase(environ, responder):
                          dict(ticket=ticket),
                          web2py_error='ticket %s' % ticket)
 
-        except:
+        except BaseException as e:
+            logger.error(''.join(traceback.format_exception(type(e), e, e.__traceback__)))
 
             if request.body:
                 request.body.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,6 @@ services:
       - jobe
       - pgbouncer
 
-
   nginx:
 
     # Note we use context: ./ here so that the Dockerfile can copy from the components folder
@@ -186,6 +185,25 @@ services:
       - runestone
       - book
       - assignment
+
+  # this second nginx is designed to sit in front of python servers running on a host machine for a more convineient dev environment
+  # it exposes the Runestone application on port 8080
+  nginx_dstart_dev:
+
+    # Note we use context: ./ here so that the Dockerfile can copy from the components folder
+    build:
+      context: ./
+      dockerfile: projects/nginx_dstart_dev/Dockerfile
+    #image: registry.digitalocean.com/runestone-registry/rs-nginx
+    image: ghcr.io/runestoneinteractive/rs-nginx-dstart-dev
+    restart: always
+    ports:
+      # ports are specified host:container
+      - 8080:80
+      #- 443:443
+    volumes:
+      - ${BOOK_PATH}:/usr/books
+
 
   # create an image/container to run rsmanage inside the composed services
   # docker compose run rsmanage rsmanage --help

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,7 @@ services:
       #- 443:443
     volumes:
       - ${BOOK_PATH}:/usr/books
+      - ./components/rsptx/templates/staticAssets:/usr/share/nginx/html/staticAssets
 
 
   # create an image/container to run rsmanage inside the composed services

--- a/dstart
+++ b/dstart
@@ -10,6 +10,13 @@ fi
 
 set -e
 SERVICE=$1
+
+# these environment variables need to be set differentlty for running the servers on the host machine
+# instead of in the docker container, so fix them up here
+
+export RUNESTONE_PATH=.
+export BOOK_PATH=~/Runestone/books
+
 cd $RUNESTONE_PATH
 
 # check to see if the rs virtual environment is active
@@ -17,6 +24,24 @@ if [[ -z "$VIRTUAL_ENV" && $VIRTUAL_ENV == *"rs/.venv" ]]; then
     echo "The rs virtual environment is not active. Please activate it first."
     exit 1
 fi
+
+# kill previously running servers if present
+if [[ "$SERVICE" == "all" || "$SERVICE" == "stopall" ]]; then
+    lsof -t -i tcp:8100 | xargs kill
+    lsof -t -i tcp:8101 | xargs kill
+    lsof -t -i tcp:8102 | xargs kill
+    lsof -t -i tcp:8103 | xargs kill
+    # wait for the servers to stop
+    sleep 5
+fi
+
+if [ "$SERVICE" == "all" ]; then
+    uvicorn rsptx.book_server_api.main:app --host 0.0.0.0 --port 8100 --reload &
+    uvicorn rsptx.assignment_server_api.core:app --host 0.0.0.0 --port 8101 --reload &
+    uvicorn rsptx.author_server_api.main:app --host 0.0.0.0 --port 8102 --reload &
+    python bases/rsptx/web2py_server/web2py.py --no-gui --password "<recycle>" --ip 0.0.0.0 --port 8103 &
+fi
+
 
 # check to see if the SERVICE is book
 if [ "$SERVICE" == "book" ]; then
@@ -43,7 +68,6 @@ if [ "$SERVICE" == "runestone" ]; then
     python web2py.py --no-gui --password "<recycle>" --ip 0.0.0.0 --port 8103
     exit 0
 fi
-
 
 # todo: start up a local nginx server to serve the static files 
 # todo: with nginx running allow multiple servers to run

--- a/projects/nginx_dstart_dev/Dockerfile
+++ b/projects/nginx_dstart_dev/Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx
+
+# The context for this Dockerfile is the root of the runestone repo
+LABEL org.opencontainers.image.source https://github.com/RunestoneInteractive/rs
+
+COPY projects/nginx_dstart_dev/runestone /etc/nginx/conf.d/default.conf
+
+# Copy the shared staticAssets so they can be served by nginx
+COPY components/rsptx/templates/staticAssets /usr/share/nginx/html/staticAssets
+
+# This image is meant to be used as the main tenant on a virtual machine.   It does not play well
+# with other tenants on the same machine. 
+
+# See - https://medium.com/rahasak/setup-lets-encrypt-certificate-with-nginx-certbot-and-docker-b13010a12994 to set up certbot

--- a/projects/nginx_dstart_dev/Dockerfile
+++ b/projects/nginx_dstart_dev/Dockerfile
@@ -5,8 +5,7 @@ LABEL org.opencontainers.image.source https://github.com/RunestoneInteractive/rs
 
 COPY projects/nginx_dstart_dev/runestone /etc/nginx/conf.d/default.conf
 
-# Copy the shared staticAssets so they can be served by nginx
-COPY components/rsptx/templates/staticAssets /usr/share/nginx/html/staticAssets
+# NOTE: unlike the prod container for nginx, this one mounts in a local directory for static assets, see the docker-compose file
 
 # This image is meant to be used as the main tenant on a virtual machine.   It does not play well
 # with other tenants on the same machine. 

--- a/projects/nginx_dstart_dev/runestone
+++ b/projects/nginx_dstart_dev/runestone
@@ -1,0 +1,150 @@
+# **\*\***\*\***\*\***\*\*\***\*\***\*\***\*\***
+
+# |docname| - nginx configuration
+
+# **\*\***\*\***\*\***\*\*\***\*\***\*\***\*\***
+
+# This sets up nginx to run both the old and new server together. It requires `processing by Python <Set up nginx based on env vars.>`\_ before use.
+
+#
+
+# This file was partially taken from the `gunicorn deployment docs <https://docs.gunicorn.org/en/stable/deploy.html#nginx-configuration>`\_.
+
+#
+
+# `gzip_static <http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html>`\_: Enables ("on") or disables ("off") checking the existence of precompressed files. Send compressed files in lieu of uncompressed files where they exist. This requires the optional `ngx_http_gzip_static_module` module.
+
+gzip_static on;
+
+rewrite_log on;
+# Specify a custom log format.
+
+#
+
+#`log_format <http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format>_`: Specifies log format.
+log_format custom_log_format '$remote_addr - [$time_local] '
+'Request: "$request" Status: $status Bytes: $body_bytes_sent '
+    'RequestTime: $request_time '
+    'Referrer: "$http_referer" Agent: "$http_user_agent"';
+
+# Use this format.
+
+#
+
+# `access_log <http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log>`\_: Sets the path, format, and configuration for a buffered log write.
+
+access_log /var/log/nginx/access.log custom_log_format;
+
+# Define the web2py and FastAPI servers.
+
+server {
+include /etc/nginx/default.d/\*.conf;
+
+    # `server_name <http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name>`_: Set name(s) of a virtual server.
+    server_name RunestoneMobile.local;
+
+    rewrite ^/ads.txt /runestone/static/ads.txt;
+    rewrite ^/runestone/static/JavaReview/(\w+)/(.*)$ /ns/books/published/apcsareview/$1/$2;
+    rewrite ^/runestone/static/csawesome/(\w+)/(.*)$ /ns/books/published/csawesome/$1/$2;
+
+
+    # Rewrite the path to static files.
+    #
+    # `location <https://nginx.org/en/docs/http/ngx_http_core_module.html#location>`_: set configuration depending on a request URI. The ``~*`` indicates the following parameter is a case-insensitive regex. Look for web2py static files.
+    #
+    # Match web2py static paths with the application specified, such as ``/runestone/static/``. Avoid matching ``admin/`` so the admin interface works -- it uses the `web2py's static asset management <http://www.web2py.com/books/default/chapter/29/04/the-core#Static-asset-management>`_ which breaks the simple redirect below.
+    #
+    # root supplies the uptree path the match gets appended to the path specified
+    # by the root directive
+    #location ~* /(?!admin/)(\w+)/static/ {
+    #    root /srv/web2py/applications/;
+    #}
+
+    # Match web2py static paths with no application specified; assume the default application is ``runestone``.
+    #location /static/ {
+    #    root /srv/web2py/applications/runestone;
+    #}
+
+    location ~* ^/staticAssets/(.*)$ {
+        alias /usr/share/nginx/html/staticAssets/$1;
+    }
+
+    # Route static book files from web2py with an application specified. Regex fun: ``(?!ns/)`` prevents a match with a prefix of ``ns/`` (since this should be routed to the new server instead).
+    ##              $1                 $2        $3              $4             $5
+    location ~* ^/(?!ns/)(\w+)/books/(published|draft)/(\w+)/(_static|_images|images)/(.*)$ {
+        alias /usr/books/$3/$2/$3/$4/$5;
+    }
+
+    # Route static book files from web2py with no application specified; assume the default application is ``runestone``.
+    ##                         $1           $2               $3           $4
+    location ~* ^/books/(published|draft)/(\w+)/(_static|_images|images)/(.*)$ {
+        alias /usr/books/$2/$1/$2/$3/$4;
+    }
+
+    # Route the ``/ns`` (new server) path to gunicorn.
+    location /ns/ {
+        # rewrite to remove /ns as bookserver does not expect it.
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        # Allow web sockets.
+        proxy_buffering off;
+        # `WebSocket proxying <https://nginx.org/en/docs/http/websocket.html?_ga=2.58949805.1641238518.1630518248-2075569494.1630518248>`_:
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        # `proxy_pass <https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass>`_: set the protocol and address of a proxied server and an optional URI to which a location should be mapped. **Tricky**: Specifying the ``location`` above with a trailing slash and including a trailing slash at the end of ``proxy_pass`` causes nginx to strip of the ``/ns`` prefix when sending it to gunicorn. Quoting the docs: "If the ``proxy_pass`` directive is specified with a URI, then when a request is passed to the server, the part of a normalized request URI matching the location is replaced by a URI specified in the directive."
+        #
+        # _`gunicorn socket`: This matches the ``--bind`` parameter when `gunicorn is run <run_bookserver>`.
+        #proxy_pass http://unix:/run/fastapi.sock:/;
+        proxy_pass http://host.docker.internal:8100/;
+        # For file uploads we need a larger limit than 1M for whiteboard pictures and pdf uploads
+        client_max_body_size 25M;
+    }
+
+    # route assignment requests
+    location /assignment/ {
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_set_header Host $http_host;
+       # we don't want nginx trying to do something clever with
+       # redirects, we set the Host: header above already.
+       proxy_redirect off;
+       proxy_pass http://host.docker.internal:8101/;
+
+    }
+
+    # route author requests
+    # This one looks a bit different due to the author server being optional in the compose setup
+    # We have to define the proxy endpoint inside the location
+    # This means the proxy_pass has to append the $request_uri in order for it to be passed on.
+    # which means that the author app is always going to get the /author/ part as part of the url
+    location /author/ {
+       resolver 127.0.0.11 valid=30s; # use the docker dns resolver
+       set $aserver http://host.docker.internal:8102;
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_set_header Host $http_host;
+       # we don't want nginx trying to do something clever with
+       # redirects, we set the Host: header above already.
+       proxy_redirect off;
+       proxy_pass $aserver$request_uri;
+
+    }
+
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
+      # See `../../gunicorn/web2py.conf.py` for the corresponding socket bind.
+      #proxy_pass http://unix:/run/web2py.sock:/;
+      proxy_pass http://host.docker.internal:8103;
+    }
+
+}

--- a/projects/nginx_dstart_dev/runestone.dev
+++ b/projects/nginx_dstart_dev/runestone.dev
@@ -1,0 +1,99 @@
+# *******************************
+# |docname| - nginx configuration
+# *******************************
+# This sets up nginx to run both the old and new server together. It requires `processing by Python <Set up nginx based on env vars.>`_ before use.
+#
+# This file was partially taken from the `gunicorn deployment docs <https://docs.gunicorn.org/en/stable/deploy.html#nginx-configuration>`_.
+#
+# `gzip_static <http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html>`_: Enables ("on") or disables ("off") checking the existence of precompressed files. Send compressed files in lieu of uncompressed files where they exist. This requires the optional ``ngx_http_gzip_static_module`` module.
+gzip_static on;
+
+# Specify a custom log format.
+#
+#`log_format <http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format>_`: Specifies log format.
+log_format custom_log_format '$remote_addr - [$time_local] '
+    'Request: "$request" Status: $status Bytes: $body_bytes_sent '
+    'RequestTime: $request_time '
+    'Referrer: "$http_referer" Agent: "$http_user_agent"';
+
+# Use this format.
+#
+# `access_log <http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log>`_: Sets the path, format, and configuration for a buffered log write.
+access_log /opt/homebrew/var/log/nginx/access.log custom_log_format;
+
+# Define the web2py and FastAPI servers.
+server {
+    listen 8080;
+    server_name localhost;
+    include /etc/nginx/default.d/*.conf;
+
+    # `server_name <http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name>`_: Set name(s) of a virtual server.
+    server_name RunestoneMobile.local;
+
+    rewrite ^/ads.txt /runestone/static/ads.txt;
+
+    # Rewrite the path to static files.
+    #
+    # `location <https://nginx.org/en/docs/http/ngx_http_core_module.html#location>`_: set configuration depending on a request URI. The ``~*`` indicates the following parameter is a case-insensitive regex. Look for web2py static files.
+    #
+    # Match web2py static paths with the application specified, such as ``/runestone/static/``. Avoid matching ``admin/`` so the admin interface works -- it uses the `web2py's static asset management <http://www.web2py.com/books/default/chapter/29/04/the-core#Static-asset-management>`_ which breaks the simple redirect below.
+    #
+    # root supplies the uptree path the match gets appended to the path specified
+    # by the root directive
+    #location ~* /(?!admin/)(\w+)/static/ {
+    #    root /srv/web2py/applications/;
+    #}
+
+    # Match web2py static paths with no application specified; assume the default application is ``runestone``.
+    #location /static/ {
+    #    root /srv/web2py/applications/runestone;
+    #}
+
+    # Route static book files from web2py with an application specified. Regex fun: ``(?!ns/)`` prevents a match with a prefix of ``ns/`` (since this should be routed to the new server instead).
+    ##              $1                 $2        $3              $4             $5
+    location ~* ^/(?!ns/)(\w+)/books/(published|draft)/(\w+)/(_static|_images|images)/(.*)$ {
+        alias /Users/bmiller/Runestone/books/$3/$2/$3/$4/$5;
+    }
+
+    # Route static book files from web2py with no application specified; assume the default application is ``runestone``.
+    ##                         $1           $2               $3           $4
+    location ~* ^/books/(published|draft)/(\w+)/(_static|_images|images)/(.*)$ {
+        alias /Users/bmiller/Runestone/books/$2/$1/$2/$3/$4;
+    }
+
+    # Route the ``/ns`` (new server) path to gunicorn.
+    location /ns/ {
+        # rewrite to remove /ns as bookserver does not expect it.
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        # Allow web sockets.
+        proxy_buffering off;
+        # `WebSocket proxying <https://nginx.org/en/docs/http/websocket.html?_ga=2.58949805.1641238518.1630518248-2075569494.1630518248>`_:
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        # `proxy_pass <https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass>`_: set the protocol and address of a proxied server and an optional URI to which a location should be mapped. **Tricky**: Specifying the ``location`` above with a trailing slash and including a trailing slash at the end of ``proxy_pass`` causes nginx to strip of the ``/ns`` prefix when sending it to gunicorn. Quoting the docs: "If the ``proxy_pass`` directive is specified with a URI, then when a request is passed to the server, the part of a normalized request URI matching the location is replaced by a URI specified in the directive."
+        #
+        # _`gunicorn socket`: This matches the ``--bind`` parameter when `gunicorn is run <run_bookserver>`.
+        #proxy_pass http://unix:/run/fastapi.sock:/;
+        proxy_pass http://localhost:8111/;
+        # For file uploads we need a larger limit than 1M for whiteboard pictures and pdf uploads
+        client_max_body_size 25M;
+    }
+
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
+      # See `../../gunicorn/web2py.conf.py` for the corresponding socket bind.
+      #proxy_pass http://unix:/run/web2py.sock:/;
+      proxy_pass http://localhost:8112;
+    }
+}


### PR DESCRIPTION
- The dstart script was already present, but only started individual servers. It is hard to work with because different URLs are served by different microservices, which are served on different ports and clicking links wouldn't lead to the right address. Some individual pages require APIs or static files served from different services so cannot render properly at all.
- Add new nginx container called nginx_dstart_dev that can be used to navigate the site at localhost:8080 and redirects requests to the host machine python processes on the ports specified in the dstart script
- add option "all" to the dstart script to start all of the servers in the background
- add option "stopall" to the dstart script to stop all of the servers, as the "all" option starts them in the background so they are harder to find/kill manually