### PR TITLE
Fix issue 970 - confusing Push Grades to LTI message

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/static/js/admin.js
+++ b/bases/rsptx/web2py_server/applications/runestone/static/js/admin.js
@@ -2550,7 +2550,7 @@ function push_lti_grades() {
         data,
         function (mess, stat, w) {
             alert(
-                `${mess} Grades are now hidden from students for ${assignment}`
+                `${mess} Grades have been sent for ${assignment}`
             );
         }
     );


### PR DESCRIPTION
Fix for https://github.com/RunestoneInteractive/rs/issues/970