### PR TITLE
Livecode - fix typo in cpp unit test detection

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -67,11 +67,11 @@ export default class LiveCode extends ActiveCode {
         let combinedSuffix = this.getCombinedSuffixes();
 
         // import used to detect java unit tests is historically assumed to always be in suffix
-        if( this.language === "java")
+        if (this.language === "java")
             return combinedSuffix.indexOf("import org.junit") > -1;
 
         // cpp unit test include may be in suffix or hidden prefix code
-        if (this.language !== "cpp")
+        if (this.language === "cpp")
             return combinedSuffix.indexOf("doctest.h") > -1 || this.prefix.indexOf("doctest.h") > -1;
 
         return false;


### PR DESCRIPTION
This one is embarrassing. I have no idea how I managed to change `=` to `!` before sending the recent PR. I had it working locally, so I know the logic wasn't busted at some point.

Appologies for the churn. :(

If making a point release of the interactives after you merge this isn't too much work, it would be greatly appreciated. If not, I earned dealing with it. :) I don't know that anyone else is using doctest based cpp unit testing yet, so it should just be me eating the dogfood.