### PR TITLE
Flexible drag and drop widths

### DIFF
--- a/bases/rsptx/interactives/runestone/dragndrop/css/dragndrop.css
+++ b/bases/rsptx/interactives/runestone/dragndrop/css/dragndrop.css
@@ -9,6 +9,7 @@
     font-family: monospace;
     font-size: 120%;
     padding-bottom: 10px;
+    min-width: 28%;
     border: 1px solid var(--componentBorderColor, #efefff);
     box-sizing: border-box;
 }

--- a/bases/rsptx/interactives/runestone/dragndrop/css/dragndrop.css
+++ b/bases/rsptx/interactives/runestone/dragndrop/css/dragndrop.css
@@ -1,5 +1,6 @@
 .rsdraggable {
-    margin-left: 2%;
+    margin-left: 1%;
+    margin-right: 1%;
     margin-top: 5px;
     display:inline;
     float:left;

--- a/bases/rsptx/interactives/runestone/dragndrop/css/dragndrop.css
+++ b/bases/rsptx/interactives/runestone/dragndrop/css/dragndrop.css
@@ -9,8 +9,6 @@
     font-family: monospace;
     font-size: 120%;
     padding-bottom: 10px;
-    min-width: 48%;
-    max-width: 48%;
     border: 1px solid var(--componentBorderColor, #efefff);
     box-sizing: border-box;
 }

--- a/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
+++ b/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
@@ -345,12 +345,17 @@ export default class DragNDrop extends RunestoneBase {
                     // Make sure element isn't already there--prevents erros w/appending child
                     ev.target.appendChild(draggedSpan);
                 }
+                this.queueMathJax(this.containerDiv).then(() => {
+                    this.adjustDragDropWidths();
+                });
             }.bind(this)
         );
     }
 
     adjustDragDropWidths() {
-        // Ensure MathJax has completed when calling this method
+        // Temporarily minimize the dragzone width to the content
+        this.draggableDiv.style.width = "fit-content";
+        
         const dragzoneWidth = this.draggableDiv.offsetWidth;
         const totalWidth = this.dragDropWrapDiv.offsetWidth;
 
@@ -404,6 +409,9 @@ export default class DragNDrop extends RunestoneBase {
         // Ensure MathJax has completed before adjusting the zone widths
         this.queueMathJax(this.containerDiv).then(() => {
             this.adjustDragDropWidths();
+            this.minheight = this.draggableDiv.offsetHeight;
+            this.dragDropWrapDiv.style.minHeight =
+                this.minheight.toString() + "px";
         });
     }
     /*===========================

--- a/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
+++ b/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
@@ -148,7 +148,10 @@ export default class DragNDrop extends RunestoneBase {
         }
         self = this;
         this.ivp = this.isValidPremise.bind(this);
-        self.queueMathJax(self.containerDiv);
+        // Ensure MathJax has completed before adjusting the zone widths
+        self.queueMathJax(self.containerDiv).then(() => {
+            this.adjustDragDropWidths();
+        });
     }
 
     finishSettingUp() {
@@ -343,6 +346,19 @@ export default class DragNDrop extends RunestoneBase {
         );
     }
 
+    adjustDragDropWidths() {
+        // Ensure MathJax has completed when calling this method
+        const dragzoneWidth = this.draggableDiv.offsetWidth;
+        const totalWidth = this.dragDropWrapDiv.offsetWidth;
+
+        let dragzonePercent = Math.ceil((dragzoneWidth / totalWidth) * 100);
+        dragzonePercent = Math.max(28, Math.min(dragzonePercent, 48));
+        const dropzonePercent = 100 - dragzonePercent - 4; // 4 accounts for zone padding
+
+        this.draggableDiv.style.width = `${dragzonePercent}%`;
+        this.dropZoneDiv.style.width = `${dropzonePercent}%`;
+    }
+
     createFeedbackDiv() {
         if (!this.feedBackDiv) {
             this.feedBackDiv = document.createElement("div");
@@ -379,6 +395,10 @@ export default class DragNDrop extends RunestoneBase {
         }
         this.answerState = {};
         this.feedBackDiv.style.display = "none";
+        // Ensure MathJax has completed before adjusting the zone widths
+        self.queueMathJax(self.containerDiv).then(() => {
+            self.adjustDragDropWidths();
+        });
     }
     /*===========================
     == Evaluation and feedback ==

--- a/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
+++ b/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
@@ -201,6 +201,10 @@ export default class DragNDrop extends RunestoneBase {
                 ) {
                     // Make sure element isn't already there--prevents erros w/appending child
                     this.draggableDiv.appendChild(draggedSpan);
+                    this.adjustDragDropWidths();
+                    this.minheight = this.draggableDiv.offsetHeight;
+                    this.dragDropWrapDiv.style.minHeight =
+                        this.minheight.toString() + "px";
                 }
             }.bind(this)
         );
@@ -406,13 +410,10 @@ export default class DragNDrop extends RunestoneBase {
         }
         this.answerState = {};
         this.feedBackDiv.style.display = "none";
-        // Ensure MathJax has completed before adjusting the zone widths
-        this.queueMathJax(this.containerDiv).then(() => {
-            this.adjustDragDropWidths();
-            this.minheight = this.draggableDiv.offsetHeight;
-            this.dragDropWrapDiv.style.minHeight =
-                this.minheight.toString() + "px";
-        });
+        this.adjustDragDropWidths();
+        this.minheight = this.draggableDiv.offsetHeight;
+        this.dragDropWrapDiv.style.minHeight =
+            this.minheight.toString() + "px";
     }
     /*===========================
     == Evaluation and feedback ==

--- a/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
+++ b/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
@@ -396,8 +396,8 @@ export default class DragNDrop extends RunestoneBase {
         this.answerState = {};
         this.feedBackDiv.style.display = "none";
         // Ensure MathJax has completed before adjusting the zone widths
-        self.queueMathJax(self.containerDiv).then(() => {
-            self.adjustDragDropWidths();
+        this.queueMathJax(this.containerDiv).then(() => {
+            this.adjustDragDropWidths();
         });
     }
     /*===========================

--- a/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
+++ b/bases/rsptx/interactives/runestone/dragndrop/js/dragndrop.js
@@ -148,10 +148,7 @@ export default class DragNDrop extends RunestoneBase {
         }
         self = this;
         this.ivp = this.isValidPremise.bind(this);
-        // Ensure MathJax has completed before adjusting the zone widths
-        self.queueMathJax(self.containerDiv).then(() => {
-            this.adjustDragDropWidths();
-        });
+        self.queueMathJax(self.containerDiv);
     }
 
     finishSettingUp() {
@@ -160,6 +157,10 @@ export default class DragNDrop extends RunestoneBase {
         this.origElem.parentNode.replaceChild(this.containerDiv, this.origElem);
         if (!this.hasStoredDropzones) {
             this.minheight = this.draggableDiv.offsetHeight;
+            // Ensure MathJax has completed before adjusting the zone widths
+            this.queueMathJax(this.containerDiv).then(() => {
+                this.adjustDragDropWidths();
+            });
         }
         this.draggableDiv.style.minHeight = this.minheight.toString() + "px";
         if (this.dropZoneDiv.offsetHeight > this.minheight) {
@@ -169,6 +170,8 @@ export default class DragNDrop extends RunestoneBase {
             this.dragDropWrapDiv.style.minHeight =
                 this.minheight.toString() + "px";
         }
+        this.draggableDiv.style.width = `${this.dragwidth}%`;
+        this.dropZoneDiv.style.width = `${this.dropwidth}%`;
     }
     addDragDivListeners() {
         let self = this;
@@ -354,6 +357,9 @@ export default class DragNDrop extends RunestoneBase {
         let dragzonePercent = Math.ceil((dragzoneWidth / totalWidth) * 100);
         dragzonePercent = Math.max(28, Math.min(dragzonePercent, 48));
         const dropzonePercent = 100 - dragzonePercent - 4; // 4 accounts for zone padding
+        
+        this.dragwidth = dragzonePercent;
+        this.dropwidth = dropzonePercent;
 
         this.draggableDiv.style.width = `${dragzonePercent}%`;
         this.dropZoneDiv.style.width = `${dropzonePercent}%`;
@@ -485,6 +491,8 @@ export default class DragNDrop extends RunestoneBase {
             act: answer,
             answer: answer,
             min_height: Math.round(this.minheight),
+            drag_width: this.dragwidth,
+            drop_width: this.dropwidth,
             div_id: this.divid,
             correct: this.correct,
             correctNum: this.correctNum,
@@ -532,6 +540,8 @@ export default class DragNDrop extends RunestoneBase {
         // Restore answers from storage retrieval done in RunestoneBase
         this.hasStoredDropzones = true;
         this.minheight = data.min_height;
+        this.dragwidth = data.drag_width;
+        this.dropwidth = data.drop_width;
         this.answerState = JSON.parse(data.answer);
         this.finishSettingUp();
     }
@@ -550,6 +560,8 @@ export default class DragNDrop extends RunestoneBase {
                 try {
                     storedObj = JSON.parse(ex);
                     this.minheight = storedObj.min_height;
+                    this.dragwidth = storedObj.drag_width;
+                    this.dropwidth = storedObj.drop_width;
                 } catch (err) {
                     // error while parsing; likely due to bad value stored in storage
                     console.log(err.message);
@@ -567,6 +579,8 @@ export default class DragNDrop extends RunestoneBase {
                         act: answer,
                         answer: answer,
                         min_height: Math.round(this.minheight),
+                        drag_width: this.dragwidth,
+                        drop_width: this.dropwidth,
                         div_id: this.divid,
                         correct: storedObj.correct,
                     });
@@ -599,6 +613,8 @@ export default class DragNDrop extends RunestoneBase {
             min_height: this.minheight,
             timestamp: timeStamp,
             correct: correct,
+            drag_width: this.dragwidth,
+            drop_width: this.dropwidth,
         };
         localStorage.setItem(
             this.localStorageKey(),


### PR DESCRIPTION
Adds the method adjustDragDropWidths to set widths (within constraints) dynamically. Integrates calls to this method after rendering, resetting, and dragging/dropping items. It also addresses the minimum height of the zones that do not reset after the reset button is pressed.