### PR TITLE
Fix floating tabs hanging on active one

### DIFF
--- a/bases/rsptx/interactives/runestone/tabbedStuff/css/tabbedstuff.css
+++ b/bases/rsptx/interactives/runestone/tabbedStuff/css/tabbedstuff.css
@@ -16,7 +16,6 @@
 .nav.nav-tabs > li > a {
     border: 1px solid var(--componentBorderColor);
     border-radius: 4px 4px 0 0;
-    border-bottom: 0;
     color: var(--bodyFont, #555);
 }
 


### PR DESCRIPTION
Fix for issue reported here:
https://groups.google.com/g/pretext-support/c/6Vp3lbOLYw0

It appears that when there was more than one row of tabs, later rows floats could "hang" on the border added to the <a> in the active one.