### PR TITLE
handle long parsons lines without wrap

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/css/parsons.css
+++ b/bases/rsptx/interactives/runestone/parsons/css/parsons.css
@@ -202,6 +202,7 @@
     clear: both;
     float: left;
     background-color: transparent;
+    white-space: pre; /* prevent wrap */
 }
 
 .parsons .block p {
@@ -324,6 +325,7 @@
 .runestone .lines {
     display: inline-block;
     align-self: left;
+    overflow: auto; /* scroll if really long lines */
 }
 
 .border_left {

--- a/bases/rsptx/interactives/runestone/parsons/css/parsons.css
+++ b/bases/rsptx/interactives/runestone/parsons/css/parsons.css
@@ -325,7 +325,8 @@
 .runestone .lines {
     display: inline-block;
     align-self: left;
-    overflow: auto; /* scroll if really long lines */
+    overflow-x: auto; /* scroll if really long lines */
+    overflow-y: hidden; /* hide vertical scroll bar in that case */
 }
 
 .border_left {


### PR DESCRIPTION
Currently, long code lines in Parsons get broken at whitespace. That is quite confusing where code is involved.

This prevents wrapping code in Parsons. Instead, if necessary, the text inside the block can be scrolled side to side to see the tail end of really long lines.