### PR TITLE
Activecode: improve display of whitespace in output of IOTests

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -608,7 +608,10 @@ export default class LiveCode extends ActiveCode {
             tr.appendChild(td2);
             const td3 = document.createElement("td");
             td3.classList.add("ac-feedback");
-            td3.innerHTML = `<pre>${produced}</pre>`;
+            // <pre> doesn't prevent browser from gulping leading space
+            // so produce a version that transforms whitespace into html entities/tags
+            let producedRenderOutput = produced.replaceAll(" ", "&nbsp;").replaceAll("\n", "<br>");
+            td3.innerHTML = `<pre>${producedRenderOutput}</pre>`;
             tr.appendChild(td3);
             const td4 = document.createElement("td");
             td4.classList.add("ac-feedback");


### PR DESCRIPTION
Fun fact: Setting the innerHTML of an element to `<pre>\n***\n***</pre>` preserves the middle newline, but strips out the first. So the value set by the browser is `<pre>***\n***</pre>`.

This causes leading whitespace to not be rendered when produced as part of a student's program output in IOTests.

This converts spaces to nbsp's and newlines to breaks in the rendering of the student's output to avoid that issue (and hopefully any other browser/whitespace ones).