### PR TITLE
Livecode: guard against undefined prefix in unit test detection

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -71,8 +71,8 @@ export default class LiveCode extends ActiveCode {
             return combinedSuffix.indexOf("import org.junit") > -1;
 
         // cpp unit test include may be in suffix or hidden prefix code
-        if (this.language === "cpp")
-            return combinedSuffix.indexOf("doctest.h") > -1 || this.prefix.indexOf("doctest.h") > -1;
+        if (this.language !== "cpp")
+            return combinedSuffix.indexOf("doctest.h") > -1 || (this.prefix && this.prefix.indexOf("doctest.h") > -1);
 
         return false;
     }


### PR DESCRIPTION
Another iteration in bulletproofing Livecode