### PR TITLE
Updates to support FITB/math problems

### DIFF
--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -12,7 +12,7 @@
                 "-": "0.0.1",
                 "@mapbox/node-pre-gyp": "^1.0.11",
                 "bootstrap": "3.4.1",
-                "btm-expressions": "^0.1.9",
+                "btm-expressions": "^0.1.10",
                 "byte-base64": "^1.1.0",
                 "codemirror": "^5.59.4",
                 "handsontable": "7.2.2",
@@ -3054,9 +3054,9 @@
             }
         },
         "node_modules/btm-expressions": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.9.tgz",
-            "integrity": "sha512-ROuatwybfjvn7+0H5ifjDSLWOTwXf/4tKuKljJ7LDWZ/81xNMmLZq1MwfHMBFmUrN490QaCROF+z3qUXErSCUQ=="
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.10.tgz",
+            "integrity": "sha512-JeuAYX3BVRpX8fD27Z5OZtQseGDPL9HtIcJXrjEBeuBZUKyVnLXruDc6ifrLtiQ20jxVthiVXhJ3/s/sb0Ljrw=="
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -10751,9 +10751,9 @@
             }
         },
         "btm-expressions": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.9.tgz",
-            "integrity": "sha512-ROuatwybfjvn7+0H5ifjDSLWOTwXf/4tKuKljJ7LDWZ/81xNMmLZq1MwfHMBFmUrN490QaCROF+z3qUXErSCUQ=="
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.10.tgz",
+            "integrity": "sha512-JeuAYX3BVRpX8fD27Z5OZtQseGDPL9HtIcJXrjEBeuBZUKyVnLXruDc6ifrLtiQ20jxVthiVXhJ3/s/sb0Ljrw=="
         },
         "buffer-from": {
             "version": "1.1.2",

--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -12,7 +12,7 @@
                 "-": "0.0.1",
                 "@mapbox/node-pre-gyp": "^1.0.11",
                 "bootstrap": "3.4.1",
-                "btm-expressions": "^0.1.10",
+                "btm-expressions": "^0.1.11",
                 "byte-base64": "^1.1.0",
                 "codemirror": "^5.59.4",
                 "handsontable": "7.2.2",
@@ -3054,9 +3054,9 @@
             }
         },
         "node_modules/btm-expressions": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.10.tgz",
-            "integrity": "sha512-JeuAYX3BVRpX8fD27Z5OZtQseGDPL9HtIcJXrjEBeuBZUKyVnLXruDc6ifrLtiQ20jxVthiVXhJ3/s/sb0Ljrw=="
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.11.tgz",
+            "integrity": "sha512-F/UhMYXAR4zzpMyYmYzSjDb+r2oLlX+TkHnKc1OuuCxe+O3xeEsqmkVA3Ueyq3iz/T/omEpgPBWUG4IaoC0k5Q=="
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -10751,9 +10751,9 @@
             }
         },
         "btm-expressions": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.10.tgz",
-            "integrity": "sha512-JeuAYX3BVRpX8fD27Z5OZtQseGDPL9HtIcJXrjEBeuBZUKyVnLXruDc6ifrLtiQ20jxVthiVXhJ3/s/sb0Ljrw=="
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.11.tgz",
+            "integrity": "sha512-F/UhMYXAR4zzpMyYmYzSjDb+r2oLlX+TkHnKc1OuuCxe+O3xeEsqmkVA3Ueyq3iz/T/omEpgPBWUG4IaoC0k5Q=="
         },
         "buffer-from": {
             "version": "1.1.2",

--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -12,7 +12,7 @@
                 "-": "0.0.1",
                 "@mapbox/node-pre-gyp": "^1.0.11",
                 "bootstrap": "3.4.1",
-                "btm-expressions": "^0.1.11",
+                "btm-expressions": "^0.1.12",
                 "byte-base64": "^1.1.0",
                 "codemirror": "^5.59.4",
                 "handsontable": "7.2.2",
@@ -3054,9 +3054,9 @@
             }
         },
         "node_modules/btm-expressions": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.11.tgz",
-            "integrity": "sha512-F/UhMYXAR4zzpMyYmYzSjDb+r2oLlX+TkHnKc1OuuCxe+O3xeEsqmkVA3Ueyq3iz/T/omEpgPBWUG4IaoC0k5Q=="
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.12.tgz",
+            "integrity": "sha512-X/IK6RxA+vm9XPvoweK2AYFLxpHcpfExM15v12eA4+0ibf4irI/FBz2iDcllOIWnIBmRVeoXZww72GHQXTiqOw=="
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -10751,9 +10751,9 @@
             }
         },
         "btm-expressions": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.11.tgz",
-            "integrity": "sha512-F/UhMYXAR4zzpMyYmYzSjDb+r2oLlX+TkHnKc1OuuCxe+O3xeEsqmkVA3Ueyq3iz/T/omEpgPBWUG4IaoC0k5Q=="
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/btm-expressions/-/btm-expressions-0.1.12.tgz",
+            "integrity": "sha512-X/IK6RxA+vm9XPvoweK2AYFLxpHcpfExM15v12eA4+0ibf4irI/FBz2iDcllOIWnIBmRVeoXZww72GHQXTiqOw=="
         },
         "buffer-from": {
             "version": "1.1.2",

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -37,7 +37,7 @@
         "-": "0.0.1",
         "@mapbox/node-pre-gyp": "^1.0.11",
         "bootstrap": "3.4.1",
-        "btm-expressions": "^0.1.9",
+        "btm-expressions": "^0.1.10",
         "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -37,7 +37,7 @@
         "-": "0.0.1",
         "@mapbox/node-pre-gyp": "^1.0.11",
         "bootstrap": "3.4.1",
-        "btm-expressions": "^0.1.10",
+        "btm-expressions": "^0.1.11",
         "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -37,7 +37,7 @@
         "-": "0.0.1",
         "@mapbox/node-pre-gyp": "^1.0.11",
         "bootstrap": "3.4.1",
-        "btm-expressions": "^0.1.11",
+        "btm-expressions": "^0.1.12",
         "byte-base64": "^1.1.0",
         "codemirror": "^5.59.4",
         "handsontable": "7.2.2",

--- a/bases/rsptx/interactives/runestone/fitb/js/fitb.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb.js
@@ -622,6 +622,7 @@ export default class FITB extends RunestoneBase {
         var feedback_html = "<ul>";
         for (var i = 0; i < this.displayFeed.length; i++) {
             let df = this.displayFeed[i];
+            let fm = (this.isCorrectArray[i] === true) ? '✔️' : '✖️';
             // Render any dynamic feedback in the provided feedback, for client-side grading of dynamic problems.
             if (typeof this.dyn_vars === "string") {
                 df = renderDynamicFeedback(
@@ -636,7 +637,7 @@ export default class FITB extends RunestoneBase {
                     ? df[0].parentElement.innerHTML
                     : "No feedback provided";
             }
-            feedback_html += `<li>${df}</li>`;
+            feedback_html += `<li>${fm} ${df}</li>`;
         }
         feedback_html += "</ul>";
         // Remove the list if it's just one element.


### PR DESCRIPTION
* Add character indicators (checkmark/x-mark) to FITB feedback for correct/incorrect.
* npm version change for btm-expressions (math formula support)
  * Added ability for formulas to do some automatic algebra reductions
  * Automatic simplification of formulas involving constants

The authored feedback for fillin problems doubles as text for the automatically-generated solution in PreTeXt sources. That feedback does not necessarily have enough context clues to indicate if an answer was correct or not (in the case of multiple blanks), so the addition of a checkmark when correct and and "x" when incorrect should improve visual clues of correctness. The characters match what is used for multiple choice feedback.

The btm-expressions version update facilitates improved automatic simplification of expressions that are used for formulas that are derived from authored formulas so that they can appear cleaner when appearing in solutions.

(Note: I don't know if there is a better way for the btm-expressions library to update. The choice of including it as a Runestone dependency was so that problems always have the resources if the Runestone Component itself loads. But then incremental improvements to the underlying library require an update of package.json without any corresponding actual change to the components. Let me know if we should transition to a different mode.)