### PR TITLE
Enforce 0 as min score for lineGrader Parsons

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/js/lineGrader.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/lineGrader.js
@@ -135,6 +135,8 @@ export default class LineBasedGrader {
         let numCorrectIndents =
             ((this.correctLines - this.incorrectIndents) / lines) * 0.4;
 
-        this.problem.percent = numLines + numCorrectBlocks + numCorrectIndents;
+        let score = numLines + numCorrectBlocks + numCorrectIndents;
+        score = Math.max(score, 0);
+        this.problem.percent = score;
     }
 }


### PR DESCRIPTION
World's dumbest PR...

A better approach would be to only penalize incorrectly indented correct lines. But that would be a significant refactor for very little gain.