### PR TITLE
use data-lang attribute instead of lang for createEditor function

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -221,14 +221,13 @@ export class ActiveCode extends RunestoneBase {
         codeDiv.classList.add("ac_code_div");
         codeDiv.setAttribute("aria-label", "CodeMirror Editor");
         this.codeDiv = codeDiv;
-        this.outerDiv.lang = this.language;
         this.origElem.replaceWith(this.outerDiv);
         if (linkdiv.id !== this.divid) {
             // Don't want the 'extra' target if they match.
             this.outerDiv.appendChild(linkdiv);
         }
         this.outerDiv.appendChild(codeDiv);
-        var edmode = this.outerDiv.lang;
+        var edmode = this.language;
         if (edmode === "sql") {
             edmode = "text/x-sql";
         } else if (edmode === "java") {

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -860,6 +860,8 @@ export class ActiveCode extends RunestoneBase {
         $(scrubber).on("slide", this.slideit.bind(this));
         $(scrubber).on("slidechange", this.slideit.bind(this));
         scrubberDiv.appendChild(scrubber);
+        // Add aria-label to the otherwise empty <a> child for scrubber:
+        scrubber.childNodes[0].setAttribute("aria-label", "History slider")
         scrubberDiv.appendChild(this.timestampP);
         // If there is a deadline set then position the scrubber at the last submission
         // prior to the deadline


### PR DESCRIPTION
This addresses the penultimate issue related to active code accessibility: the use of `@lang` in a outerDiv to help determine the value of the programming langue for the textarea.  Switched to `@data-lang` and tested against the sample book.