### PR TITLE
Check that the basecourse/book has been built before creating a course from it

### DIFF
--- a/bases/rsptx/rsmanage/core.py
+++ b/bases/rsptx/rsmanage/core.py
@@ -304,6 +304,10 @@ async def addcourse(
 ):
     """Create a course in the database"""
 
+    bookrec = await fetch_library_book(basecourse)
+    if bookrec.build_system is None:
+        click.echo(f"Failed: Build the corresponding base course first!")
+        exit(1)
     done = False
     regex = r"^([\x30-\x39]|[\x41-\x5A]|[\x61-\x7A]|[_-])*$"
     if course_name:


### PR DESCRIPTION
If a course is created via `rsmanage --addcourse` from a basecourse/book before that book has been built, then the needed attributes don't exist yet and are not copied over. This PR adds a check to prevent a user from accidentally creating a course too soon.