### PR TITLE
LTI1p3: sync RS date to LMS on assignment initial linking

### DIFF
--- a/bases/rsptx/admin_server_api/routers/lti1p3.py
+++ b/bases/rsptx/admin_server_api/routers/lti1p3.py
@@ -996,7 +996,7 @@ async def assign_select(launch_id: str, request: Request, course=None):
                 dlr.set_target("window")
 
                 line_item = LineItem()
-                update_line_item_from_assignment(line_item, assign, course, use_pts)
+                update_line_item_from_assignment(line_item, assign, course, use_pts, push_duedate=True)
                 dlr.set_lineitem(line_item)
 
                 # add to list of things for LMS to create

--- a/components/rsptx/lti1p3/pylti1p3/deep_link_resource.py
+++ b/components/rsptx/lti1p3/pylti1p3/deep_link_resource.py
@@ -95,6 +95,13 @@ class DeepLinkResource:
             if submission_review:
                 line_item["submissionReview"] = submission_review
 
+            # if line item has a end date, include it in the resource
+            # as both availability and submission end dates
+            end_date_time = self._lineitem.get_end_date_time()
+            if end_date_time:
+                res["available"] = {"endDateTime": end_date_time}
+                res["submission"] = {"endDateTime": end_date_time}
+
             res["lineItem"] = line_item
 
         if self._icon_url:


### PR DESCRIPTION
This sends RS assignment duedate to LMS when you use LTI to create LMS assignments from RS ones.

After that point LMS is ground truth on duedates - they are only synced from LMS --> RS.