### PR TITLE
Datafiles: fix where filename is accessed from in constructor

### DIFF
--- a/bases/rsptx/interactives/runestone/datafile/js/datafile.js
+++ b/bases/rsptx/interactives/runestone/datafile/js/datafile.js
@@ -23,6 +23,7 @@ class DataFile extends RunestoneBase {
         this.divid = orig.id;
         this.dataEdit = this.parseBooleanAttribute(orig, "data-edit");
         this.isImage = this.parseBooleanAttribute(orig, "data-isimage");
+        this.fileName = orig.dataset.filename || null;
         this.displayClass = "block"; // Users can specify the non-edit component to be hidden--default is not hidden
         if (this.parseBooleanAttribute(orig, "data-hidden")) {
             this.displayClass = "none";


### PR DESCRIPTION
This bug appears to date back quite a ways.

The `data-filename` is not copied from `orig` to the replacement container that is created by Runestone. Thus the filename is never correctly set.

This impacts livecode's that try to access that filename to use in sending the file to Jobe, but only when the datafile is on the same page. When the datafile is coming from the database, things are fine.