### PR TITLE
Add styling to manual grading tab to fix #386

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/static/js/admin.js
+++ b/bases/rsptx/web2py_server/applications/runestone/static/js/admin.js
@@ -30,7 +30,12 @@ function gradeIndividualItem() {
     }
 
     $(rightSideDiv)[0].style.visibility = "visible";
-    rightSideDiv.html(""); //empty it out
+    rightSideDiv.css({
+        "z-index": "1050",
+        "position": "relative",
+        "overflow": "auto",
+        "max-height": "90vh"
+    }).html(""); //empty it out
     rightSideDiv.html(`<div id='filterqs'
     style="
     width: 60%;


### PR DESCRIPTION
I added some CSS styling to the manual grading pop-up to prevent it from being covered by the grading summary tab. This pretty much fixes #386 , but I can improve it if needed.