### PR TITLE
Bugfix: guide link for LTI in admin panel

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/views/admin/admin.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/admin/admin.html
@@ -320,7 +320,7 @@
             <h2 style="text-align: center">LTI Configuration</h2>
             <p>LTI is <strong>Community Supported!</strong> It works but you need to know how to configure things on your own LMS.
                There is strong evidence that LTI works on Canvas, Sakai, Moodle, and Desire2Learn.
-               Please <a href="https://guide.runestone.academy/chapter-4.html#lti_integration" rel="noopener noreferrer" target="_blank">Read the docs <span class="glyphicon glyphicon-link"></span></a>  first,
+               Please <a href="https://guide.runestone.academy/InstructorGuide-7.html#lti_integration" rel="noopener noreferrer" target="_blank">Read the docs <span class="glyphicon glyphicon-link"></span></a>  first,
             then feel free to ask for help on the <code>#lti_community_support</code> channel on Discord. If you have it working on another
             LMS please helps us out and contribute to the docs so that others can benefit.</p>
             <p>To launch lti on Runestone use <code>https://runestone.academy/runestone/lti</code></p>


### PR DESCRIPTION
Fixes the link from the admin panel to the LTI section in the guide