### PR TITLE
Better tabbed activecode handling

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -275,6 +275,8 @@ export class ActiveCode extends RunestoneBase {
         CodeMirror.on(editor, "refresh", (cm) => {
             window.requestAnimationFrame(() => {
                 this.setLockedRegions();
+                // make sure vscrollbar does not overlap the resize handle
+                editor.display.scrollbars.vert.style.bottom =  "16px";
             });
         });
 
@@ -284,7 +286,6 @@ export class ActiveCode extends RunestoneBase {
             resize: function () {
                 editor.setSize($(this).width(), $(this).height());
                 editor.refresh();
-                ac.setLockedRegions();
             },
         });
         editor.on("keydown", (cm, event) => {


### PR DESCRIPTION
When an activecode is initially hidden (e.g. in a tab), Codemirror does not render the lines. Thus the initial existing height calculation is wrong and line decorations (locked regions) are not applied correctly. Commit 1 addresses this.

Commit 2 gets rid of the current overlap between vscrollbar and resize handle:
![image](https://github.com/user-attachments/assets/a339100a-6a03-4193-be1e-9bfba96776d6)
