### PR TITLE
Matching: use queuMathJax instead of typesetPromise

### DIFF
--- a/bases/rsptx/interactives/runestone/matching/js/matching.js
+++ b/bases/rsptx/interactives/runestone/matching/js/matching.js
@@ -61,9 +61,7 @@ export class MatchingProblem extends RunestoneBase {
         this.renderBoxes();
         this.attachEvents();
 
-        if (window.MathJax && MathJax.typesetPromise) {
-            MathJax.typesetPromise();
-        }
+        this.queueMathJax(this.containerDiv);
     }
 
     // required elements for a Runestone component


### PR DESCRIPTION
I believe this should fix:
https://groups.google.com/g/pretext-dev/c/iIy3kSG-WqY/m/9IsTgEPjAgAJ?utm_medium=email&utm_source=footer

And possibly:
https://github.com/RunestoneInteractive/rs/issues/762

I don't believe matching should be triggering a full `typesetPromise` on init. Depending on the timing, this can cause the typeset that is supposed to process the rest of the page to try to convert elements that have already been converted.

Definitely should only target its own content. Not sure about using queueMathJax, but that seems wise too.