### PR TITLE
Update instructor links on course home page

### DIFF
--- a/components/rsptx/templates/book/course/current_course.html
+++ b/components/rsptx/templates/book/course/current_course.html
@@ -72,20 +72,20 @@ textbook
 <div class="instructor_menu">
 <h2>Instructor Links</h2>
 <div class="nav flex-column" id="v-pills-tab"  aria-orientation="vertical">
-  <a class="nav-link" id="v-pills-home-tab"  href="/runestone/dashboard"  aria-controls="v-pills-home" aria-selected="true">Student Progress</a>
-  <a class="nav-link" id="v-pills-gradebook-tab"  href="/runestone/dashboard/grades"  aria-controls="v-pills-home" aria-selected="true">Gradebook</a>
-  <a class="nav-link" id="v-pills-profile-tab"  href="/runestone/admin/admin"  aria-controls="v-pills-profile" aria-selected="false">Class Administration</a>
-  <a class="nav-link" id="v-pills-grading-tab" href="/runestone/admin/grading"  aria-controls="v-pills-profile" aria-selected="false">Grading</a>
-  <a class="nav-link" id="v-pills-messages-tab"  href="/runestone/admin/assignments"  aria-controls="v-pills-messages" aria-selected="false">Manage Assignments</a>
-  <a class="nav-link" id="v-pills-messages-tab"  href="/assignment/instructor/except"  aria-controls="v-pills-messages" aria-selected="false">Manage Accommodations</a>
-  <a class="nav-link" id="v-pills-settings-tab" href="/runestone/admin/practice" aria-controls="v-pills-settings" aria-selected="false">Manage Practice</a>
+  <a class="nav-link" id="v-pills-instructor-dashboard" href="admin/instructor/menu">Instructor Dashboard</a>
+  <a class="nav-link" id="v-pills-home-tab" href="/runestone/dashboard">Student Progress</a>
+  <a class="nav-link" id="v-pills-gradebook-tab" href="/runestone/dashboard/grades">Gradebook</a>
+  <a class="nav-link" id="v-pills-grading-tab" href="/assignment/instructor/gradebook">Grading</a>
+  <a class="nav-link" id="v-pills-messages-tab" href="/assignment/instructor/builder">Manage Assignments</a>
+  <a class="nav-link" id="v-pills-messages-tab" href="/assignment/instructor/except">Manage Accommodations</a>
+  <a class="nav-link" id="v-pills-settings-tab" href="/runestone/admin/practice">Manage Practice</a>
   {% if has_discussion_group: %}
   <h3>Get help, learn about updates, share resources!</h3>
   <ul>
   {% for book in book_list: %}
   {% if book.social_url: %}
   <li>
-  <a class="nav-link" href="{{book.social_url}}" aria-controls="v-pills-settings" aria-selected="false">Instructors Group for {{book.title}}</a>
+  <a class="nav-link" href="{{book.social_url}}">Instructors Group for {{book.title}}</a>
   </li>
   {% endif %}
   {% endfor %}


### PR DESCRIPTION
The "Instructor Links" section of the course homepage had links to the deprecated assignment builder.  This update

- Adds a link to the Instructor Dashboard, and removes the link to the "Class Administration" page (since those features moved to the Instructor Dashboard).
- Update links for assignment builder and gradebook to the new locations.
- Removes the `aria-component` and `aria-status` attributes; I believe these are unnecessary and likely a remnant from where these links were originally copied from (the tabs on the old instructor pages).

I tried to set up a dev environment to test this, but got stuck.  So currently untested, but it should just work.