### PR TITLE
Activecode - reduce editor min-width

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.css
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.css
@@ -141,7 +141,7 @@
     border: solid 2px;
     margin-bottom: 10px;
     max-width: 100%;
-    min-width: 30em;
+    min-width: 5em;
     min-height: 100px;
     /* best way to control height is let CodeMirror-scroll do it */
     height: auto;

--- a/bases/rsptx/web2py_server/applications/runestone/static/runestone-custom-sphinx-bootstrap.css
+++ b/bases/rsptx/web2py_server/applications/runestone/static/runestone-custom-sphinx-bootstrap.css
@@ -158,7 +158,7 @@ div.section {
      * the CM editors to no more than the size needed
      * unless resized) */
     max-height: 30em;
-    min-width: 30em;
+    min-width: 5em;
 }
 
 .ac_section .CodeMirror pre {

--- a/components/rsptx/templates/staticAssets/css/runestone-custom-sphinx-bootstrap.css
+++ b/components/rsptx/templates/staticAssets/css/runestone-custom-sphinx-bootstrap.css
@@ -158,7 +158,7 @@ div.section {
      * the CM editors to no more than the size needed
      * unless resized) */
     max-height: 30em;
-    min-width: 30em;
+    min-width: 5em;
 }
 
 .ac_section .CodeMirror pre {


### PR DESCRIPTION
I put in a CodeMirror editor min-width to avoid user resizing via handle making it so small you couldn't grab the handle again.
The value 30em is too large. Reducing it to 5em still prevents the issue, but makes sure even on a tiny phone screen we don't get the editor sticking off the screen like this:
<img width="641" height="307" alt="image" src="https://github.com/user-attachments/assets/812221b0-955e-4705-b6ee-ba3ebeeea1b8" />
