### PR TITLE
Fix aria-live tags for activecode error/stdout

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -1003,6 +1003,7 @@ export class ActiveCode extends RunestoneBase {
 
         var coachDiv = document.createElement("div");
         coachDiv.classList.add("alert", "alert-warning", "codecoach");
+        coachDiv.setAttribute("aria-live", "polite");
         $(coachDiv).css("display", "none");
         let coachHead = coachDiv.appendChild(document.createElement("h3"));
         coachHead.textContent = $.i18n("msg_activecode_code_coach");

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -1004,6 +1004,8 @@ export class ActiveCode extends RunestoneBase {
         var coachDiv = document.createElement("div");
         coachDiv.classList.add("alert", "alert-warning", "codecoach");
         coachDiv.setAttribute("aria-live", "polite");
+        coachDiv.setAttribute("aria-atomic", "true");
+        coachDiv.setAttribute("role", "log");
         $(coachDiv).css("display", "none");
         let coachHead = coachDiv.appendChild(document.createElement("h3"));
         coachHead.textContent = $.i18n("msg_activecode_code_coach");
@@ -1648,8 +1650,11 @@ Yet another is that there is an internal error.  The internal error message is: 
                         document.createElement("pre")
                     );
                     checkPre.textContent = p.value;
-                    this.codecoach.append(checkDiv);
                     $(this.codecoach).css("display", "block");
+                    // screenreaders seem to miss error message without the delay
+                    setTimeout(() => {
+                        this.codecoach.append(checkDiv);
+                    }, 10);
                 }
             }
         });

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode_js.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode_js.js
@@ -58,6 +58,9 @@ export default class JSActiveCode extends ActiveCode {
         this.eContainer = this.outerDiv.appendChild(
             document.createElement("div")
         );
+        this.eContainer.setAttribute("aria-live", "polite");
+        this.eContainer.setAttribute("aria-atomic", "true");
+        this.eContainer.setAttribute("role", "log");
         this.eContainer.className = "error alert alert-danger";
         this.eContainer.id = this.divid + "_errinfo";
         this.eContainer.appendChild(errHead[0]);

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode_js.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode_js.js
@@ -68,7 +68,10 @@ export default class JSActiveCode extends ActiveCode {
             document.createElement("pre")
         );
         var errString = err.toString();
-        errText.innerHTML = errString;
+        // screenreaders seem to miss error message without the delay
+        setTimeout(() => {
+            errText.innerHTML = errString;
+        }, 10);
         console.log("Runtime Error: " + err.toString());
     }
 }

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
@@ -237,8 +237,11 @@ export default class SQLActiveCode extends ActiveCode {
             } else {
                 let messageBox = document.createElement("pre");
                 messageBox.textContent = r.message;
-                section.appendChild(messageBox);
                 section.classList.add("ac_sql_result_failure");
+                // screenreaders seem to miss error message without the delay
+                setTimeout(() => {
+                    section.appendChild(messageBox);
+                }, 10);
             }
         }
 

--- a/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode_sql.js
@@ -199,6 +199,9 @@ export default class SQLActiveCode extends ActiveCode {
         for (let r of resultArray) {
             let section = document.createElement("div");
             section.setAttribute("class", "ac_sql_result");
+            section.setAttribute("aria-live", "polite");
+            section.setAttribute("aria-atomic", "true");
+            section.setAttribute("role", "log");
             respDiv.appendChild(section);
             if (r.status === "success") {
                 if (r.columns) {

--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -675,7 +675,10 @@ export default class LiveCode extends ActiveCode {
         eContainer.id = this.divid + "_errinfo";
         eContainer.appendChild(errHead[0]);
         var errText = eContainer.appendChild(document.createElement("pre"));
-        errText.innerHTML = escapeHtml(err);
+        // screenreaders seem to miss error message without the delay
+        setTimeout(() => {
+            errText.innerHTML = escapeHtml(err);
+        }, 10);
     }
     /**
      * Checks to see if file is on server

--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -668,6 +668,9 @@ export default class LiveCode extends ActiveCode {
             document.createElement("div")
         );
         this.errDiv = eContainer;
+        eContainer.setAttribute("aria-live", "polite");
+        eContainer.setAttribute("aria-atomic", "true");
+        eContainer.setAttribute("role", "log");
         eContainer.className = "error alert alert-danger";
         eContainer.id = this.divid + "_errinfo";
         eContainer.appendChild(errHead[0]);


### PR DESCRIPTION
This PR fixes some cases where `aria-live` tags were missing for activecode results. Notably:

- Codecoach outputs now have proper tags (bb3d3924f0144085ffcf743efcf6d82473f935b2)
- Javascript errors are properly tagged (5503d7ae5e26bc3f7359553eac883713a374d4fa)
- Languages that use JOBE have their errors properly tagged (a5b1ca96e11165e7786ad85cea5e2b25b093556d)
- SQL results are properly tagged (7e2db26b770cd74cf71d9414783e883299dacc27)

These issues were caused by the fact that originally the tags were only added in `activecode.js`, and not the other files that can generate their own error/output divs (see diff for details on where this happens).

This PR resolves RunestoneInteractive/rs#635.
