### PR TITLE
LTI1p3 cookie improvements

### DIFF
--- a/bases/rsptx/admin_server_api/routers/lti1p3.py
+++ b/bases/rsptx/admin_server_api/routers/lti1p3.py
@@ -255,7 +255,7 @@ def add_w2py_session_cookie(response: Response, cookie: str):
     Add the w2p session cookie to the response.
     """
     cookie_parts = cookie.split("=")
-    response.set_cookie(cookie_parts[0], cookie_parts[1], httponly=True, samesite="lax")
+    response.set_cookie(cookie_parts[0], cookie_parts[1], httponly=True, samesite="None", secure=True)
 
 def check_launch_data(
     launch: FastAPIMessageLaunch, key: str, default_value: str = None

--- a/components/rsptx/lti1p3/pylti1p3/cookies_allowed_check.py
+++ b/components/rsptx/lti1p3/pylti1p3/cookies_allowed_check.py
@@ -31,6 +31,7 @@ class CookiesAllowedCheckPage:
         css_block = """\
         body {
         font-family: Geneva, Arial, Helvetica, sans-serif;
+        padding: 20px;
         }
         """
         return css_block
@@ -121,6 +122,7 @@ class CookiesAllowedCheckPage:
         <html lang="en">
         <head>
         <title></title>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css"/>
         <meta charset="UTF-8">
         <style type="text/css">
         {css_block}
@@ -135,7 +137,22 @@ class CookiesAllowedCheckPage:
         </div>
         <div id="lti1p3-warning-msg" style="display: none;">
         {header_block}
-        <p><strong>{main_text}</strong> <a href="javascript: void(0);" id="lti1p3-new-tab-link">{click_text}</a></p>
+        <p><strong>{main_text}</strong></p>
+        <p>You can either try to:</p>
+        <ul>
+            <li>Enable third-party cookies in your browser settings and reload this page. (Look for a setting for "third-party cookies" (Chrome) or "enable cross site tracking" (Safari) or "enhanced tracking protection" (Firefox).)</li>
+            <li>Open the content in a new tab: <a href="javascript: void(0);" id="lti1p3-new-tab-link">{click_text}</a></li>
+            </ul>
+            <div class="alert alert-info" role="alert">
+            <p>
+                <strong>Students:</strong> Most Runestone Academy content works best in its own window (and not embedded within another site). It is recommended you open the content in a new tab.
+            </p>
+            </div>
+            <div class="alert alert-warning" role="alert">
+            <p>
+                <strong>Instructors:</strong> If you are an instructor trying to link content, you should first try to enable third party cookies. Opening the "Select Content" page in a new tab may not work correctly.
+            </p>
+            </div>
         </div>
         </body>
         </html>

--- a/components/rsptx/lti1p3/pylti1p3/message_launch.py
+++ b/components/rsptx/lti1p3/pylti1p3/message_launch.py
@@ -715,7 +715,7 @@ class MessageLaunch(t.Generic[REQ, TCONF, SES, COOK]):
             state_from_request, id_token_hash
         ):
             state_from_cookie = self._cookie_service.get_cookie(state_from_request)
-            if state_from_request != state_from_cookie:
+            if state_from_cookie and state_from_request != state_from_cookie:
                 # Error if state doesn't match.
                 raise LtiException("State not found")
 

--- a/components/rsptx/lti1p3/pylti1p3/oidc_login.py
+++ b/components/rsptx/lti1p3/pylti1p3/oidc_login.py
@@ -34,7 +34,7 @@ class OIDCLogin(t.Generic[REQ, TCONF, SES, COOK, RED]):
     _cookies_check: bool = False
     _cookies_check_loading_text: str = "Loading..."
     _cookies_unavailable_msg_main_text: str = (
-        "Your browser prohibits saving cookies in the iframes."
+        "Your browser blocked cookies in this iframe."
     )
     _cookies_unavailable_msg_click_text: str = (
         "Click here to open content in the new tab."


### PR DESCRIPTION
Three things to help re: 3rd party cookie issues:
* When LTI1p3 sets w2py session cookie make it always secure/samesite none. LTI1p3 won't function without https anyway.
* If an LTI redirect attempt is missing the session cookie, but has a valid state token in request, don't treat as error
* Improve messaging re: blocked cookies