### PR TITLE
Bugfix for compileAlso getting list of files

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -384,13 +384,14 @@ export default class LiveCode extends ActiveCode {
             }
         }
         if (this.compileAlso) {
-            // a space separated list of files that also need to be compiled
+            // a comma separated list of files that also need to be compiled
             // they also all should be part of additional_files
             // we will stick them onto the end of the compilerargs
             // so that jobe builds them into the string sent to the compiler
             // e.g. g++ [other_compile_args] [compileAlso] sourcefile -o executable
             paramobj.compileargs = paramobj.compileargs || [];
-            paramobj.compileargs.push(this.compileAlso);
+            let compileList = this.compileAlso.split(",");
+            paramobj.compileargs = paramobj.compileargs.concat(compileList);
         }
         let runspec = {
             language_id: this.language,


### PR DESCRIPTION
If PTX puts a list of files into compile-also, RS is currently not breaking that list up into individual files. This fixes that.