### PR TITLE
Bugfix for RST datafiles lookups

### DIFF
--- a/bases/rsptx/book_server_api/routers/rslogging.py
+++ b/bases/rsptx/book_server_api/routers/rslogging.py
@@ -616,7 +616,7 @@ async def get_source_code(
     """
     course = await fetch_course(course_id)
 
-    rslogger.debug(f"get_source_code: -{acid}-{filename}-")
+    rslogger.debug(f"get_source_code: course_name:{course.course_name} acid: {acid} filename: {filename} course_name:{course.course_name}")
 
     db_result = await fetch_source_code(
         base_course=course.base_course,
@@ -628,7 +628,8 @@ async def get_source_code(
     if db_result:
         # Found data, unpack desired fields
         file_contents = db_result.main_code
-        filename = db_result.filename
+        if db_result.filename:
+            filename = db_result.filename
     else:
         file_contents = None
 
@@ -636,6 +637,4 @@ async def get_source_code(
         "filename": filename,
         "file_contents": file_contents,
     }
-    import pprint
-    rslogger.debug(f"get_source_code: {pprint.pformat(response_bundle)}")
     return make_json_response(detail=response_bundle)

--- a/bases/rsptx/interactives/runestone/datafile/__init__.py
+++ b/bases/rsptx/interactives/runestone/datafile/__init__.py
@@ -192,7 +192,7 @@ class DataFile(RunestoneIdDirective):
             )
             engine.execute(
                 Source_code.insert().values(
-                    acid=divid, course_id=course_name, main_code=source
+                    acid=divid, course_id=course_name, main_code=source, filename=divid
                 )
             )
         else:

--- a/components/rsptx/db/crud.py
+++ b/components/rsptx/db/crud.py
@@ -3312,13 +3312,16 @@ async def fetch_source_code(
     :param acid: str, the acid of the source code
     :return: SourceCodeValidator, the SourceCodeValidator object
     """
+    rslogger.debug(f"fetch_source_code: -{acid}-{filename}-{course_name}-{base_course}")
     if acid is None and filename is None:
         return None
-    
     elif acid is None:
+        # match against filename or acid for backwards compatibility
         query = select(SourceCode).where(
             and_(
-                SourceCode.filename == filename,
+                or_(
+                    SourceCode.filename == filename, SourceCode.acid == filename,
+                ),
                 or_(
                     SourceCode.course_id == base_course, SourceCode.course_id == course_name
                 ),


### PR DESCRIPTION
Bug fix for the recent PR.

Debbie Yuster reported a bug with cross book lookup of datafiles. I think the issue is datafiles that are in the DB without a filename in the source_code table. The migration from previous PR took care of old builds, but I think rebuilds were still missing filenames.

This has fixes at both ends:
*Makes sure the RST datafile build script adds filenames to the source_code table
*Modifies the crud.py `fetch_source_code` function to, when a datafile is requested by filename, match the filename against either the filename OR the acid.

Should not need a book rebuild for `fetch_source_code` to fix issue Debbie reported. But first fix will make sure everything is in DB correctly on build.