### PR TITLE
Activecode - set large memorylimit if code tries to use fsanitize

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -202,6 +202,10 @@ export default class LiveCode extends ActiveCode {
         if (this.language === "octave") {
             paramobj.memorylimit = 200000;
         }
+        if (this.compileargs.toString().indexOf("fsanitize") > -1) {
+            //fsanitize requires an allocation of a giant block of memory
+            paramobj.memorylimit = 2000000000;
+        }
         if (this.timelimit) {
             // convert to seconds to match JOBE - decimal is OK
             let timelimitSeconds = this.timelimit / 1000;


### PR DESCRIPTION
The -fsanitize compiler flag generates code that requires a large shadow block of memory which exceeds the Jobe  default limit. This detects attempts to use fsanitize and tells Jobe to set a very high memory limit.