### PR TITLE
Livecode: allow doctest import in prefix code to trigger unit tests

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -65,8 +65,16 @@ export default class LiveCode extends ActiveCode {
 
     hasUnitTests() {
         let combinedSuffix = this.getCombinedSuffixes();
-        return this.language === "java" && combinedSuffix.indexOf("import org.junit") > -1
-        || this.language === "cpp" && combinedSuffix.indexOf("doctest.h") > -1;
+
+        // import used to detect java unit tests is historically assumed to always be in suffix
+        if( this.language === "java")
+            return combinedSuffix.indexOf("import org.junit") > -1;
+
+        // cpp unit test include may be in suffix or hidden prefix code
+        if (this.language !== "cpp")
+            return combinedSuffix.indexOf("doctest.h") > -1 || this.prefix.indexOf("doctest.h") > -1;
+
+        return false;
     }
 
     /*  Main runProg method for livecode


### PR DESCRIPTION
I am finding spots where it would be nice to do the include needed for C++ unit testing in prefix code as opposed to suffix.

The old java code always assumed suffix... would it ever make sense for it to have the `import org.junit` in prefix code? If so I can expand this so both languages support either location.

BTW - not really urgent. I would like to refactor some problems, but don't need this for current exercises