### PR TITLE
Parsons help combine blocks bugfix

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/js/parsonsBlock.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsonsBlock.js
@@ -92,8 +92,8 @@ export default class ParsonsBlock {
                     );
                     // todo: if language is natural or math then don't do this
                     if (
-                        this.options.language !== "natural" &&
-                        this.options.language !== "math"
+                        this.problem.options.language !== "natural" &&
+                        this.problem.options.language !== "math"
                     ) {
                         $(lines[i].view).addClass(
                             "indent" + (lines[i].indent - line.indent)


### PR DESCRIPTION
Existing test for language is invalid, sometimes causes error midway through combining blocks which breaks the problem.

To reproduce, start with a Parsons that has a defined language. Move a block that should be heavily indented to the top of the solution area (to get past test on line 88). Fail three times, then hit help.

@sean-fitzpatrick - ~this may be part of your problem... but this bug only affects blocks in Parsons with language != "natural" or "math". Which makes me think you have something else going on~ Duh, the test itself is what breaks. Pretty sure this is your problem.