### PR TITLE
Add two more indentation levels to Parsons puzzles

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/css/parsons.css
+++ b/bases/rsptx/interactives/runestone/parsons/css/parsons.css
@@ -164,6 +164,73 @@
     background-color: var(--parsonsCorrectBgColor);
     border-color: var(--parsonsCorrectBorderColor);
 }
+ /* The following styles are for the 5th and 6th indentation levels, if applicable */
+.parsons .answer5 {
+    background: linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box;
+    background-size: 1px 100%, 1px 100%, 1px 100%, 1px 100%;
+    background-position: 30px 0, 60px 0, 90px 0, 120px 0, 150px 0;
+    background-origin: padding-box, padding-box, padding-box, padding-box;
+    background-color: var(--parsonsBgColor);
+    border-color: var(--parsonsBorderColor);
+}
+.parsons .answer5.incorrect {
+    background: linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box;
+    background-size: 1px 100%, 1px 100%, 1px 100%, 1px 100%;
+    background-position: 30px 0, 60px 0, 90px 0, 120px 0, 150px 0;
+    background-origin: padding-box, padding-box, padding-box, padding-box;
+    background-color: var(--parsonsIncorrectBgColor);
+    border-color: var(--parsonsIncorrectBorderColor);
+}
+.parsons .answer5.correct {
+    background: linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box;
+    background-size: 1px 100%, 1px 100%, 1px 100%, 1px 100%;
+    background-position: 30px 0, 60px 0, 90px 0, 120px 0, 150px 0;
+    background-origin: padding-box, padding-box, padding-box, padding-box;
+    background-color: var(--parsonsCorrectBgColor);
+    border-color: var(--parsonsCorrectBorderColor);
+}
+.parsons .answer6 {
+    background: linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsBorderColor), var(--parsonsBorderColor)) no-repeat border-box;
+    background-size: 1px 100%, 1px 100%, 1px 100%, 1px 100%;
+    background-position: 30px 0, 60px 0, 90px 0, 120px 0, 150px 0, 180px 0;
+    background-origin: padding-box, padding-box, padding-box, padding-box;
+    background-color: var(--parsonsBgColor);
+    border-color: var(--parsonsBorderColor);
+}
+.parsons .answer6.incorrect {
+    background: linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsIncorrectBorderColor), var(--parsonsIncorrectBorderColor)) no-repeat border-box;
+    background-size: 1px 100%, 1px 100%, 1px 100%, 1px 100%;
+    background-position: 30px 0, 60px 0, 90px 0, 120px 0, 150px 0, 180px 0;
+    background-origin: padding-box, padding-box, padding-box, padding-box;
+    background-color: var(--parsonsIncorrectBgColor);
+    border-color: var(--parsonsIncorrectBorderColor);
+}
+.parsons .answer6.correct {
+    background: linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box,
+        linear-gradient(var(--parsonsCorrectBorderColor), var(--parsonsCorrectBorderColor)) no-repeat border-box;
+    background-size: 1px 100%, 1px 100%, 1px 100%, 1px 100%;
+    background-position: 30px 0, 60px 0, 90px 0, 120px 0, 150px 0, 180px 0;
+    background-origin: padding-box, padding-box, padding-box, padding-box;
+    background-color: var(--parsonsCorrectBgColor);
+    border-color: var(--parsonsCorrectBorderColor);
+}
 .parsons .block {
     position: absolute;
     -moz-border-radius: 10px;
@@ -228,6 +295,18 @@
 }
 .parsons .indent4 {
     margin-left: 120px;
+}
+.parsons .indent5 {
+    margin-left: 150px;
+}
+.parsons .indent6 {
+    margin-left: 180px;
+}
+.parsons .indent7 {
+    margin-left: 210px;
+}
+.parsons .indent8 {
+    margin-left: 240px;
 }
 .parsons .correct {
     border: 1px solid #d6e9c6;

--- a/bases/rsptx/interactives/runestone/parsons/js/parsonsBlock.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsonsBlock.js
@@ -39,7 +39,7 @@ export default class ParsonsBlock {
             } else {
                 lineIndent = line.indent - sharedIndent;
             }
-            $(line.view).removeClass("indent1 indent2 indent3 indent4");
+            $(line.view).removeClass("indent1 indent2 indent3 indent4 indent5 indent6");
             if (
                 this.problem.options.language != "natural" &&
                 this.problem.options.language != "math"
@@ -72,7 +72,7 @@ export default class ParsonsBlock {
     }
     // Add a line (from another block) to this block
     addLine(line) {
-        $(line.view).removeClass("indent1 indent2 indent3 indent4");
+        $(line.view).removeClass("indent1 indent2 indent3 indent4 indent5 indent6");
         if (this.problem.noindent) {
             if (line.indent > 0) {
                 $(line.view).addClass("indent" + line.indent);
@@ -88,7 +88,7 @@ export default class ParsonsBlock {
             } else if (sharedIndent > line.indent) {
                 for (let i = 0; i < lines.length; i++) {
                     $(lines[i].view).removeClass(
-                        "indent1 indent2 indent3 indent4"
+                        "indent1 indent2 indent3 indent4 indent5 indent6"
                     );
                     // todo: if language is natural or math then don't do this
                     if (
@@ -136,7 +136,7 @@ export default class ParsonsBlock {
         for (let i = 0; i < this.lines.length; i++) {
             var line = this.lines[i];
             if (line.indent > 0) {
-                $(line.view).removeClass("indent1 indent2 indent3 indent4");
+                $(line.view).removeClass("indent1 indent2 indent3 indent4 indent5 indent6");
                 $(line.view).addClass("indent" + line.indent);
             }
         }


### PR DESCRIPTION
One of the Python Parsons problems used in our study requires up to 5 levels of indentation (counting from level 0). But the current Parsons problem only supported a maximum of 4 levels. 
This PR increases the supported indentation depth by adding two more levels to accommodate more complex nested structures.