### PR TITLE
Temp lti logging

### DIFF
--- a/bases/rsptx/admin_server_api/routers/lti1p3.py
+++ b/bases/rsptx/admin_server_api/routers/lti1p3.py
@@ -233,7 +233,9 @@ async def login_or_create_user(
     url = f"https://{domain}/default/w2py_login?token={encoded_jwt}"
     async with aiohttp.ClientSession() as session:
         try:
+            rslogger.info(f"LTI1p3 - TEMP - Logging in to w2p server at {url}")
             resp = await session.get(url)
+            rslogger.info(f"LTI1p3 - TEMP - got response from w2p server: {resp.__dict__}")
             resp.raise_for_status()
             cookies = resp._headers.getall('Set-Cookie')
             for cookie in cookies:

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
@@ -189,7 +189,6 @@ def w2py_login():
     """
     logger.debug("Generating web2py token")
     token = request.vars["token"]
-    print(token)
     try:
         if not token:
             err = "No token provided to w2py_login"

--- a/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
+++ b/bases/rsptx/web2py_server/applications/runestone/controllers/default.py
@@ -189,22 +189,26 @@ def w2py_login():
     """
     logger.debug("Generating web2py token")
     token = request.vars["token"]
+    logger.info(f"LTI1p3 - TEMP - w2py_login got token: {token}")
     try:
         if not token:
             err = "No token provided to w2py_login"
             raise Exception(err)
 
         decoded = jwt.decode(token, settings.jwt_secret, "HS256")
+        logger.info(f"LTI1p3 - TEMP - w2py_login decoded token: {decoded}")
         if not decoded:
             err = "Invalid token provided to w2py_login"
             raise Exception(err)
 
         user = db(db.auth_user.registration_id == decoded["registration_id"]).select().first()
+        logger.info(f"LTI1p3 - TEMP - w2py_login found user: {user}")
         if not user:
             err = "Unkonwn user in token provided to w2py_login"
             raise Exception(err)
 
         auth.login_user(user)
+        logger.info(f"LTI1p3 - TEMP - w2py_login logged in user: {user.username}")
         return "User logged in"
     except Exception as e:
         logger.error(f"Error in w2py_login: {e}")


### PR DESCRIPTION
Extra logging to debug what is going on with Canvas student impersonation login.

Two commits:
First gets rid of a random `print()` call I left in from development. That is a permanent commit.
Second has the new logging. Once we are done with it, we can revert that one commit.