### PR TITLE
issue-869 Enhance exercise filtering in ChooseExercises with a toggle switch and improved layout

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/AssignmentBuilder.module.css
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/AssignmentBuilder.module.css
@@ -852,6 +852,5 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  max-height: calc(100vh - 180px);
   overflow: hidden;
 }

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/AssignmentEdit.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/AssignmentEdit.tsx
@@ -199,11 +199,6 @@ export const AssignmentEdit = ({
         </div>
         <div className={styles.mainContentInner}>
           <Tooltip target="[data-pr-tooltip]" />
-          <BreadCrumb
-            model={getBreadcrumbModel()}
-            home={{ icon: "pi pi-home", command: () => onTabChange("basic") }}
-            className="mb-3"
-          />
           {activeTab === "basic" && (
             <div className={styles.formContainer}>
               <div className={styles.card}>

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/AssignmentExercisesTable.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/AssignmentExercisesTable.tsx
@@ -104,7 +104,7 @@ export const AssignmentExercisesTable = ({
         }
         dataKey="id"
         scrollable
-        scrollHeight="calc(100vh - 320px)"
+        scrollHeight="calc(100vh - 280px)"
         size="small"
         rowClassName={() => "assignmentExercise_row"}
         stripedRows

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ChooseExercises/ChooseExercises.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ChooseExercises/ChooseExercises.tsx
@@ -18,7 +18,8 @@ import {
   getLeafNodes,
   getSelectedKeys,
   filterExercisesByQuestionType,
-  filterOutExercisesByQuestionType
+  filterOutExercisesByQuestionType,
+  filterExercisesByFromSource
 } from "@/utils/exercise";
 
 export const ChooseExercises = () => {
@@ -26,13 +27,17 @@ export const ChooseExercises = () => {
   const { assignmentExercises = [] } = useExercisesSelector();
   const availableExercises = useSelector(exercisesSelectors.getAvailableExercises);
   const [selectedQuestionTypes, setSelectedQuestionTypes] = useState<string[]>([]);
+  const [fromSourceOnly, setFromSourceOnly] = useState<boolean>(false);
 
   const selectedKeys = useSelector(chooseExercisesSelectors.getSelectedKeys);
   const selectedExercises = useSelector(chooseExercisesSelectors.getSelectedExercises);
 
-  const filteredExercises = filterOutExercisesByQuestionType(
-    filterExercisesByQuestionType(availableExercises, selectedQuestionTypes),
-    ["datafile"]
+  const filteredExercises = filterExercisesByFromSource(
+    filterOutExercisesByQuestionType(
+      filterExercisesByQuestionType(availableExercises, selectedQuestionTypes),
+      ["datafile"]
+    ),
+    fromSourceOnly
   );
 
   const updateState = (selEx: Exercise[]) => {
@@ -108,6 +113,8 @@ export const ChooseExercises = () => {
           resetSelections={resetSelections}
           selectedQuestionTypes={selectedQuestionTypes}
           onQuestionTypeChange={setSelectedQuestionTypes}
+          fromSourceOnly={fromSourceOnly}
+          onFromSourceChange={setFromSourceOnly}
         />
       }
     >
@@ -123,7 +130,7 @@ export const ChooseExercises = () => {
       <Column style={{ width: "15%" }} field="qnumber" header="Question number" />
       <Column style={{ width: "20%" }} field="name" header="Name" />
       <Column
-        style={{ width: "5rem" }}
+        style={{ width: "6rem" }}
         field="htmlsrc"
         header="Preview"
         body={({ data }: { data: Exercise }) => {
@@ -144,6 +151,7 @@ export const ChooseExercises = () => {
         style={{ width: "10%" }}
         field="from_source"
         header="Source"
+        sortable
         body={({ data }: { data: Exercise }) => {
           if (data.from_source === undefined) return;
           return <i className={data.from_source ? "pi pi-book" : "pi pi-user"} />;

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ChooseExercises/ChooseExercisesHeader.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/ChooseExercises/ChooseExercisesHeader.tsx
@@ -3,6 +3,7 @@ import { chooseExercisesSelectors } from "@store/chooseExercises/chooseExercises
 import { datasetSelectors } from "@store/dataset/dataset.logic";
 import { Button } from "primereact/button";
 import { confirmPopup, ConfirmPopup } from "primereact/confirmpopup";
+import { InputSwitch } from "primereact/inputswitch";
 import { MultiSelect } from "primereact/multiselect";
 import { MouseEvent } from "react";
 import { useSelector } from "react-redux";
@@ -14,12 +15,16 @@ interface ChooseExercisesHeaderProps {
   resetSelections: () => void;
   selectedQuestionTypes: string[];
   onQuestionTypeChange: (selectedTypes: string[]) => void;
+  fromSourceOnly: boolean;
+  onFromSourceChange: (fromSourceOnly: boolean) => void;
 }
 
 export const ChooseExercisesHeader = ({
   resetSelections,
   selectedQuestionTypes,
-  onQuestionTypeChange
+  onQuestionTypeChange,
+  fromSourceOnly,
+  onFromSourceChange
 }: ChooseExercisesHeaderProps) => {
   const { updateAssignmentExercises } = useUpdateAssignmentExercise();
 
@@ -71,10 +76,25 @@ export const ChooseExercisesHeader = ({
             label="Choose exercises"
             size="small"
             severity="warning"
+            className="text-sm"
           />
         )}
       </div>
       <div className="flex align-items-center gap-2">
+        <div className="flex align-items-center gap-2">
+          <label htmlFor="source-switch" className="text-sm font-medium text-gray-700">
+            {fromSourceOnly ? "Book exercises" : "All Exercises"}
+          </label>
+          <InputSwitch
+            inputId="source-switch"
+            checked={fromSourceOnly}
+            onChange={(e) => onFromSourceChange(e.value)}
+            className="p-inputswitch-sm"
+            style={{ transform: "scale(0.8)" }}
+            tooltip="Show only exercises from the source material"
+            tooltipOptions={{ position: "bottom" }}
+          />
+        </div>
         <MultiSelect
           value={selectedQuestionTypes}
           options={questionTypeOptions}
@@ -82,16 +102,28 @@ export const ChooseExercisesHeader = ({
           optionLabel="label"
           optionValue="value"
           placeholder="Exercise types"
-          display="chip"
+          className="text-sm"
+          style={{
+            minWidth: "250px",
+            maxWidth: "250px"
+          }}
+          panelClassName="text-sm"
+          maxSelectedLabels={1}
+          selectedItemsLabel="{0} exercise types selected"
         />
         <Button
           icon="pi pi-replay"
           rounded
-          size="small"
           tooltipOptions={{ showDelay: 500, position: "left" }}
           tooltip="Reset selection"
           disabled={!hasAnyChanges}
           onClick={resetSelections}
+          style={{
+            width: "16px",
+            height: "16px",
+            fontSize: "0.75rem",
+            padding: "16px"
+          }}
         />
       </div>
     </div>

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/SearchExercises/SmartSearchExercises.module.css
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/SearchExercises/SmartSearchExercises.module.css
@@ -35,15 +35,24 @@
   display: flex;
   gap: 0.75rem;
   margin-bottom: 0.5rem;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .searchField {
   flex: 2;
 }
 
+.filtersContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .typeFilter {
-  flex: 1;
-  min-width: 12.5rem;
+  font-size: 0.875rem;
+  min-width: 250px;
+  max-width: 250px;
 }
 
 .statusBar {
@@ -627,6 +636,9 @@
 .baseCourseFilter {
   flex: 0 0 auto;
   min-width: 9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .checkboxLabel {
@@ -642,4 +654,14 @@
 .checkboxLabel span {
   font-weight: 500;
   user-select: none;
+}
+
+.switchLabel {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.inputSwitch {
+  transform: scale(0.8);
 }

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/SearchExercises/SmartSearchExercises.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/SearchExercises/SmartSearchExercises.tsx
@@ -7,11 +7,11 @@ import {
 } from "@store/searchExercises/searchExercises.logic";
 import { FilterMatchMode, SortOrder } from "primereact/api";
 import { Button } from "primereact/button";
-import { Checkbox } from "primereact/checkbox";
 import { Chip } from "primereact/chip";
 import { Chips } from "primereact/chips";
 import { Column } from "primereact/column";
 import { DataTable, DataTableFilterMetaData } from "primereact/datatable";
+import { InputSwitch } from "primereact/inputswitch";
 import { MultiSelect } from "primereact/multiselect";
 import { Paginator } from "primereact/paginator";
 import { ProgressSpinner } from "primereact/progressspinner";
@@ -184,8 +184,24 @@ export const SmartSearchExercises = () => {
             </span>
           </div>
 
-          {/* Exercise type filter */}
-          <div className={styles.typeFilter}>
+          <div className={styles.filtersContainer}>
+            <div className={styles.baseCourseFilter}>
+              <label htmlFor="source-switch" className={styles.switchLabel}>
+                {searchParams.use_base_course ? "Book exercises" : "All Exercises"}
+              </label>
+              <InputSwitch
+                inputId="source-switch"
+                checked={searchParams.use_base_course}
+                onChange={(e) => toggleBaseCourse(e.value || false)}
+                className={styles.inputSwitch}
+                tooltip={
+                  searchParams.use_base_course
+                    ? "Showing exercises from current book only"
+                    : "Showing exercises from all books"
+                }
+                tooltipOptions={{ position: "bottom" }}
+              />
+            </div>
             <MultiSelect
               value={(filters.question_type as DataTableFilterMetaData).value}
               options={exerciseTypes}
@@ -194,27 +210,14 @@ export const SmartSearchExercises = () => {
                   question_type: { value: e.value, matchMode: FilterMatchMode.IN }
                 });
               }}
-              placeholder="Type"
-              className="w-full"
-              display="chip"
+              optionLabel="label"
+              optionValue="value"
+              placeholder="Exercise types"
+              className={styles.typeFilter}
+              panelClassName="text-sm"
+              maxSelectedLabels={1}
+              selectedItemsLabel="{0} exercise types selected"
             />
-          </div>
-
-          {/* Base course filter toggle */}
-          <div className={styles.baseCourseFilter}>
-            <label className={styles.checkboxLabel}>
-              <Checkbox
-                checked={searchParams.use_base_course}
-                onChange={(e) => toggleBaseCourse(e.checked || false)}
-                tooltip={
-                  searchParams.use_base_course
-                    ? "Showing exercises from current book only"
-                    : "Showing exercises from all books"
-                }
-                tooltipOptions={{ position: "top" }}
-              />
-              <span>Current book only</span>
-            </label>
           </div>
         </div>
 

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.tsx
@@ -65,7 +65,7 @@ export const AssignmentReadingsTable = ({
         }
         dataKey="id"
         scrollable
-        scrollHeight="calc(100vh - 320px)"
+        scrollHeight="calc(100vh - 280px)"
         size="small"
         rowClassName={() => "assignmentExercise_row"}
         stripedRows

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/utils/exercise.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/utils/exercise.ts
@@ -163,3 +163,26 @@ export const filterOutExercisesByQuestionType = (
     }))
     .filter((node) => !questionTypes.includes(node.data?.question_type));
 };
+
+const shouldIncludeFromSourceNode = (node: TreeNode, fromSourceOnly: boolean): boolean =>
+  !node.children?.length
+    ? fromSourceOnly
+      ? node.data?.from_source === true
+      : true
+    : node.children.length > 0;
+
+export const filterExercisesByFromSource = (
+  nodes: TreeNode[],
+  fromSourceOnly: boolean = false
+): TreeNode[] => {
+  if (!fromSourceOnly) return nodes;
+
+  return nodes
+    .map((node) => ({
+      ...node,
+      children: node.children
+        ? filterExercisesByFromSource(node.children, fromSourceOnly)
+        : undefined
+    }))
+    .filter((node) => shouldIncludeFromSourceNode(node, fromSourceOnly));
+};


### PR DESCRIPTION
- Removed the breadcrumb in exercise editing to free up more space (it wasn’t useful anyway; site navigation needs a redesign).
- Added a switch in Browse Exercises to show only exercises from the book.
- Added the ability to sort exercises by source.
- Fixed a visual bug in the multiselect for choosing exercise types (Browse Exercises, Search Exercises).

fix #869 
