### PR TITLE
Livecode same page additional file lookup fix

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/js/livecode.js
+++ b/bases/rsptx/interactives/runestone/activecode/js/livecode.js
@@ -268,13 +268,15 @@ export default class LiveCode extends ActiveCode {
             // Check on page to see if we have the datafile.
             // Datafiles are looked up via data-filename attribute while additional_files are looked up via id
             let fileElement;
-            if (f.type === "datafile")
+            if (f.type === "datafile") {
                 fileElement = document.querySelector(`[data-filename="${f.filename}"]`);
                 // But RST markup uses filename as id
                 if (!fileElement)
                     fileElement = document.getElementById(f.filename);
-            else
+            }
+            else {
                 fileElement = document.getElementById(f.acid);
+            }
 
             if (fileElement) {
                 // if the element is a code mirror, get the value from the editor


### PR DESCRIPTION
Missing { } are causing an issue with finding elements that are not data files on the same page to send to Jobe for livecodes.
Only affects code "files" that are not in the database and only for livecode.

This fixes the issue.