### PR TITLE
LTI1p3: update timezone handling to accomodate Canvas change

### DIFF
--- a/bases/rsptx/admin_server_api/routers/lti1p3.py
+++ b/bases/rsptx/admin_server_api/routers/lti1p3.py
@@ -22,6 +22,7 @@ import json
 import uuid
 import os
 import tldextract
+from zoneinfo import ZoneInfo
 
 # Third-party imports
 # -------------------
@@ -42,6 +43,7 @@ import jwt
 # -------------------
 from rsptx.db.models import (
     AuthUserValidator,
+    Courses,
     CoursesValidator,
     Lti1p3Conf,
     Lti1p3User,
@@ -461,7 +463,7 @@ async def launch(request: Request):
         # make sure RS assignment is up to date (e.g. end date)
         course_attributes = await fetch_all_course_attributes(course.id)
         await update_rsassignment_from_lti(
-            rs_assign, assign_lineitem, course_attributes
+            rs_assign, assign_lineitem, course_attributes, course
         )
 
         # start redirect to assignment
@@ -508,14 +510,34 @@ async def update_lti_assignment_record(
 
 
 async def update_rsassignment_from_lti(
-    assign: AssignmentValidator, line_item: LineItem, course_attributes: dict
+    assign: AssignmentValidator,
+    line_item: LineItem,
+    course_attributes: dict,
+    course: Courses,
 ) -> AssignmentValidator:
     """
     Update a runestone assignment from LTI data.
     """
     try:
         lms_due_string = line_item.get_end_date_time()
-        lms_due = datetime.datetime.fromisoformat(lms_due_string)
+        rslogger.info(
+            f"LTI1p3 - Received {lms_due_string} for assignment {assign.name}"
+        )
+
+        # Parse ISO datetime. Normalize trailing Z so fromisoformat can parse UTC.
+        normalized_due_string = (
+            lms_due_string.replace("Z", "+00:00")
+            if lms_due_string.endswith("Z")
+            else lms_due_string
+        )
+        lms_due = datetime.datetime.fromisoformat(normalized_due_string)
+
+        # If LMS provided timezone info and course has a timezone, convert to course local time.
+        if lms_due.tzinfo is not None and course.timezone:
+            lms_due = lms_due.astimezone(ZoneInfo(course.timezone))
+            rslogger.info(
+                f"LTI1p3 - Converted to {lms_due} in timezone {course.timezone}"
+            )
         lms_due = lms_due.replace(tzinfo=None)
         if (
             lms_due is not None
@@ -1125,7 +1147,9 @@ async def assign_select(launch_id: str, request: Request, course=None):
                 )
                 await ags.update_lineitem(line_item)
                 # update RS due date
-                await update_rsassignment_from_lti(assign, line_item, course_attributes)
+                await update_rsassignment_from_lti(
+                    assign, line_item, course_attributes, course
+                )
     deep_link = message_launch.get_deep_link()
     response_html = deep_link.output_response_form(response_list)
     response = HTMLResponse(content=response_html, status_code=200)


### PR DESCRIPTION

This pull request enhances the handling of assignment due dates received from LTI integrations by improving timezone awareness and ensuring due dates are accurately converted to the course's local time. The changes also update function signatures to pass the `course` object where needed for timezone conversion.

**Timezone handling improvements:**

* The `update_rsassignment_from_lti` function now normalizes ISO datetime strings with trailing "Z" (UTC) and, if both the incoming due date and the course have timezone information, converts the due date to the course's local timezone using `ZoneInfo`. Logging has been added for better traceability.

**Function signature and import updates:**

* The `update_rsassignment_from_lti` function signature is updated to accept a `course` parameter, and all calls to this function in `launch` and `assign_select` are updated accordingly. [[1]](diffhunk://#diff-2ae9619df5f402f69e38956e1bbb45f958ae7ba9965bd34c1ce0bd330c163492L464-R466) [[2]](diffhunk://#diff-2ae9619df5f402f69e38956e1bbb45f958ae7ba9965bd34c1ce0bd330c163492L1128-R1152)
* The `Courses` model and `ZoneInfo` are imported to support the new timezone logic. [[1]](diffhunk://#diff-2ae9619df5f402f69e38956e1bbb45f958ae7ba9965bd34c1ce0bd330c163492R25) [[2]](diffhunk://#diff-2ae9619df5f402f69e38956e1bbb45f958ae7ba9965bd34c1ce0bd330c163492R46)