### PR TITLE
Fix: get_peer_votes function to fetch every student's latest votes only

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/views/peer/dashboard.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/peer/dashboard.html
@@ -8,7 +8,6 @@
  </div>
 
 <h2>Peer Instruction: {{=assignment_name}}</h2>
-<div id="imessage"></div>
 
 <div class="row">
     <div class="col-md-6">
@@ -53,21 +52,21 @@
             <div id="chat-modality">
                 <button
                     type="button"
-                    id="makep"
-                    class="btn btn-info"
-                    onclick="makePartners(event)"
-                    disabled
-                >
-                    Enable Text Chat
-                </button>
-                <button
-                    type="button"
                     id="facechat"
                     class="btn btn-info"
                     onclick="enableFaceChat(event)"
                     disabled
                 >
                 Enable in-person Chat
+                </button>
+                <button
+                    type="button"
+                    id="makep"
+                    class="btn btn-info"
+                    onclick="makePartners(event)"
+                    disabled
+                >
+                    Enable Text Chat
                 </button>
             </div>
             <button
@@ -122,6 +121,8 @@
         </form>
     </div>
 </div>
+
+<div id="imessage"></div>
 
 <div class="row">
     <div class="oneq col-md-6 runestone-sphinx">

--- a/components/rsptx/db/crud.py
+++ b/components/rsptx/db/crud.py
@@ -173,16 +173,27 @@ async def get_peer_votes(div_id: str, course_name: str, voting_stage: int):
     Provide the answers for a peer instruction multiple choice question.
     What percent of students chose each option. This is used for the Review page of Peer Instruction questions.
     """
+    # Subquery to get the latest vote for each student
+    subquery = (
+        select(func.max(Useinfo.id).label("max_id"))
+        .where(
+            (Useinfo.event == "mChoice") &
+            (Useinfo.course_id == course_name) &
+            (Useinfo.div_id == div_id) &
+            Useinfo.act.like(f"%vote{voting_stage}")
+        )
+        # Group by student ID to get each student's latest vote
+        .group_by(Useinfo.sid)
+        .subquery()
+    )
+
+    # Querying the Useinfo table for every student's latest votes using the subquery
     query = (
         select(Useinfo.act)
-        .where(
-            (Useinfo.event == "mChoice")
-            & (Useinfo.course_id == course_name)
-            & (Useinfo.div_id == div_id)
-            & Useinfo.act.like(f"%vote{voting_stage}")
-        )
+        .join(subquery, Useinfo.id == subquery.c.max_id)
         .order_by(Useinfo.id.desc())
     )
+
     async with async_session() as session:
         result = await session.execute(query)
         ans = result.scalars().all()


### PR DESCRIPTION
This PR contains the following edits:

- `get_peer_votes()`: This function, in `crud.py`, has been modified to only fetch every student's latest votes for creating the graphs on the PI Review Page. Previously, the function would fetch every vote, leading to duplicate entries in the graphs.
- PI instructor dashboard UI fixes: Barb wanted me to move around the chat buttons so that "In-person Chat" is situated before "Text Chat" and the feedback div is moved beneath all the buttons.