### PR TITLE
Hparson math rendering fixes

### DIFF
--- a/bases/rsptx/interactives/runestone/hparsons/js/hparsons.js
+++ b/bases/rsptx/interactives/runestone/hparsons/js/hparsons.js
@@ -195,9 +195,12 @@ export default class HParsons extends RunestoneBase {
             });
 
             if (window.MathJax && MathJax.typesetPromise) {
-                MathJax.typesetPromise().then(() => this.simulateSolution());
+                MathJax.typesetPromise([blocks]).then(() => this.simulateSolution());
             }
-        }, 0);
+        }, 100);
+        // Ugly... but there are timing issues with block rendering in microparsons and MathJax
+        // most noticeable if multiple hparsons problems are on the same page
+        // this delay seems to help avoid issues
     }
 
     /*


### PR DESCRIPTION
Fixes new seeming issue with language detection since JQuery removal.

Missing `data-language` produces `null` now, not `undefined`. Something to watch for in future conversions. I intentionally changed the contruct to `this.language == null` using `==` since `null` does == `undefined` but they are not `===`.

Second commit restricts the mathjax scope and adds a bit of a delay. Especially with multiple problems to render (but sometimes even without them), I can produce unrendered math even before the commit that removed JQuery and introduced the new issue. The fix is kind of ugly, but I don't know how to more gracefully tap into the work that the imported microparsons is doing.