### PR TITLE
Fix focus on activecode modal close

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -183,7 +183,7 @@ export default class ACFactory {
         closeBtn.addEventListener("click", function () {
             let popUp = document.getElementById("ac_modal_" + divid);
             popUp.style.display = "none";
-            document.querySelector("a.activecode-toggle").focus();
+            document.querySelector(".activecode-toggle").focus();
         });
     }
 

--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -183,7 +183,7 @@ export default class ACFactory {
         closeBtn.addEventListener("click", function () {
             let popUp = document.getElementById("ac_modal_" + divid);
             popUp.style.display = "none";
-            document.querySelector("button.activecode-toggle").focus();
+            document.querySelector("a.activecode-toggle").focus();
         });
     }
 

--- a/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/acfactory.js
@@ -224,7 +224,7 @@ export default class ACFactory {
             } else {
                 if (event.key === "Escape") {
                     realDiv.style.display = "none";
-                    document.querySelector("button.activecode-toggle").focus();
+                    document.querySelector(".activecode-toggle").focus();
                 }
             }
         });

--- a/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/bases/rsptx/interactives/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -226,7 +226,7 @@ window.MathJax = {
         <!-- <li id="scratch_ac_link"><a href="javascript:ACFactory.toggleScratchActivecode()">Scratch ActiveCode</a></li> -->
 
         <!-- <li class="dropdown">             -->
-          <li id="scratch_ac_link" class="dropdown"><a href="javascript:runestoneComponents.popupScratchAC()">
+          <li id="scratch_ac_link" class="dropdown"><a class="activecode-toggle" href="javascript:runestoneComponents.popupScratchAC()">
               <i class="glyphicon glyphicon-pencil" style="opacity:0.9;"><span class="visuallyhidden" aria-label="Scratch Activecode" >Scratch Activecode</span></i></a></li>
         <!-- </li> -->
 

--- a/bases/rsptx/web2py_server/applications/runestone/views/layout.html
+++ b/bases/rsptx/web2py_server/applications/runestone/views/layout.html
@@ -155,7 +155,7 @@
                         {{ if settings.academy_mode: }}
                             <!-- Omit the scratch activecode icon if ``no_scratch_activecode`` is True. Otherwise, include it. -->
                             {{ if "no_scratch_activecode" not in globals() or not no_scratch_activecode: }}
-                                <li id="scratch_ac_link" class="dropdown"><a href="javascript:runestoneComponents.popupScratchAC()">
+                                <li id="scratch_ac_link" class="dropdown"><a class="activecode-toggle" href="javascript:runestoneComponents.popupScratchAC()">
                                     <i class="glyphicon glyphicon-pencil" style="opacity:0.9;"><span aria-label="Scratch Activecode" class="visuallyhidden">Scratch Activecode</span></i></a></li>
                             {{pass}}
                             <!-- help menu dropdown -->


### PR DESCRIPTION
When the activecode modal is closed, focus is intended to return to the pencil icon (that was used to open the modal originally). There is currently code for this:
```js
let closeBtn = document.querySelector(".ac-modal-header button.close");
closeBtn.addEventListener("click", function () {
    let popUp = document.getElementById("ac_modal_" + divid);
    popUp.style.display = "none";
    document.querySelector("button.activecode-toggle").focus();
});
```
However, it errors since `document.querySelector("button.activecode-toggle")` fails to find any elements:
![image](https://github.com/user-attachments/assets/cc6b6835-42ff-4572-9525-7709a79ec2eb)
I'm guessing this is some sort of regression where the HTML was changed after this feature was implemented.

This PR fixes the selector/html so that the functionality works properly again.
