### PR TITLE
Assignment builder: allow search to match exercise qnumber field

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/AssignmentExercisesTable.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/AssignmentExercisesList/AssignmentExercisesTable.tsx
@@ -110,7 +110,7 @@ export const AssignmentExercisesTable = ({
         stripedRows
         showGridlines
         globalFilter={globalFilter}
-        globalFilterFields={["name", "title"]}
+        globalFilterFields={["name", "title", "qnumber"]}
         emptyMessage={
           <div className="text-center p-5">
             <i className="pi pi-book text-4xl text-500 mb-3" style={{ display: "block" }} />


### PR DESCRIPTION
Since the `qnumber` field is the user visible title of an exercise in PTX world, it would be useful to be able to search against those in the assignment builder assignment list.