### PR TITLE
Fitb update

### DIFF
--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "-": "0.0.1",
         "bootstrap": "3.4.1",
-        "btm-expressions": "^0.1.8",
+        "btm-expressions": "^0.1.9",
         "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "-": "0.0.1",
         "bootstrap": "3.4.1",
-        "btm-expressions": "^0.1.7",
+        "btm-expressions": "^0.1.8",
         "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",

--- a/bases/rsptx/interactives/runestone/fitb/js/fitb-utils.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb-utils.js
@@ -229,6 +229,24 @@ export function checkAnswersCore(
                         );
                         break;
                     }
+                // If this is NOT a dynamic solution, but given a testing function
+                } else if ("solution_code" in fbl[j]) {
+                    // Create a function to wrap the expression to evaluate. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function.
+                    // Pass the answer, array of all answers, then all entries in ``this.dyn_vars_eval`` dict as function parameters.
+                    const is_equal = window.Function(
+                        "ans",
+                        "ans_array",
+                        `"use strict;"\nreturn ${fbl[j]["solution_code"]};`
+                    )(given, given_arr);
+                    // If student's answer is equal to this item, then append this item's feedback.
+                    if (is_equal) {
+                        displayFeed.push(
+                            typeof is_equal === "string"
+                                ? is_equal
+                                : fbl[j]["feedback"]
+                        );
+                        break;
+                    }
                 } else {
                     // Undefined method of testing.
                     console.assert("number" in fbl[j]);

--- a/bases/rsptx/interactives/runestone/fitb/js/fitb.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb.js
@@ -210,6 +210,7 @@ export default class FITB extends RunestoneBase {
                 this.indicate_component_ready();
             });
         });
+        this.queueMathJax(this.descriptionDiv);
     }
 
     // Find the script tag containing JSON in a given root DOM node.
@@ -345,7 +346,6 @@ export default class FITB extends RunestoneBase {
                 }
             }
 
-            this.queueMathJax(this.descriptionDiv);
             this.setupBlanks();
         }
     }
@@ -373,6 +373,7 @@ export default class FITB extends RunestoneBase {
         // Restore the seed first, since the dynamic render clears all the blanks.
         this.seed = data.seed;
         this.renderDynamicContent();
+        this.queueMathJax(this.descriptionDiv);
 
         var arr;
         // Restore answers from storage retrieval done in RunestoneBase.
@@ -505,6 +506,7 @@ export default class FITB extends RunestoneBase {
             //
             this.seed = Math.floor(Math.random() * 2 ** 32);
             this.renderDynamicContent();
+            this.queueMathJax(this.descriptionDiv);
         } else {
             // This is the server-side case. Send a request to the `results <getAssessResults>` endpoint with ``new_seed`` set to True.
             const request = new Request("/assessment/results", {


### PR DESCRIPTION
Javascript-based testing of answers was not fully compatible with string/number testing. Non-dynamic problems with mathematics in the statement were not rendering in MathJax.

Modifications made to adjust the answer testing for the missed cases. Moved the queueing of MathJax rending out of renderDynamicContent to each reference where the html was being updated.

Also btm-expressions (npm webpack package for math objects) had some bug-fixes and improvements that need to be available for math fitb problems.