### PR TITLE
Improve identification of autogradable activecodes in runestone-manifest

### DIFF
--- a/components/rsptx/build_tools/core.py
+++ b/components/rsptx/build_tools/core.py
@@ -1051,11 +1051,19 @@ def _determine_practice_flag(qtype, el):
 
 def _determine_autograde(dbtext):
     """Determine autograde setting based on content."""
+    extraCode = ""
     if "====" in dbtext:
         extraCode = dbtext.partition("====")[2]
+    elif "===!" in dbtext:
+        extraCode = dbtext.partition("===!")[2]
+    if extraCode:
         for utKeyword in ["assert", "unittest", "TEST_CASE", "junit"]:
             if utKeyword in extraCode:
                 return "unittest"
+
+    if "===iotests===" in dbtext:
+        return "unittest"
+
     return ""
 
 


### PR DESCRIPTION
Activecodes with visible test blocks and iotests were not being identified as autogradeable during processing of runestone-manifest from PTX build.