### PR TITLE
Fix bug that prevents parsons from waiting for mathjax formatting

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -475,7 +475,7 @@ export default class Parsons extends RunestoneBase {
                 this.options.language == "natural" ||
                 this.options.language == "math"
             ) {
-                if (typeof runestoneMathready !== "undefined") {
+                if (typeof runestoneMathReady !== "undefined") {
                     await runestoneMathReady.then(
                         async () => await self.queueMathJax(item[0])
                     );


### PR DESCRIPTION
Typo in Parsons code prevents it from waiting for MathJax to format. Thus you can get cut off content as proper width was not known:
![image](https://github.com/user-attachments/assets/b328a05b-cff7-4b2a-b780-223bc650ada9)

This fixes the issue:
![image](https://github.com/user-attachments/assets/b7ecfa94-bfc7-48ba-afa4-8b4456545875)
