### PR TITLE
Better handling of unit tests in visible or invisible suffix code

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/activecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/activecode.js
@@ -1543,6 +1543,7 @@ Yet another is that there is an internal error.  The internal error message is: 
             }
             prog = pretext + prog;
         }
+        //any visible suffix already is included in editor code
         if (useSuffix && this.suffix) {
             prog = prog + this.suffix;
         }

--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -52,9 +52,21 @@ export default class LiveCode extends ActiveCode {
     }
     createErrorOutput() { }
 
+
+    getCombinedSuffixes() {
+        if (this.suffix && this.visibleSuffix)
+            return this.suffix + this.visibleSuffix;
+        else if (this.suffix)
+            return this.suffix;
+        else if (this.visibleSuffix)
+            return this.visibleSuffix;
+        return "";
+    }
+
     hasUnitTests() {
-        return this.language === "java" && this.suffix && this.suffix.indexOf("import org.junit") > -1
-        || this.language === "cpp" && this.suffix && this.suffix.indexOf("[doctest]") > -1;
+        let combinedSuffix = this.getCombinedSuffixes();
+        return this.language === "java" && combinedSuffix.indexOf("import org.junit") > -1
+        || this.language === "cpp" && combinedSuffix.indexOf("doctest.h") > -1;
     }
 
     /*  Main runProg method for livecode
@@ -491,7 +503,7 @@ export default class LiveCode extends ActiveCode {
                     let output = result.stdout ? result.stdout : "";
                     $(odiv).html(output);
                 }
-                if (this.suffix) {
+                if (this.hasUnitTests() || this.iotests) {
                     if (this.parsedOutput.pct === undefined) {
                         this.parsedOutput.pct =
                             this.parsedOutput.passed =


### PR DESCRIPTION
Found a bug in unit tests located in visible suffixes. They currently are scored visually on the page correctly, but not reported as a logged event.