### PR TITLE
Datafile height to max-height

### DIFF
--- a/bases/rsptx/interactives/runestone/datafile/css/datafile.css
+++ b/bases/rsptx/interactives/runestone/datafile/css/datafile.css
@@ -24,7 +24,7 @@
     max-width: 100%;
     overflow: auto;
     white-space: pre;
-    height: 30em;
+    max-height: 30em;
     border: 1px solid var(--componentBorderColor);
     font-size: 90%;
 }


### PR DESCRIPTION
Datafiles currently get 30ems of height even if they are only 1-2 lines. Better as max-height to constrain long files but not add whitespace to short ones.

Only affects non-editable datafile as editable get row/cols sizing via textarea.