### PR TITLE
darken pretext keyword color to fix contrast error

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
+++ b/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
@@ -5,7 +5,7 @@
 
 // Force some colors to match those used by PreTeXt for syntax highlighting
 .cm-s-default .cm-comment { color: #3a812e; }
-.cm-s-default .cm-keyword { color: rgb(18, 137, 201); }
+.cm-s-default .cm-keyword { color: #1186C5; }
 .cm-s-default .cm-variable { color: #5e1ca0; }
 
 // Values pulled from codemirror/theme/blackboard.css

--- a/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
+++ b/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
@@ -5,7 +5,7 @@
 
 // Force some colors to match those used by PreTeXt for syntax highlighting
 .cm-s-default .cm-comment { color: #3a812e; }
-.cm-s-default .cm-keyword { color: #1186C5; }
+.cm-s-default .cm-keyword { color: #067CBC; }
 .cm-s-default .cm-variable { color: #5e1ca0; }
 
 // Values pulled from codemirror/theme/blackboard.css

--- a/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
+++ b/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
@@ -5,7 +5,7 @@
 
 // Force some colors to match those used by PreTeXt for syntax highlighting
 .cm-s-default .cm-comment { color: #3a812e; }
-.cm-s-default .cm-keyword { color: #067CBC; }
+.cm-s-default .cm-keyword { color: #0679B7; }
 .cm-s-default .cm-variable { color: #5e1ca0; }
 
 // Values pulled from codemirror/theme/blackboard.css


### PR DESCRIPTION
This addresses the contrast errors for keywords in activecode in light mode.

A PR to pretext to have their keywords match this color will follow.