### PR TITLE
Better block sizing for parsons problems

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/css/parsons.css
+++ b/bases/rsptx/interactives/runestone/parsons/css/parsons.css
@@ -202,6 +202,7 @@
     clear: both;
     float: left;
     background-color: transparent;
+    white-space: pre;
 }
 
 .parsons .block p {

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -201,11 +201,6 @@ export default class Parsons extends RunestoneBase {
             "aria-describedby",
             this.counterId + "-sourceTip"
         );
-        // set the source width to its max value.  This allows the blocks to be created
-        // at their "natural" size. As long as that is smaller than the max.
-        // This allows us to use sensible functions to determine the correct heights
-        // and widths for the drag and drop areas.
-        this.sourceArea.style.width = "425px"; // The max it will be resized later.
         this.sourceRegionDiv.appendChild(this.sourceArea);
         this.answerRegionDiv = document.createElement("div");
         this.answerRegionDiv.id = this.counterId + "-answerRegion";
@@ -455,6 +450,21 @@ export default class Parsons extends RunestoneBase {
         for (let i = 0; i < this.lines.length; i++) {
             this.lines[i].initializeWidth();
         }
+
+        // Set the source width to its max value.  This allows the blocks to be created
+        // at their "natural" size. As long as that is smaller than the max.
+        // This allows us to use sensible functions to determine the correct heights
+        // and widths for the drag and drop areas.
+        // Like most of the sizing, this is a bit of a hack.
+        const availableWidth = this.outerDiv.offsetWidth;
+        const answerIndentSpace = this.options.pixelsPerIndent * this.indent;
+        const marginFudge = 80;  // margins, padding, etc...
+        let maxSourceAreaWidth = (availableWidth - answerIndentSpace - marginFudge) / 2;
+        if (this.options.numbered != undefined) {
+            maxSourceAreaWidth -= 25;
+        }
+        this.sourceArea.style.width = maxSourceAreaWidth + "px"; // likely reduced later
+
         // Layout the areas
         var areaWidth, areaHeight;
         // Establish the width and height of the droppable areas
@@ -469,7 +479,7 @@ export default class Parsons extends RunestoneBase {
         // item is a jQuery object
         // outerHeight can be unreliable if elements are not yet visible
         // outerHeight will return bad results if MathJax has not rendered the math
-        areaWidth = 300;
+        areaWidth = 0;
         let self = this;
         maxFunction = async function (item) {
             if (


### PR DESCRIPTION
Improves block sizing for Parsons problems. New pretext styling upset some of the delicate magic.

This reduces some of the assumptions for the `sourceRegion` width. Instead of starting at 425px max, the max possible width is calculated based on what is actually available. There is also no longer a min width of 300, so in a narrow view, you can still end up with side by side presentation if the content is reflowable.

![image](https://github.com/user-attachments/assets/fd18f0f5-b627-487d-8baf-d0db2becd294)
