### PR TITLE
issue-939 Enhance table components with gridline styling and enable column resizing

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/AssignmentExercisesTable.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/AssignmentExercisesTable.tsx
@@ -120,9 +120,12 @@ export const AssignmentExercisesTable = ({
         }
         reorderableRows
         onRowReorder={(e) => reorderExercises(e.value.map((exercise) => exercise.id))}
+        resizableColumns
+        columnResizeMode="fit"
       >
-        <Column selectionMode="multiple" style={{ width: "3rem" }} />
+        <Column resizeable={false} selectionMode="multiple" style={{ width: "3rem" }} />
         <Column
+          resizeable={false}
           style={{ width: "2rem" }}
           body={(data: Exercise) => (
             <div className="flex gap-2 justify-content-center">
@@ -136,6 +139,7 @@ export const AssignmentExercisesTable = ({
           )}
         />
         <Column
+          resizeable={false}
           style={{ width: "3rem" }}
           body={(data: Exercise) => (
             <div className="flex gap-2 justify-content-center">
@@ -149,6 +153,7 @@ export const AssignmentExercisesTable = ({
           )}
         />
         <Column
+          resizeable={false}
           style={{ width: "3rem" }}
           body={(data: Exercise) => (
             <div className="flex gap-2 justify-content-center">
@@ -168,6 +173,7 @@ export const AssignmentExercisesTable = ({
           )}
         />
         <Column
+          resizeable={false}
           style={{ width: "3rem" }}
           body={(data: Exercise) => (
             <div className="flex gap-2 justify-content-center">
@@ -201,8 +207,10 @@ export const AssignmentExercisesTable = ({
           )}
           sortField="name"
           sortable
+          resizeable
         />
         <Column
+          resizeable={false}
           field="question_type"
           header="Type"
           body={(data: Exercise) => getExerciseTypeTag(data.question_type)}
@@ -210,6 +218,7 @@ export const AssignmentExercisesTable = ({
           style={{ width: "12rem" }}
         />
         <Column
+          resizeable={false}
           style={{ width: "12rem" }}
           field="autograde"
           header={() => (
@@ -229,6 +238,7 @@ export const AssignmentExercisesTable = ({
           )}
         />
         <Column
+          resizeable={false}
           field="which_to_grade"
           header={() => (
             <EditDropdownValueHeader
@@ -252,6 +262,7 @@ export const AssignmentExercisesTable = ({
           )}
         />
         <Column
+          resizeable={false}
           field="points"
           bodyStyle={{ padding: 0 }}
           style={{ width: "8rem" }}
@@ -268,7 +279,7 @@ export const AssignmentExercisesTable = ({
             />
           )}
         />
-        <Column rowReorder style={{ width: "3rem" }} />
+        <Column resizeable={false} rowReorder style={{ width: "3rem" }} />
       </DataTable>
       <TableSelectionOverlay
         startItemId={startItemId}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ChooseExercises/ChooseExercises.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ChooseExercises/ChooseExercises.tsx
@@ -102,7 +102,7 @@ export const ChooseExercises = () => {
       onUnselect={handleUnselect}
       value={filteredExercises}
       resizableColumns
-      className="table_sticky-header"
+      className="table_sticky-header header-gridlines-only"
       header={
         <ChooseExercisesHeader
           resetSelections={resetSelections}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/SearchExercises/SmartSearchExercises.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/SearchExercises/SmartSearchExercises.tsx
@@ -317,10 +317,12 @@ export const SmartSearchExercises = () => {
             rowHover
             filterDisplay="menu"
             tableStyle={{ tableLayout: "fixed" }} // Fixed table layout
-            reorderableColumns
+            resizableColumns
+            columnResizeMode="fit"
           >
             {/* Multiple selection column */}
             <Column
+              resizeable={false}
               selectionMode="multiple"
               headerStyle={{ width: "3rem" }}
               style={{ width: "3rem" }}
@@ -330,6 +332,7 @@ export const SmartSearchExercises = () => {
 
             {/* Preview */}
             <Column
+              resizeable={false}
               headerStyle={{ width: "4rem" }}
               style={{ width: "4rem" }}
               body={renderPreview}
@@ -339,6 +342,7 @@ export const SmartSearchExercises = () => {
 
             {/* Copy button */}
             <Column
+              resizeable={false}
               headerStyle={{ width: "4rem" }}
               style={{ width: "4rem" }}
               body={renderCopyButton}
@@ -348,6 +352,7 @@ export const SmartSearchExercises = () => {
 
             {/* Question number */}
             <Column
+              resizeable={false}
               field="qnumber"
               header="Number"
               headerStyle={{ width: "7rem" }}
@@ -369,10 +374,12 @@ export const SmartSearchExercises = () => {
               showFilterMenu={true}
               filterMenuStyle={{ width: "15rem" }}
               className="name-column"
+              resizeable
             />
 
             {/* Question type */}
             <Column
+              resizeable={false}
               field="question_type"
               header="Type"
               sortable

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.tsx
@@ -81,8 +81,10 @@ export const AssignmentReadingsTable = ({
         }
         reorderableRows
         onRowReorder={(e) => reorderReadings(e.value.map((reading) => reading.id))}
+        resizableColumns
+        columnResizeMode="fit"
       >
-        <Column selectionMode="multiple" style={{ width: "3rem" }} />
+        <Column resizeable={false} selectionMode="multiple" style={{ width: "3rem" }} />
 
         {/* Chapter */}
         <Column
@@ -97,6 +99,7 @@ export const AssignmentReadingsTable = ({
             </div>
           )}
           sortable
+          resizeable
         />
 
         {/* Subchapter */}
@@ -111,10 +114,12 @@ export const AssignmentReadingsTable = ({
             </div>
           )}
           sortable
+          resizeable
         />
 
         {/* Activity count (read-only) */}
         <Column
+          resizeable={false}
           field="numQuestions"
           header="Activity count"
           style={{ maxWidth: "7rem" }}
@@ -126,6 +131,7 @@ export const AssignmentReadingsTable = ({
 
         {/* # required (editable, no bulk edit) */}
         <Column
+          resizeable={false}
           field="activities_required"
           header="# required"
           style={{ maxWidth: "7rem" }}
@@ -145,6 +151,7 @@ export const AssignmentReadingsTable = ({
 
         {/* Points */}
         <Column
+          resizeable={false}
           field="points"
           bodyStyle={{ padding: 0 }}
           style={{ maxWidth: "7rem" }}
@@ -166,6 +173,7 @@ export const AssignmentReadingsTable = ({
 
         {/* Which to grade */}
         <Column
+          resizeable={false}
           field="which_to_grade"
           header={() => (
             <EditDropdownValueHeaderReadings
@@ -189,7 +197,7 @@ export const AssignmentReadingsTable = ({
           )}
         />
 
-        <Column rowReorder style={{ width: "3rem" }} />
+        <Column resizeable={false} rowReorder style={{ width: "3rem" }} />
       </DataTable>
       <TableSelectionOverlay
         startItemId={startItemId}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/styles/_table.scss
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/styles/_table.scss
@@ -13,6 +13,22 @@
   }
 }
 
+.header-gridlines-only {
+  .p-treetable-thead > tr > th {
+    border-right: 1px solid var(--surface-border);
+    border-bottom: 1px solid var(--surface-border);
+  }
+
+  .p-treetable-thead > tr > th:last-child {
+    border-right: none;
+  }
+
+  .p-treetable-tbody > tr > td {
+    border-right: none;
+    border-bottom: 1px solid var(--surface-border);
+  }
+}
+
 .editable-table-cell {
   .editable-table-input,
   .editable-table-dropdown,


### PR DESCRIPTION
I added separator lines in the "browse chapter" header to make it clearer that we have column resize handlers. 
I also added the ability to resize some columns in the assignment exercises, assignment readings, and search exercises tables

Fix #939 