### PR TITLE
Prune excess mathjax when grading questions

### DIFF
--- a/bases/rsptx/interactives/runestone/common/js/runestonebase.js
+++ b/bases/rsptx/interactives/runestone/common/js/runestonebase.js
@@ -568,8 +568,7 @@ class AutoQueue extends Queue {
         try {
             this._pendingPromise = true;
 
-            let payload = await MathJax.startup
-                .defaultPageReady()
+            let payload = await window.runestoneMathReady
                 .then(async function () {
                     console.log(
                         `MathJax Ready -- dequeing a typesetting run for ${item.component.id}`

--- a/components/rsptx/templates/staticAssets/js/admin.js
+++ b/components/rsptx/templates/staticAssets/js/admin.js
@@ -2089,7 +2089,6 @@ async function renderRunestoneComponent(componentSrc, whereDiv, moreOpts) {
         }
         // $(`#${whereDiv}`).css("background-color", "white");
     }
-    MathJax.typeset([document.querySelector(`#${whereDiv}`)]);
 }
 
 // Called by the "Search" button in the "Search question bank" panel.


### PR DESCRIPTION
Addresses issue #478 

Reuse `window.runestoneMathReady` promise instead of triggering a new `MathJax.startup.defaultPageReady()` promise.

Remove old stopgap `MathJax.typeset` in admin.js renderComponent.

Seems to still render fine, reduces the number of mathjax calls and avoids calls to typesetPromise with null element list.