### PR TITLE
Livecode: better handling of trailing newlines and pre formatted output boxes

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -571,22 +571,24 @@ export default class LiveCode extends ActiveCode {
         let passedTests = 0;
         // we will stop on the first error
         this.errinfo = null;
-        const trimLines = (s) => s.split("\n").map( s => s.trimEnd()).join("\n")
+        // trim any trailing whitespace so invisible extra newline doesn't fail test
+        // then trim trailing whitespace on each remaining line
+        const trimLines = (s) => s.trimEnd().split("\n").map( s => s.trimEnd()).join("\n")
         for (let result of resultList) {
             const produced = trimLines(result.stdout);
             const desired = trimLines(result.test.out);
             const tr = document.createElement("tr");
             const td1 = document.createElement("td");
             td1.classList.add("ac-feedback");
-            td1.innerHTML = result.test.input.replace(/\n/g, "<br>");
+            td1.innerHTML = `<pre>${result.test.input}\n\n</pre>`;
             tr.appendChild(td1);
             const td2 = document.createElement("td");
             td2.classList.add("ac-feedback");
-            td2.innerHTML = desired.replace(/\n/g, "<br>");
+            td2.innerHTML = `<pre>${desired}</pre>`;
             tr.appendChild(td2);
             const td3 = document.createElement("td");
             td3.classList.add("ac-feedback");
-            td3.innerHTML = produced.replace(/\n/g, "<br>");
+            td3.innerHTML = `<pre>${produced}</pre>`;
             tr.appendChild(td3);
             const td4 = document.createElement("td");
             td4.classList.add("ac-feedback");


### PR DESCRIPTION
The updated whitespace trimming results in student answers that are missing a trailing newline always being wrong.

PreTeXt always generates a newline at the end of the `<output>` block of an `<iotest>`. I don't necessarily love that, but it is consistent with other PTX behavior when processing code like blocks. So in the screenshot below, the expected answer is:
```
4 5

```
With a trailing newline.

The provided answer is:
```
4 5
```
Without a newline. 

The rendered output gives no indication that there is an issue. Even wrapping the outputs in `<pre>` tags won't make the issue visible. 

<img width="750" height="166" alt="image" src="https://github.com/user-attachments/assets/bd92274c-3387-458d-b66e-de99c8579199" />

@skiadas This will mean students never get answers wrong for missing or extra trailing newlines. But I think that is much better than the current behavior. Do you see a reason to ever mark those wrong? If so, how do you think we should make the issue more visible to students?