### PR TITLE
HParsons style cleanup - remove hardcoded max-widths

### DIFF
--- a/bases/rsptx/interactives/runestone/hparsons/css/hparsons.css
+++ b/bases/rsptx/interactives/runestone/hparsons/css/hparsons.css
@@ -1,18 +1,5 @@
 /* Todo, better integration with prism and Pretext dark mode*/
 
-.hparsons_section {
-    position: relative;
-    margin-right: auto;
-    margin-left: auto;
-    max-width: 800px;
-    clear: both;
-}
-
-.hparsons_section > *:not(.hparsons_section) {
-    max-width: 500pt;
-    margin-left: auto;
-    margin-right: auto;
-}
 
 .hp_question {
     padding-left: 10px;
@@ -26,11 +13,17 @@
 
 .hp_output {
     display: none;
-    max-width: 450px;
+    margin-left: 15px; /* align with micro-parsons */
+    margin-right: 15px;
     background-color: inherit;
 }
 .hp_output pre {
     background-color: var(--questionBgColor, lightgray);
+}
+
+.hp_feedback {
+    margin-left: 15px; /* align with micro-parsons */
+    margin-right: 15px;
 }
 
 .hp_sql_result {

--- a/bases/rsptx/interactives/runestone/hparsons/js/BlockFeedback.js
+++ b/bases/rsptx/interactives/runestone/hparsons/js/BlockFeedback.js
@@ -75,7 +75,7 @@ export default class BlockFeedback extends HParsonsFeedback {
         if (this.grade === "correct") {
             answerArea.addClass("correct");
             feedbackArea.fadeIn(100);
-            feedbackArea.attr("class", "alert alert-info");
+            feedbackArea.attr("class", "hp_feedback alert alert-info");
             if (this.checkCount > 1) {
                 feedbackArea.html(
                     $.i18n("msg_parson_correct", this.checkCount)
@@ -90,7 +90,7 @@ export default class BlockFeedback extends HParsonsFeedback {
             // too little code
             answerArea.addClass("incorrect");
             feedbackArea.fadeIn(500);
-            feedbackArea.attr("class", "alert alert-danger");
+            feedbackArea.attr("class", "hp_feedback alert alert-danger");
             feedbackArea.html($.i18n("msg_parson_too_short"));
         }
 


### PR DESCRIPTION
Found some style rules that were limiting the growth of hparsons.

Pulled them out so that "wide" themes.

Books using RST will not be affected. In PreTeXt books using deprecated style="wide", hparsons get a bit wider. In modern wide themes, hparsons will not be able grow to width controlled by theme.
