### PR TITLE
Improve CodeTailor dropdown labels for clarity

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/ActiveCodeExercise/ActiveCodeExerciseSettings.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/exercises/components/CreateExercise/components/ActiveCodeExercise/ActiveCodeExerciseSettings.tsx
@@ -18,8 +18,8 @@ interface ActiveCodeExerciseSettingsProps {
 }
 
 const PERSONALIZATION_LEVELS = [
-  { label: "Solution", value: "movable" },
-  { label: "Solution & Block", value: "partial" }
+  { label: "Arrange all blocks", value: "movable" },
+  { label: "Correct blocks locked; arrange incorrect blocks", value: "partial" }
 ];
 
 export const ActiveCodeExerciseSettings: FC<ActiveCodeExerciseSettingsProps> = ({
@@ -96,7 +96,7 @@ export const ActiveCodeExerciseSettings: FC<ActiveCodeExerciseSettingsProps> = (
                 className="w-full"
                 onChange={(e) => handlePersonalizationChange(e.value)}
               />
-              <label htmlFor="parsonspersonalize">Personalization Level</label>
+              <label htmlFor="parsonspersonalize">Personalized blocks to arrange</label>
             </span>
           </div>
 


### PR DESCRIPTION
Replace unclear "Solution" / "Solution & Block" labels with more descriptive descriptions that communicate what students will actually experience in the Personalized Parsons Problem.