### PR TITLE
FITB: fix blank feedback; update btm-expressions version

### DIFF
--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "-": "0.0.1",
                 "bootstrap": "3.4.1",
-                "btm-expressions": "^0.1.6",
+                "btm-expressions": "^0.1.7",
                 "byte-base64": "^1.1.0",
                 "codemirror": "^5.59.4",
                 "handsontable": "7.2.2",
@@ -2784,9 +2784,9 @@
             }
         },
         "node_modules/btm-expressions": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.6.tgz",
-            "integrity": "sha512-e+xi71CY1zkdASzJ6DdJU0i9tkaZFUbmVeW8XoR5rEvyaKLl5+AvC7xDvgSIcRTPKYbfbTjRvXC7z2TIUEyMYQ=="
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.7.tgz",
+            "integrity": "sha512-Lr57ng7x6UMlL5gW93CbubxngM+6KFmzx55w8OFpPaqYmFKFq8sbzEC1WoqBUXZUKEOx+gF1z5FddeJMbhQNiw=="
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -10277,9 +10277,9 @@
             }
         },
         "btm-expressions": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.6.tgz",
-            "integrity": "sha512-e+xi71CY1zkdASzJ6DdJU0i9tkaZFUbmVeW8XoR5rEvyaKLl5+AvC7xDvgSIcRTPKYbfbTjRvXC7z2TIUEyMYQ=="
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.7.tgz",
+            "integrity": "sha512-Lr57ng7x6UMlL5gW93CbubxngM+6KFmzx55w8OFpPaqYmFKFq8sbzEC1WoqBUXZUKEOx+gF1z5FddeJMbhQNiw=="
         },
         "buffer-from": {
             "version": "1.1.2",

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "-": "0.0.1",
         "bootstrap": "3.4.1",
-        "btm-expressions": "^0.1.6",
+        "btm-expressions": "^0.1.7",
         "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",

--- a/bases/rsptx/interactives/runestone/fitb/js/fitb-utils.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb-utils.js
@@ -176,8 +176,27 @@ export function checkAnswersCore(
                     displayFeed.push(fbl[j]["feedback"]);
                     break;
                 }
-                // If this is a dynamic solution...
-                if (dyn_vars_eval) {
+                // If this is a regexp...
+                if ("regex" in fbl[j]) {
+                    const patt = RegExp(
+                        fbl[j]["regex"],
+                        fbl[j]["regexFlags"]
+                    );
+                    if (patt.test(given)) {
+                        displayFeed.push(fbl[j]["feedback"]);
+                        break;
+                    }
+                } else if ("number" in fbl[j]) {
+                    // This is a number.
+                    const [min, max] = fbl[j]["number"];
+                    // Convert the given string to a number. While there are `lots of ways <https://coderwall.com/p/5tlhmw/converting-strings-to-number-in-javascript-pitfalls>`_ to do this; this version supports other bases (hex/binary/octal) as well as floats.
+                    const actual = +given;
+                    if (actual >= min && actual <= max) {
+                        displayFeed.push(fbl[j]["feedback"]);
+                        break;
+                    }
+                // If this is a dynamic solution, they should provide a testing function
+                } else if (dyn_vars_eval) {
                     const [namedBlankValues, given_arr_converted] =
                         parseAnswers(blankNamesDict, given_arr, dyn_vars_eval);
                     // If there was a parse error, then it student's answer is incorrect.
@@ -211,27 +230,8 @@ export function checkAnswersCore(
                         break;
                     }
                 } else {
-                    // If this is a regexp...
-                    if ("regex" in fbl[j]) {
-                        const patt = RegExp(
-                            fbl[j]["regex"],
-                            fbl[j]["regexFlags"]
-                        );
-                        if (patt.test(given)) {
-                            displayFeed.push(fbl[j]["feedback"]);
-                            break;
-                        }
-                    } else {
-                        // This is a number.
-                        console.assert("number" in fbl[j]);
-                        const [min, max] = fbl[j]["number"];
-                        // Convert the given string to a number. While there are `lots of ways <https://coderwall.com/p/5tlhmw/converting-strings-to-number-in-javascript-pitfalls>`_ to do this; this version supports other bases (hex/binary/octal) as well as floats.
-                        const actual = +given;
-                        if (actual >= min && actual <= max) {
-                            displayFeed.push(fbl[j]["feedback"]);
-                            break;
-                        }
-                    }
+                    // Undefined method of testing.
+                    console.assert("number" in fbl[j]);
                 }
             }
 

--- a/bases/rsptx/interactives/runestone/fitb/js/fitb.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb.js
@@ -630,7 +630,7 @@ export default class FITB extends RunestoneBase {
                     this.dyn_vars_eval
                 );
                 // Convert the returned NodeList into a string of HTML.
-                df = df
+                df = (df?.[0] !== undefined)
                     ? df[0].parentElement.innerHTML
                     : "No feedback provided";
             }


### PR DESCRIPTION
The fitb component did not deal correctly with empty feedback string. Updated the code in interactive/runestone/fitb/js/fitb.js to catch this possible error.

Also updated version on btm-expressions for some critical changes in behavior.