### PR TITLE
Handle highlight lines specified in PTX markup

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.css
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.css
@@ -164,7 +164,12 @@
     background-color: #000;
 }
 .CodeMirror__locked-line {
-    background-color: #f8f8f8;
+    background-color: var(--ac-locked-line-bg);
+}
+
+/* keep after locked-line so this has higher priority */
+.CodeMirror__highlight-line {
+    background-color: var(--ac-highlight-line-bg);
 }
 
 .ac_sql_result {

--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.less
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.less
@@ -6,10 +6,14 @@
     --ac-out-background: lightgray;
     --ac-failed: rgb(222, 142, 150);
     --ac-passed: rgb(131, 211, 130);
+    --ac-highlight-line-bg: #feffe6;
+    --ac-locked-line-bg: #f8f8f8;
 }
 
 :root.dark-mode {
     --ac-out-background: var(--code-inline, #2e2e2e);
     --ac-failed: #592d2d;
     --ac-passed: rgb(40, 88, 40);
+    --ac-highlight-line-bg: #282816;
+    --ac-locked-line-bg: #222;
 }

--- a/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
+++ b/bases/rsptx/interactives/runestone/activecode/css/codemirror-dark.less
@@ -46,9 +46,6 @@
             .cm-s-default .cm-type { color: rgb(45, 148, 251); }
         }
     }
-    .CodeMirror__locked-line {
-        background-color: #222;
-    }
     .CodeMirror__gutter-locked-marker {
         background-color: #888;
     }

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -71,6 +71,7 @@ export class ActiveCode extends RunestoneBase {
         this.code = $(orig).text() || "\n\n\n\n\n";
         this.language = $(orig).data("lang");
         this.timelimit = $(orig).data("timelimit");
+        this.highlightLines = $(orig).data("highlight-lines");
         this.includes = $(orig).data("include");
         this.hidecode = $(orig).data("hidecode");
         this.chatcodes = $(orig).data("chatcodes");
@@ -204,8 +205,9 @@ export class ActiveCode extends RunestoneBase {
         setTimeout(
             function () {
                 this.editor.refresh();
-                // need to regen locked decoration
+                // need to regen/highlight locked decoration
                 this.setLockedRegions();
+                this.setHighlightLines();
             }.bind(this),
             1000
         );
@@ -275,6 +277,7 @@ export class ActiveCode extends RunestoneBase {
         CodeMirror.on(editor, "refresh", (cm) => {
             window.requestAnimationFrame(() => {
                 this.setLockedRegions();
+                this.setHighlightLines();
                 // make sure vscrollbar does not overlap the resize handle
                 editor.display.scrollbars.vert.style.bottom =  "16px";
             });
@@ -379,8 +382,32 @@ export class ActiveCode extends RunestoneBase {
         // lock down code prefix/suffix
         this.setLockedRegions();
 
+        this.setHighlightLines();
+
         if (this.hidecode) {
             $(this.codeDiv).css("display", "none");
+        }
+    }
+
+    async setHighlightLines() {
+        if (this.highlightLines) {
+            if (typeof this.highlightLines === "number")
+                this.highlightLines = this.highlightLines.toString();
+
+            let highlightList = this.highlightLines.split(",");
+            let lines = this.containerDiv.querySelectorAll(".CodeMirror-code > div");
+            highlightList.forEach((line) => {
+                // addLineClass not used here for reason described in setLockedRegions
+                line = line.trim();
+                let lineNum = line.split("-");
+                if (lineNum.length > 1) {
+                    for (let i = parseInt(lineNum[0]); i <= parseInt(lineNum[1]); i++) {
+                        lines[i - 1].classList.add("CodeMirror__highlight-line");
+                    }
+                } else {
+                    lines[lineNum - 1].classList.add("CodeMirror__highlight-line");
+                }
+            });
         }
     }
 
@@ -880,6 +907,10 @@ export class ActiveCode extends RunestoneBase {
                     div_id: this.divid,
                 });
             }
+            // Only re-highlight lines if we are at initial position
+            // otherwise may be highlighting wrong ones
+            if(pos === 0)
+                this.setHighlightLines();
         };
         $(scrubber).slider({
             max: this.history.length - 1,
@@ -920,6 +951,7 @@ export class ActiveCode extends RunestoneBase {
         } else {
             scrubber.value = 0;
         }
+        this.setHighlightLines();
         let pos = $(scrubber).slider("value");
         let outOf = this.history.length;
         let ts = this.timestamps[$(scrubber).slider("value")];


### PR DESCRIPTION
Adds handling for highlight-lines attribute that can be specified in PreTeXt markup for programs to activecodes.

The highlighting is intentionally only shown when when the history slider is at the position 1 to avoid highlighting the wrong lines in versions students have edited.

Depends on pretext PR https://github.com/PreTeXtBook/pretext/pull/2473 to function, but should be safe to merge without the partner PR.