### PR TITLE
Livecode C++ unit test regression fix

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -71,7 +71,7 @@ export default class LiveCode extends ActiveCode {
             return combinedSuffix.indexOf("import org.junit") > -1;
 
         // cpp unit test include may be in suffix or hidden prefix code
-        if (this.language !== "cpp")
+        if (this.language === "cpp")
             return combinedSuffix.indexOf("doctest.h") > -1 || (this.prefix && this.prefix.indexOf("doctest.h") > -1);
 
         return false;


### PR DESCRIPTION
The fix in dc0d4699c90da8acc8045efc72469a5ef48e99e2 was undone in 47343149a97c4ba56c155c6c94278b07d3d44d19. They were in flight at the same time and looks like a merge grabbed the wrong version of `this.language === "cpp"`

This undoes the regression.