### PR TITLE
Enable changing CodeMirror indentation unit.

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -57,6 +57,8 @@ CodeMirror.commands.autocomplete = function (cm) {
     cm.showHint({ hint: CodeMirror.hint.anyword });
 };
 
+const codeIndent = () => Number(window.getComputedStyle(document.body).getPropertyValue('--code-editor-indentation') || 4);
+
 // separate into constructor and init
 export class ActiveCode extends RunestoneBase {
     constructor(opts) {
@@ -265,7 +267,7 @@ export class ActiveCode extends RunestoneBase {
             value: this.code,
             lineNumbers: true,
             mode: edmode,
-            indentUnit: 4,
+            indentUnit: codeIndent(),
             matchBrackets: true,
             autoMatchParens: true,
             gutters: gutterList,


### PR DESCRIPTION
Just a small tweak to activecode.js to allow a book to change the indentation unit in CodeMirror using a CSS variable, e.g.

```css
:root {
    --code-editor-indentation: 2;
}
```

Defaults to the old value of 4 if the variable is not set.

Tested it in my local docker cluster with and without that variable defined in the CSS.