### PR TITLE
Fix activity label contrast

### DIFF
--- a/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/interactives/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -1080,7 +1080,7 @@ textarea.lp-result {
 }
 
 .runestone_caption_divid {
-    opacity: 50%;
+    font-style: italic;
 }
 
 #questions .runestone_caption:before {


### PR DESCRIPTION
When logged in as an instructor, currently portions of the activity labels currently have insufficient contrast per WCAG guidelines:
![image](https://github.com/user-attachments/assets/39a8efcd-fdc6-4f52-a9a5-6f5e4f0258c3)

This PR fixes this by using italics instead of reduced opacity to indicate the activity identifier:
![image](https://github.com/user-attachments/assets/3a002613-aac6-473a-bf8b-1df12b137741)

Let me know if you'd prefer a different method (other than italics) of indicating the assignment identifier. One alternative is just to use the parenthesis without any additional styling, which would look like:
![image](https://github.com/user-attachments/assets/a31bddc1-490e-4b42-87c3-6efc2d355d64)
or bolding the rest of the caption:
![image](https://github.com/user-attachments/assets/0a79aaa6-a355-42cf-b811-5c188521c7d0)
 