### PR TITLE
Allow livecodes to read updated contents of editable datafiles

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -233,7 +233,12 @@ export default class LiveCode extends ActiveCode {
                     // check to see if file is in db
                     content = this.fileReader(fileName);
                 } else {
-                    content = file.textContent;
+                    // if file element is editable textarea, file.value is defined and has the current contents
+                    // otherwise rely on static contents
+                    if(file.value)
+                        content = file.value;
+                    else
+                        content = file.textContent;
                     // may be undefined at this point if file is an image
                 }
                 if (fileExtension === "jar") {


### PR DESCRIPTION
Currently livecodes ignore any changes to editable datafiles.

`el.textContent` only returns the initial contents of the text area. `el.value` is required to get to the current contents.