### PR TITLE
FITB: only attempt to select text inputs from statement while renderings

### DIFF
--- a/bases/rsptx/interactives/runestone/fitb/js/fitb.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb.js
@@ -364,7 +364,9 @@ export default class FITB extends RunestoneBase {
 
     setupBlanks() {
         // Find and format the blanks. If a dynamic problem just changed the HTML, this will find the newly-created blanks.
-        const ba = $(this.descriptionDiv).find(":input");
+        // WARNING - this assumes that the only text inputs in the descriptionDiv are the blanks.
+        // Ideally, there should be some unique attribute that can be used to select the blanks.
+        const ba = $(this.descriptionDiv).find('input[type="text"]');
         ba.attr("class", "form form-control selectwidthauto");
         ba.attr("aria-label", "input area");
         this.blankArray = ba.toArray();


### PR DESCRIPTION
Temp fix for issue discussed here:
https://discord.com/channels/1013815439161315348/1013815511357857902/1423101030442209301

I think the new code still represents a possible source of bugs, but now it only assumes all text inputs belong to the fitb, not all inputs in general.