### PR TITLE
Adjust Scratch AC positioning

### DIFF
--- a/bases/rsptx/interactives/runestone/activecode/css/activecode.css
+++ b/bases/rsptx/interactives/runestone/activecode/css/activecode.css
@@ -240,11 +240,12 @@
     /* Hidden by default */
     position: fixed;
     /* Stay in place */
-    z-index: 200;
+    z-index: 9000;
     /* Sit on top */
-    left: 200px;
-    top: 200px;
+    left: calc((100% - 800px) / 2);
     width: 800px;
+    top: 5%;
+    max-height: 90%;
     overflow: auto;
     /* Enable scroll if needed */
     padding: 20px;
@@ -253,9 +254,11 @@
     background-color: var(--background);
 }
 
-.scratch-ac-modal {
-    max-height: 90%;
-    overflow-y: scroll;
+@media (max-width: 960px) {
+    .scratch-ac-modal {
+        width: 90%;
+        left: 5%;
+    }
 }
 
 .ac-modal-body,


### PR DESCRIPTION
The positioning for scratch AC only works in a relatively large viewport.

Mobile:

<img width="225" height="372" alt="2026-02-13 09_05_23-#cs162 _ Chemeketa CS - Discord" src="https://github.com/user-attachments/assets/5f1fd86c-d449-4f29-a2b0-592f2a9260a5" />

Short window on desktop

<img width="804" height="388" alt="2026-02-13 09_05_49-#cs162 _ Chemeketa CS - Discord" src="https://github.com/user-attachments/assets/55f07b54-2b70-4041-acac-935fd33774c0" />


This adjusts the postioning to always be centered and never extend off screen