### PR TITLE
More generic "introductory" course level

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/views/designer/index.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/designer/index.html
@@ -154,7 +154,7 @@ h3 {
 					<option value="unknown" disabled selected>Please Select</option>
 					<option value="grad">Graduate</option>
 					<option value="undergradadv">Undergraduate Advanced</option>
-					<option value="undergradintro">Undergraduate Intro (CS1/2)</option>
+					<option value="undergradintro">Undergraduate Introductory</option>
 					<option value="communitycollege">Community College</option>
 					<option value="high">High School</option>
 					<option value="middle">Middle School</option>


### PR DESCRIPTION
Maybe when creating a course, the introducTory level should not suggest just CS1 and CS2?