### PR TITLE
Color/spacing fixes for fieldset/legend in exercises

### DIFF
--- a/bases/rsptx/interactives/ptxrs-bootstrap.less
+++ b/bases/rsptx/interactives/ptxrs-bootstrap.less
@@ -44,7 +44,7 @@
     --links: #7289da;
     --bodyFont: var(--body-text-color, #99aab5);
     --tooltip: #000000;
-    --grayToWhite: #ffffff;
+    --grayToWhite: #aaa;
     --navbar: #3d3d3d;
     --navbarFont: #ffffff;
     --navbarFontHover: #d6d6d6;

--- a/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -1210,3 +1210,10 @@ details.ptx-footnote {
     background-color: var(--content-background, #fff);
     color: var(--bodyFont, #000);
 }
+
+
+legend {
+    /* allow darkmode to override legend color */
+    color: var(--grayToWhite, #333);
+    border-bottom-color: var(--grayToWhite, #333);
+}

--- a/bases/rsptx/interactives/runestone/mchoice/css/mchoice.css
+++ b/bases/rsptx/interactives/runestone/mchoice/css/mchoice.css
@@ -13,4 +13,8 @@
 
 .multiplechoice_section label > .para {
     display: inline;
-} 
+}
+
+.multiplechoice_section .exercise-interactives {
+    margin-top: 1em;
+}


### PR DESCRIPTION
Legends (e.g. `Chose one` message for multiplechocie) currently always have dark text and are unreadable in dark mode. This makes them controlled by an existing CSS variable.

Also adds some margin to the top of a class that will appear in https://github.com/PreTeXtBook/pretext/pull/2506 to fix a lack of space above the legend that will otherwise appear with that PR.