### PR TITLE
Add cpp as a pretty language for parsons

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -154,6 +154,7 @@ export default class Parsons extends RunestoneBase {
             html: "prettyprint lang-html",
             c: "prettyprint lang-c",
             "c++": "prettyprint lang-cpp",
+            cpp: "prettyprint lang-cpp",
             ruby: "prettyprint lang-rb",
         }[language];
         if (prettifyLanguage == undefined) {


### PR DESCRIPTION
PTX generates the language attribute as `cpp`. The RS Parsons JS is looking for `c++`. This makes RS accept either string as being c++ code.