### PR TITLE
Datafile: trigger render on runestone:login-complete

### DIFF
--- a/bases/rsptx/interactives/runestone/datafile/js/datafile.js
+++ b/bases/rsptx/interactives/runestone/datafile/js/datafile.js
@@ -79,7 +79,8 @@ class DataFile extends RunestoneBase {
 == Find the custom HTML tags and ==
 ==   execute our code on them    ==
 =================================*/
-document.addEventListener("DOMContentLoaded", function () {
+
+document.addEventListener("runestone:login-complete", function () {
     document.querySelectorAll("[data-component=datafile]").forEach(function (el) {
         try {
             dfList[el.id] = new DataFile({ orig: el });


### PR DESCRIPTION
Unlike most other components, the datafile component didn't use the `runestone:login-complete` event handler to trigger rending. (Before or after JQuery refactor.) This makes it trigger initial rendering on that event.