### PR TITLE
use is not None test to prevent futurewarning

### DIFF
--- a/components/rsptx/build_tools/core.py
+++ b/components/rsptx/build_tools/core.py
@@ -689,7 +689,7 @@ def manifest_data_to_db(course_name, manifest_path):
                 practice = "F"
                 if qtype == "webwork":
                     practice = "T"
-                if el and "practice" in el.attrib:
+                if el is not None and "practice" in el.attrib:
                     practice = "T"
                 autograde = ""
                 if "====" in dbtext:


### PR DESCRIPTION
when building a pretext book, I see this warning:

```
/Users/jason/rs/components/rsptx/build_tools/core.py:692: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if el and "practice" in el.attrib:
```

The fix is easy enough, just use `is not None` test.