### PR TITLE
Fix dashboard/student-progress exercise analytics links in PTX

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/controllers/dashboard.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/dashboard.py
@@ -187,6 +187,8 @@ def index():
                 "not_attempted": stats[0],
                 "attemptedBy": stats[1] + stats[2] + stats[3],
             }
+        #problem_id is course_version_id, we want just the problem_id for use in the URL
+        entry['ptx_link_id'] = "_".join(entry['id'].split("_")[2:])
         questions.append(entry)
         logger.debug("ADDING QUESTION %s ", entry["chapter"])
 

--- a/bases/rsptx/web2py_server/applications/runestone/views/dashboard/index.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/dashboard/index.html
@@ -110,7 +110,11 @@
                                 <div id="chart-question-{{=question['id']}}" class="donut-chart"></div>
                                 <div class="question-info" style="">
                                     {{ if "chapter" in question.keys(): }}
+                                        {{ if origin == "Runestone":}}
                                         <a style="color: #333;" href="{{=get_course_url( question['chapter'], question['sub_chapter'])}}.html"><b>{{=question["text"]}}</b></a>
+                                        {{ else: }}
+                                        <a style="color: #333;" href="{{=get_course_url(question['sub_chapter'])}}.html#{{=question['ptx_link_id']}}"><b>{{=question["text"]}}</b></a>
+                                        {{ pass }}
                                     {{ else: }}
                                         <b>{{=question["text"]}}</b>
                                     {{ pass }}


### PR DESCRIPTION
Fixes the links shown in image below for PTX books.

I don't love the solution (borrows code from higherup in index.html). It seems like it could get messy fast to have the template logic doing lots of deciding what platform it is working with. Should both get refactored so that the controller (or the `get_course_url` function does the work of handling PTX/RS?

![image](https://github.com/user-attachments/assets/346ef938-c8e2-480c-b1e8-480b8a788fae)
