### PR TITLE
Strip multiple tags from parsons

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -335,7 +335,7 @@ export default class Parsons extends RunestoneBase {
                 options["displaymath"] = false;
             }
             textBlock = textBlock.replace(
-                /\s*#(paired|distractor|tag:.*;.*;\s*)/g,
+                /\s*#(paired|distractor|tag:.*;.*;)\s*/g,
                 function (mystring, arg1) {
                     options[arg1] = true;
                     return "";

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -335,7 +335,7 @@ export default class Parsons extends RunestoneBase {
                 options["displaymath"] = false;
             }
             textBlock = textBlock.replace(
-                /#(paired|distractor|tag:.*;.*;)/,
+                /\s*#(paired|distractor|tag:.*;.*;\s*)/g,
                 function (mystring, arg1) {
                     options[arg1] = true;
                     return "";


### PR DESCRIPTION
Bug fix - currently if a Parsons line has "#distractor #tag:cSquared; depends:a,b;" only the first #tag gets removed

See demo
https://jsbin.com/fapapahewe/edit?js,console