### PR TITLE
use database connection to reset database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,6 +312,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-WARN}
       - JWT_SECRET=${JWT_SECRET}
       - WEB2PY_PRIVATE_KEY=${WEB2PY_PRIVATE_KEY}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-runestone}
 
   author:
     profiles: [ "author" ]


### PR DESCRIPTION
instead of using the dropdb/createdb command line utils, use a database connection to drop/create the database. This mattters because the command line utils are not install in the rsmanage docker container environment.

One bit of weird is that we can't drop the database we're connected to, so we connect to "template1" (the default database created by postgres) to issue the commands.