### PR TITLE
Update var names that are linking to PreTeXt defined variables

### DIFF
--- a/bases/rsptx/interactives/ptxrs-bootstrap.less
+++ b/bases/rsptx/interactives/ptxrs-bootstrap.less
@@ -8,7 +8,7 @@
     --background: #ffffff;
     --outerBackground: #eeeeee;
     --links: #0645ad;
-    --bodyFont: var(--bodyfontcolor, #000000);
+    --bodyFont: var(--body-text-color, #000000);
     --tooltip: #ffffff;
     --grayToWhite: #333333;
     --navbar: #f8f8f8;
@@ -40,7 +40,7 @@
     --background: #2c2f33;
     --outerBackground: #23272a;
     --links: #7289da;
-    --bodyFont: var(--bodyfontcolor, #99aab5);
+    --bodyFont: var(--body-text-color, #99aab5);
     --tooltip: #000000;
     --grayToWhite: #ffffff;
     --navbar: #3d3d3d;
@@ -55,9 +55,9 @@
     --codeButtonsBorder: #ffffff;
     --dangerAlerts: #8c2626;
     --successAlerts: #217300;
-    --componentBgColor: var(--rs-component-bg, var(--knowlbackground, #07467d));
-    --componentBorderColor: var(--rs-component-border, var(--knowlborder, #939090));
-    --questionBgColor: var(--rs-component-bg, var(--knowlNested1Background, #0f5a9b));
+    --componentBgColor: var(--rs-component-bg, var(--knowl-background, #07467d));
+    --componentBorderColor: var(--rs-component-border, var(--knowl-border-color, #939090));
+    --questionBgColor: var(--rs-component-bg, var(--knowl-nested-1-background, #0f5a9b));
     --parsonsBgColor: rgb(232, 232, 178);
     --parsonsBorderColor: rgb(168, 168, 45);
     --parsonsCorrectBgColor: #a3c097;


### PR DESCRIPTION
We refactored a few of the CSS variable names defined in new themes. This updates the RS variables that attempt to point at those to use the new names.

Should be safe to deploy whenever. 