### PR TITLE
Book Index Focus Fix

### DIFF
--- a/components/rsptx/templates/book/index.html
+++ b/components/rsptx/templates/book/index.html
@@ -48,9 +48,10 @@
             <div class="library_entry">
                 <div class="book_title">
                     <a
+                        class="link1"
                         href="{{canonical_host}}/ns/books/published/{{book['basecourse']}}/{{ book['main_page']}}?mode=browsing"
                     >
-                        <span class="link1">{{ book['title'] }}</span>
+                        {{ book['title'] }}
                     </a>
                 </div>
                 <div class="book_descript">

--- a/components/rsptx/templates/staticAssets/index.css
+++ b/components/rsptx/templates/staticAssets/index.css
@@ -17,7 +17,7 @@
     position: relative;
 }
 
-.book_title:hover {
+.book_title:hover, .book_title:focus-within {
     background-color: #c94d23;
 }
 

--- a/components/rsptx/templates/staticAssets/index.css
+++ b/components/rsptx/templates/staticAssets/index.css
@@ -54,7 +54,12 @@
     left: 0;
     z-index: 1;
     color: white;
-    margin-left: 1%;
+    padding-left: 1%;
+}
+
+.link1:hover {
+    color: white;
+    text-decoration: none;
 }
 
 .searchbar {


### PR DESCRIPTION
Currently, the focus indicators on the book titles in the library are broken:
![image](https://github.com/user-attachments/assets/a1f9d3c1-e2a2-4cac-90f9-5aa1a4493a1e)
Instead of a proper focus indicator surrounding the title link, there is (on firefox) a small dot in the corner. On some other browsers, there was no focus indicator at all.

This PR fixes the focus indicator (so that it surrounds the whole link), and also causes the color change triggered by a mouse hover to also be triggered by keyboard focus (similar to how buttons behave):
![image](https://github.com/user-attachments/assets/70fac315-557a-48c5-b69f-285986ca30ef)
