### PR TITLE
Fix issue 897 - New Assignment Builder: too many scrollbars

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/ExerciseSuccessDialog.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/ExerciseSuccessDialog.tsx
@@ -23,6 +23,7 @@ export const ExerciseSuccessDialog = ({
     </div>
   );
 
+  if (!showSuccessDialog) return null;
   return (
     <Dialog
       visible={showSuccessDialog}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ExercisePreview/ExercisePreview.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ExercisePreview/ExercisePreview.tsx
@@ -6,8 +6,7 @@ import { renderRunestoneComponent } from "@/componentFuncs";
 import { Exercise } from "@/types/exercises";
 
 export const ExercisePreview = ({
-  htmlsrc,
-  maxHeight = "600px"
+  htmlsrc
 }: Pick<Exercise, "htmlsrc"> & { maxHeight?: string }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
@@ -23,11 +22,18 @@ export const ExercisePreview = ({
   return (
     <MathJaxWrapper>
       <MathJax>
+        <style>
+          {`
+            .ptx-runestone-container .CodeMirror-scroll {
+              max-height: none !important;
+            }
+            .ptx-runestone-container .CodeMirror {
+              height: auto !important;
+            }
+          `}
+        </style>
         <div className="ptx-runestone-container relative flex justify-content-center w-full">
-          <div
-            className="overflow-y-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100 flex justify-content-center"
-            style={{ maxHeight }}
-          >
+          <div className="flex justify-content-center">
             <div ref={ref} className="text-left mx-auto"></div>
           </div>
         </div>

--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.css
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.css
@@ -124,7 +124,7 @@
 .ac-feedback {
     border: 1px solid var(--componentBorderColor);
     padding: 3px;
-    background-color: var(--content-background,#fff);
+    background-color: var(--content-background, #fff);
 }
 
 .ac-feedback-pass {
@@ -157,7 +157,7 @@
 
 /* decorate locked lines that do not have lock marker */
 .CodeMirror__locked-line .CodeMirror-gutter-wrapper:not(:has(.CodeMirror__gutter-locked-marker)):before {
-    content:" ";
+    content: " ";
     display: block;
     width: 2px;
     height: 1lh;
@@ -166,6 +166,7 @@
     background-color: #888;
     float: left;
 }
+
 .CodeMirror__gutter-locked-marker {
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 -960 960 960' width='16px' fill='%23currentColor'%3E%3Cpath d='M263.72-96Q234-96 213-117.15T192-168v-384q0-29.7 21.15-50.85Q234.3-624 264-624h24v-96q0-79.68 56.23-135.84 56.22-56.16 136-56.16Q560-912 616-855.84q56 56.16 56 135.84v96h24q29.7 0 50.85 21.15Q768-581.7 768-552v384q0 29.7-21.16 50.85Q725.68-96 695.96-96H263.72Zm.28-72h432v-384H264v384Zm216.21-120Q510-288 531-309.21t21-51Q552-390 530.79-411t-51-21Q450-432 429-410.79t-21 51Q408-330 429.21-309t51 21ZM360-624h240v-96q0-50-35-85t-85-35q-50 0-85 35t-35 85v96Zm-96 456v-384 384Z'/%3E%3C/svg%3E");
     mask-repeat: no-repeat;
@@ -175,6 +176,7 @@
     width: 20px;
     background-color: #000;
 }
+
 .CodeMirror__locked-line {
     background-color: var(--ac-locked-line-bg);
 }


### PR DESCRIPTION
Fix #897. In exercise preview, remove unnecessary scrolls, leave only one. Fix non-clickable page bug after creating an exercise