### PR TITLE
Course creation: fix double handler for invoice me checkbox

### DIFF
--- a/components/rsptx/templates/admin/instructor/create_course.html
+++ b/components/rsptx/templates/admin/instructor/create_course.html
@@ -312,16 +312,6 @@
         return true;
     });
 
-    document.getElementById('invoice-me').addEventListener('change', function () {
-        if (this.checked) {
-            let res = confirm("Checking this box means you want us to email you an Invoice (Thank you!!).  If you want to keep using Runestone for free just click cancel");
-            if (res === true) {
-                this.checked = false;
-            }
-        }
-    });
-
-
     // Book filter logic
     function setupBookFilter() {
         var filterInput = document.getElementById('bookFilter');


### PR DESCRIPTION
There are two copies of the event handler for `invoice-me`. The one on line 248 appears to have the correct logic. This one is reversed.

Currently if you click that button, the confirmation triggers twice, and the second one turns off the radio when you hit "OK". So it is impossible to offer RS money!