### PR TITLE
Back to top keyboard focus fix

### DIFF
--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -107,6 +107,9 @@ window.MathJax = {
 {# Sidebar: Rework into our Boostrap nav section. #}
 {% macro navBar() %}
 
+<!-- Dummy div that is focused by js when user uses "back to top"-->
+<div id="top" tabindex="-1"></div>
+
 <!-- Begin navbar -->
 <div id="navbar" class="navbar navbar-default navbar-fixed-top" role="navigation">
 
@@ -411,7 +414,7 @@ window.MathJax = {
       <span id='numuserspan'></span><span class='loggedinuser'></span>
       {% endif %}
       {% endif %}
-      | <a href="#">Back to top</a>
+      | <a href="#" onclick="document.getElementById('top').focus()">Back to top</a>
       {% if theme_source_link_position == "footer" %}
         <br />
         {% include "sourcelink.html" %}

--- a/bases/rsptx/web2py_server/applications/runestone/views/layout.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/layout.html
@@ -36,7 +36,7 @@
 
     </head>
     <body class="sphinxrs">
-        <a class="assistive" href="#rst-content">Skip to main content</a>
+        <a id="skip-to-content" class="assistive" href="#rst-content">Skip to main content</a>
         {{ block navbar }}
         <!-- Begin navbar -->
         <div id="navbar" class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -218,9 +218,9 @@
                         &emsp; ● <a href="/{{=request.application}}/default/privacy">Privacy Policy</a> &emsp; ●  <a href="/{{=request.application}}/default/terms">Terms of Service</a>
                     {{ pass }}
                     {{ if auth.user: }}
-                        <span class='loggedinuser'>{{=auth.user.email}}</span> | <a href="#">Back to top</a>
+                        <span class='loggedinuser'>{{=auth.user.email}}</span> | <a href="#" onclick="document.getElementById('skip-to-content').focus()">Back to top</a>
                     {{ else: }}
-                        <span class='loggedinuser'>Not logged in</span> | <a href="#">Back to top</a>
+                        <span class='loggedinuser'>Not logged in</span> | <a href="#" onclick="document.getElementById('skip-to-content').focus()">Back to top</a>
                     {{ pass }}
                 </p>
             </div>


### PR DESCRIPTION
This PR addresses the issue that the "back to top" links in the application only scroll to the top of the page, and don't reset keyboard focus. This means if a user were to hit tab after clicking "back to top", they'd be sent back to the bottom of the page instead of the first focusable element as intended.

Changes:
- For RST-based books, we include a "dummy" div at the top of the page that the javascript can set focus to. An alternative would be to just have it focus the runestone logo (which felt slightly less portable to me), but I can have it work that way if you'd prefer.
- For the instructor page (and other pages served by that layout), we return focus to the existing "skip to content" element (which is first in the focus order)