### PR TITLE
Livecode fix escapeHtml functions for empty strings

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -958,6 +958,9 @@ export default class LiveCode extends ActiveCode {
         return classes;
     }
 }
+
+// Warning - returns undefined if safe is an empty string
+// existing usages in constructor appear to rely on that behavior
 function unescapeHtml(safe) {
     if (safe) {
         return safe
@@ -968,6 +971,8 @@ function unescapeHtml(safe) {
             .replace(/&#x27;/g, "'");
     }
 }
+
+// Designed to produce HTML from a string, so always return a string
 function escapeHtml(str) {
     if (str) {
         return str
@@ -977,4 +982,5 @@ function escapeHtml(str) {
             .replace(/'/g, '&#x27;')
             .replace(/"/g, '&quot;');
     }
+    return '';
 }


### PR DESCRIPTION
The escapeHtml functions at the end of livecode.js return nothing if passed an empty string as an empty string counts as false.

This causes an issue if a program times out without producing any output (e.g. a non-printing loop). In that case, an empty string is passed to this function but comes back as undefined. Then `.replace` is called on that result which blows up when we started with an empty string. (Livecode.js line 539)

This guarantees we always get a string back from escapeHtml.

Looked at unescapeHtml as well, but it appears existing code might depend on getting back undefined when given a null string. So I just added a comment to highlight the difference.