### PR TITLE
CSS darkmode adjustments for activecode

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.css
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.css
@@ -62,8 +62,11 @@
 }
 
 .unittest-results {
-    margin-left: 20px;
     margin-bottom: 20px;
+}
+
+.unittest-results table {
+    width: 100%;
 }
 
 .ac_output {
@@ -77,8 +80,10 @@
     background-color: var(--ac-out-background);
 }
 
-.python_check_results pre {
-    background-color: #f5f5f5;
+.python_check_results pre,
+.ac_section .error pre,
+.ac-modal-body .error pre {
+    background-color: var(--content-background, #fefefe);
 }
 
 .ac_caption {
@@ -119,22 +124,17 @@
 .ac-feedback {
     border: 1px solid var(--componentBorderColor);
     padding: 3px;
-    background-color: var(--mainbackground, #fff);
+    background-color: var(--content-background,#fff);
 }
 
 .ac-feedback-pass {
-    background-color: rgb(131, 211, 130);
+    background-color: var(--ac-passed);
     text-align: center;
 }
 
 .ac-feedback-fail {
-    background-color: rgb(222, 142, 150);
+    background-color: var(--ac-failed);
     text-align: center;
-}
-
-.unittest-results tr:not(:first-of-type) td:first-of-type {
-    color: #111;
-    /* deal with hardcoded light backgrounds in skulpt :( */
 }
 
 .CodeMirror {
@@ -146,27 +146,18 @@
     background-color: var(--ac-out-background);
     padding: 10px;
     border-radius: 6px;
-    margin-bottom: 10px;
-}
-
-.ac_sql_result_success {
-    background-color: transparent;
-    color: green;
-    border: 0px;
-    padding: 0px;
     margin-top: 10px;
     margin-bottom: 10px;
-    min-height: 0px !important;
 }
 
+.ac_sql_result_success,
 .ac_sql_result_failure {
-    background-color: transparent;
-    color: red;
     border: 0px;
     padding: 0px;
-    margin-top: 10px;
-    margin-bottom: 10px;
-    min-height: 0px !important;
+}
+
+.ac_sql_result_failure pre {
+    background: var(--dangerAlerts);
 }
 
 .codelens {

--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.less
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.less
@@ -4,12 +4,12 @@
 
 :root {
     --ac-out-background: lightgray;
-    // --ac-failed: rgb(222, 142, 150);
-    // --ac-passed: rgb(131, 211, 130);
+    --ac-failed: rgb(222, 142, 150);
+    --ac-passed: rgb(131, 211, 130);
 }
 
 :root.dark-mode {
     --ac-out-background: var(--code-inline, #2e2e2e);
-    // --ac-failed: #592d2d;
-    // --ac-passed: rgb(40, 88, 40);
+    --ac-failed: #592d2d;
+    --ac-passed: rgb(40, 88, 40);
 }

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
@@ -234,8 +234,8 @@ export default class SQLActiveCode extends ActiveCode {
             } else {
                 let messageBox = document.createElement("pre");
                 messageBox.textContent = r.message;
-                messageBox.setAttribute("class", "ac_sql_result_failure");
                 section.appendChild(messageBox);
+                section.classList.add("ac_sql_result_failure");
             }
         }
 

--- a/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -145,10 +145,6 @@ body {
     background-color: var(--outerBackground);
 }
 
-pre {
-    margin: 0 0 1em;
-}
-
 h5 {
     font-weight: bold;
     padding: 10px 0;
@@ -1220,3 +1216,8 @@ details.ptx-footnote {
     display: inline;
 }
 /* ---------------------------------------------------------- */
+
+.handsontable td, .handsontable th {
+    background-color: var(--content-background, #fff);
+    color: var(--bodyFont, #000);
+}


### PR DESCRIPTION
Changes:

- Styling for unit test and code coach for python
- Styling for SQL unit test and error message
- Removes "dirty" style from code editor on run
- No display of error box if empty