### PR TITLE
Fix URLs for SQL Activecode PreTeXt books built for static HTML

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
@@ -21,8 +21,7 @@ export default class SQLActiveCode extends ActiveCode {
             fnprefix = bookprefix + "/_static";
         } else {
             // The else clause handles the case where you are building for a static web browser
-            bookprefix = "";
-            fnprefix = "/_static";
+            fnprefix = "_static";
         }
         this.config = {
             locateFile: (filename) => `${fnprefix}/${filename}`,
@@ -33,9 +32,20 @@ export default class SQLActiveCode extends ActiveCode {
             // set up call to load database asynchronously if given
             if (self.dburl) {
                 if (self.dburl.startsWith("/_static")) {
+                    // RST markup
                     self.dburl = `${bookprefix}${self.dburl}`;
                 } else if (self.dburl.startsWith("external")) {
-                    self.dburl = `${bookprefix}/${self.dburl}`;
+                    // PTX markup
+                    if(
+                        eBookConfig.useRunestoneServices  ||
+                        window.location.search.includes("mode=browsing")
+                    ) {
+                        // On Runestone server
+                        self.dburl = `${bookprefix}/${self.dburl}`;
+                    } else {
+                        // static individual book
+                        self.dburl = `${self.dburl}`;
+                    }
                 }
                 $(self.runButton).attr("disabled", "disabled");
                 let buttonText = $(self.runButton).text();


### PR DESCRIPTION
This makes sql-wasm and DB files load correctly for static HTML builds with PreTeXt. Tested with local copy of sample-book.

I don't *think* this should affect RST based builds negatively. I think it might help them... `/_static` is almost never going to be the right way to start the URL.

Should be able close these two:
https://github.com/RunestoneInteractive/rs/issues/584
https://github.com/RunestoneInteractive/rs/issues/351