### PR TITLE
Pass args instead of null

### DIFF
--- a/projects/jobe/files/CodeTestHelper.java
+++ b/projects/jobe/files/CodeTestHelper.java
@@ -439,7 +439,7 @@ public class CodeTestHelper {
                 if (m.getName().equals(methodName)) {
 
                     if (!checkStaticMethod(m) && checkReturnType(m, "void")) {
-                        return getInstanceMethodOutput(m, null);
+                        return getInstanceMethodOutput(m, args);
                     } else if (!checkStaticMethod(m)) {
                         Object o = getTestInstance();
 


### PR DESCRIPTION
This pass through method wasn’t passing necessary args for methods that take arguments. Now it does.