### PR TITLE
Remove .exercises from video.css

### DIFF
--- a/bases/rsptx/interactives/runestone/video/css/video.css
+++ b/bases/rsptx/interactives/runestone/video/css/video.css
@@ -1,7 +1,3 @@
-.exercises {
-    background-color: #f0ffff;
-}
-
 figcaption {
     margin: 0.75em 0;
     text-align: center;


### PR DESCRIPTION
Sean reported a CSS bug in APEX. Turns out it is this rule from video.css:
```
.exercises {
    background-color: #f0ffff;
}
```
I can't see where it is used, so I removed it. If it is needed, we need to restrict its scope.