### PR TITLE
issue-946 Fix issue with optionList IDs

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/MultiChoiceExercise/MultiChoiceExercise.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/MultiChoiceExercise/MultiChoiceExercise.tsx
@@ -38,8 +38,18 @@ const getDefaultFormData = (): Partial<CreateExerciseFormType> => ({
   statement: "",
   forceCheckboxes: false,
   optionList: [
-    { id: `option-${Date.now()}`, choice: "", feedback: "", correct: false } as OptionWithId,
-    { id: `option-${Date.now() + 1}`, choice: "", feedback: "", correct: false } as OptionWithId
+    {
+      id: `option-${crypto.randomUUID()}`,
+      choice: "",
+      feedback: "",
+      correct: false
+    } as OptionWithId,
+    {
+      id: `option-${crypto.randomUUID()}`,
+      choice: "",
+      feedback: "",
+      correct: false
+    } as OptionWithId
   ]
 });
 

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/MultiChoiceExercise/MultiChoiceOptions.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/MultiChoiceExercise/MultiChoiceOptions.tsx
@@ -142,7 +142,7 @@ export const MultiChoiceOptions = ({ options, onChange }: MultiChoiceOptionsProp
     onChange([
       ...options,
       {
-        id: `option-${Date.now()}`,
+        id: `option-${crypto.randomUUID()}`,
         choice: "",
         feedback: "",
         correct: false

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/PollExercise/PollExercise.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/PollExercise/PollExercise.tsx
@@ -50,8 +50,8 @@ const getDefaultFormData = (): Partial<CreateExerciseFormType> => ({
   scale_min: 1,
   scale_max: SCALE_CONFIG.DEFAULT,
   optionList: [
-    { id: `option-${Date.now()}`, choice: "" } as PollOption,
-    { id: `option-${Date.now() + 1}`, choice: "" } as PollOption
+    { id: `option-${crypto.randomUUID()}`, choice: "" } as PollOption,
+    { id: `option-${crypto.randomUUID()}`, choice: "" } as PollOption
   ]
 });
 
@@ -165,8 +165,8 @@ export const PollExercise: FC<BaseExerciseProps> = ({
         updateFormData("scale_max", undefined);
 
         const defaultOptions = [
-          { id: `option-${Date.now()}`, choice: "", feedback: "", correct: false },
-          { id: `option-${Date.now() + 1}`, choice: "", feedback: "", correct: false }
+          { id: `option-${crypto.randomUUID()}`, choice: "", feedback: "", correct: false },
+          { id: `option-${crypto.randomUUID()}`, choice: "", feedback: "", correct: false }
         ] as PollOption[];
 
         updateFormData("optionList", defaultOptions);

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/PollExercise/PollOptions.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/PollExercise/PollOptions.tsx
@@ -128,7 +128,7 @@ export const PollOptions = ({
 
   const handleAdd = () => {
     const newOption: PollOption = {
-      id: `option-${Date.now()}`,
+      id: `option-${crypto.randomUUID()}`,
       choice: ""
     };
 

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/hooks/useBaseExercise.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/hooks/useBaseExercise.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 
-import { CreateExerciseFormType } from "@/types/exercises";
+import { CreateExerciseFormType, Option } from "@/types/exercises";
 import { createExerciseId } from "@/utils/exercise";
+import { OptionWithId } from "@components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components";
 
 export type UseBaseExerciseProps<T extends Partial<CreateExerciseFormType>> = {
   initialData?: T;
@@ -17,6 +18,19 @@ export type UseBaseExerciseProps<T extends Partial<CreateExerciseFormType>> = {
   resetForm?: boolean;
   onFormReset?: () => void;
   isEdit?: boolean;
+};
+
+const handleOptionIds = (options?: OptionWithId[] | Option[]) => {
+  const opts = options ?? [];
+  return opts.map((opt) => {
+    if (!("id" in opt) || !opt.id) {
+      return {
+        ...opt,
+        id: `option-${crypto.randomUUID()}`
+      };
+    }
+    return opt as OptionWithId;
+  });
 };
 
 export const useBaseExercise = <T extends Partial<CreateExerciseFormType>>({
@@ -34,13 +48,18 @@ export const useBaseExercise = <T extends Partial<CreateExerciseFormType>>({
   isEdit = false
 }: UseBaseExerciseProps<T>) => {
   const [formData, setFormData] = useState<T>(() => {
-    if (initialData) {
-      return {
-        ...getDefaultFormData(),
-        ...initialData
-      };
-    }
-    return getDefaultFormData();
+    const mergedData = initialData
+      ? {
+          ...getDefaultFormData(),
+          ...initialData
+        }
+      : getDefaultFormData();
+
+    return {
+      ...mergedData,
+      // Ensure options have IDs if they are present
+      optionList: handleOptionIds(mergedData.optionList)
+    };
   });
 
   const [activeStep, setActiveStep] = useState(0);


### PR DESCRIPTION
Fixed a bug that sometimes happened in older multiple choice questions, where the option list did not have an ID, and our checkboxes could not understand which option to select.

I also changed the way we set IDs, to make sure the situation cannot happen when non-uniq ID is generated.

This fix should also solve the issue when multiple choice options looked grey, like they were disabled. They could not be dragged because the ID was missing or not unique.

The same logic was added to prevent similar situations in poll exercises.

Fix #946 