### PR TITLE
Fix PI sync grading issue

### DIFF
--- a/bases/rsptx/web2py_server/applications/runestone/static/js/peer.js
+++ b/bases/rsptx/web2py_server/applications/runestone/static/js/peer.js
@@ -286,7 +286,7 @@ function connect(event) {
                         "Submit";
                     window.componentMap[currentQuestion].enableInteraction();
                     if (typeof studentVoteCount !== "undefined") {
-                        // studentVoteCount += 1;
+                        studentVoteCount += 1;
                         if (studentVoteCount > 2) {
                             studentVoteCount = 2;
                             console.log("WARNING: resetting studentVoteCount to 2");


### PR DESCRIPTION
Fixes sync PI grading issue where students were receiving half credit since ~Feb 17.

studentVoteCount += 1 was accidentally commented out while adding async LLM features, causing vote2 submissions to be tagged as vote1. The grader never detected a second vote, so students who did face-to-face chat (no sendmessage event) received 0.5 instead of full credit.