### PR TITLE
Synchrnous PI fixes from feedback

### DIFF
--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -1222,7 +1222,6 @@ async def clear_pairs(
 
 
 @router.get("/course_students")
-@instructor_role_required()
 @with_course()
 async def get_course_students(
     request: Request,

--- a/components/rsptx/templates/assignment/instructor/peer_dashboard.html
+++ b/components/rsptx/templates/assignment/instructor/peer_dashboard.html
@@ -241,16 +241,6 @@ Peer Instruction Dashboard - {{ assignment_name }}
     #vote1details summary:hover { color: var(--pi-teal-dark); }
     #vote1details > div { padding: 4px 16px 12px; font-size: 13px; color: var(--af-ink-2); }
 
-    .pi-lineno {
-        display: inline-block;
-        min-width: 2em;
-        color: #999;
-        text-align: right;
-        border-right: 1px solid #ddd;
-        padding-right: 0.5em;
-        margin-right: 0.8em;
-        user-select: none;
-    }
 </style>
 {% endblock %}
 
@@ -588,15 +578,5 @@ Peer Instruction Dashboard - {{ assignment_name }}
         syncActivityFlow();
     }
 
-    setTimeout(function addLineNumbers() {
-        document.querySelectorAll(".oneq pre").forEach(function (pre) {
-            var lines = pre.innerHTML.split("\n");
-            if (lines.length <= 1) return;
-            if (lines[lines.length - 1].trim() === "") lines.pop();
-            pre.innerHTML = lines.map(function (line, i) {
-                return '<span class="pi-lineno">' + (i + 1) + "</span>" + line;
-            }).join("\n");
-        });
-    }, 1000);
 </script>
 {% endblock %}

--- a/components/rsptx/templates/assignment/instructor/peer_dashboard.html
+++ b/components/rsptx/templates/assignment/instructor/peer_dashboard.html
@@ -240,6 +240,17 @@ Peer Instruction Dashboard - {{ assignment_name }}
     #vote1details[open] summary::before { transform: rotate(90deg); }
     #vote1details summary:hover { color: var(--pi-teal-dark); }
     #vote1details > div { padding: 4px 16px 12px; font-size: 13px; color: var(--af-ink-2); }
+
+    .pi-lineno {
+        display: inline-block;
+        min-width: 2em;
+        color: #999;
+        text-align: right;
+        border-right: 1px solid #ddd;
+        padding-right: 0.5em;
+        margin-right: 0.8em;
+        user-select: none;
+    }
 </style>
 {% endblock %}
 
@@ -271,7 +282,6 @@ Peer Instruction Dashboard - {{ assignment_name }}
                     </select>
                 </div>
             </div>
-            <div id="pi-session-status">Vote 1 in Progress</div>
             <div id="pi-assignment-navigation">
                 {% if not is_last %}
                 <button type="submit" id="nextq" class="btn btn-info" name="next" value="Next">Next Question</button>
@@ -577,5 +587,16 @@ Peer Instruction Dashboard - {{ assignment_name }}
         });
         syncActivityFlow();
     }
+
+    setTimeout(function addLineNumbers() {
+        document.querySelectorAll(".oneq pre").forEach(function (pre) {
+            var lines = pre.innerHTML.split("\n");
+            if (lines.length <= 1) return;
+            if (lines[lines.length - 1].trim() === "") lines.pop();
+            pre.innerHTML = lines.map(function (line, i) {
+                return '<span class="pi-lineno">' + (i + 1) + "</span>" + line;
+            }).join("\n");
+        });
+    }, 1000);
 </script>
 {% endblock %}

--- a/components/rsptx/templates/assignment/instructor/peer_dashboard.html
+++ b/components/rsptx/templates/assignment/instructor/peer_dashboard.html
@@ -387,7 +387,10 @@ Peer Instruction Dashboard - {{ assignment_name }}
                 <div class="vote-count-strip">
                     <span class="vote-count-big" id="answerCountDisplay">—</span>
                     <div>
-                        <div class="vote-count-main">answers received</div>
+                        <div class="vote-count-main" id="answerCountLabel">answers received</div>
+                        <div class="vote-count-sub" id="vote1CountLabel" style="display:none">
+                            Vote 1 count: <span id="vote1CountDisplay">—</span>
+                        </div>
                         <div class="vote-count-sub" id="messDisplay" style="display:none">
                             <span id="messNum">0</span> messages sent
                         </div>
@@ -475,6 +478,8 @@ Peer Instruction Dashboard - {{ assignment_name }}
             }
         } else {
             counterel.innerHTML = `<p>Vote ${v} Answers: ${spec.count}</p>`;
+            const vote1Label = document.getElementById('vote1CountLabel');
+            if (vote1Label) vote1Label.style.display = '';
         }
 
         if (spec.mess_count > 0) {

--- a/components/rsptx/templates/assignment/student/peer_question.html
+++ b/components/rsptx/templates/assignment/student/peer_question.html
@@ -108,7 +108,7 @@ Peer Instruction - {{ assignment_name }}
             <div id="group_select_panel" class="col-md-6" style="display: none;">
                 <p><strong>Who did you talk to?</strong> Click to open the dropdown, type a name to search or scroll to select.</p>
                 <select id="assignment_group" multiple class="assignment_partner_select" style="width: 95%">
-                    <option value=""></option>
+                    <option value="" disabled hidden></option>
                 </select>
                 <p style="font-size:12px; color:#6b7280; margin-top:4px;">You can select multiple people.</p>
             </div>

--- a/components/rsptx/templates/assignment/student/peer_question.html
+++ b/components/rsptx/templates/assignment/student/peer_question.html
@@ -31,16 +31,7 @@ Peer Instruction - {{ assignment_name }}
         display: none;
     }
 
-    .pi-lineno {
-        display: inline-block;
-        min-width: 2em;
-        color: #999;
-        text-align: right;
-        border-right: 1px solid #ddd;
-        padding-right: 0.5em;
-        margin-right: 0.8em;
-        user-select: none;
-    }
+
 </style>
 {% endblock %}
 
@@ -215,15 +206,6 @@ Peer Instruction - {{ assignment_name }}
     }
     doIt();
 
-    setTimeout(function addLineNumbers() {
-        document.querySelectorAll(".oneq pre").forEach(function (pre) {
-            var lines = pre.innerHTML.split("\n");
-            if (lines.length <= 1) return;
-            if (lines[lines.length - 1].trim() === "") lines.pop();
-            pre.innerHTML = lines.map(function (line, i) {
-                return '<span class="pi-lineno">' + (i + 1) + "</span>" + line;
-            }).join("\n");
-        });
-    }, 1000);
+
 </script>
 {% endblock %}

--- a/components/rsptx/templates/assignment/student/peer_question.html
+++ b/components/rsptx/templates/assignment/student/peer_question.html
@@ -30,6 +30,17 @@ Peer Instruction - {{ assignment_name }}
     .hidden-content {
         display: none;
     }
+
+    .pi-lineno {
+        display: inline-block;
+        min-width: 2em;
+        color: #999;
+        text-align: right;
+        border-right: 1px solid #ddd;
+        padding-right: 0.5em;
+        margin-right: 0.8em;
+        user-select: none;
+    }
 </style>
 {% endblock %}
 
@@ -104,9 +115,11 @@ Peer Instruction - {{ assignment_name }}
             </div>
 
             <div id="group_select_panel" class="col-md-6" style="display: none;">
-                <p><strong>In person discussion:</strong> select the people in your discussion group.</p>
+                <p><strong>Who did you talk to?</strong> Click to open the dropdown, type a name to search or scroll to select.</p>
                 <select id="assignment_group" multiple class="assignment_partner_select" style="width: 95%">
+                    <option value=""></option>
                 </select>
+                <p style="font-size:12px; color:#6b7280; margin-top:4px;">You can select multiple people.</p>
             </div>
         </div>
     </div>
@@ -201,5 +214,16 @@ Peer Instruction - {{ assignment_name }}
         await setupPeerGroup();
     }
     doIt();
+
+    setTimeout(function addLineNumbers() {
+        document.querySelectorAll(".oneq pre").forEach(function (pre) {
+            var lines = pre.innerHTML.split("\n");
+            if (lines.length <= 1) return;
+            if (lines[lines.length - 1].trim() === "") lines.pop();
+            pre.innerHTML = lines.map(function (line, i) {
+                return '<span class="pi-lineno">' + (i + 1) + "</span>" + line;
+            }).join("\n");
+        });
+    }, 1000);
 </script>
 {% endblock %}

--- a/components/rsptx/templates/common/static_assets.html
+++ b/components/rsptx/templates/common/static_assets.html
@@ -29,6 +29,8 @@ I don't know if any of the following are needed anymore.
 <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.css" rel="stylesheet" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.full.js"></script>
 
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/themes/prism.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-numbers/prism-line-numbers.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/components/prism-core.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/autoloader/prism-autoloader.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-numbers/prism-line-numbers.min.js"

--- a/components/rsptx/templates/staticAssets/js/peer.js
+++ b/components/rsptx/templates/staticAssets/js/peer.js
@@ -592,6 +592,12 @@ async function enableFaceChat(event) {
 function startVote2(event) {
     handleButtonClick(event);
 
+    const vote1CountEl = document.getElementById('vote1CountDisplay');
+    const currentCount = document.getElementById('answerCountDisplay');
+    if (vote1CountEl && currentCount) {
+        vote1CountEl.textContent = currentCount.textContent;
+    }
+
     let butt = document.querySelector("#vote2");
     butt.classList.replace("btn-info", "btn-secondary");
     event.srcElement.disabled = true;

--- a/components/rsptx/templates/staticAssets/js/peer.js
+++ b/components/rsptx/templates/staticAssets/js/peer.js
@@ -333,27 +333,7 @@ function connect(event) {
                 case "enableFaceChat":
                     console.log("got enableFaceChat message");
                     console.log(`group = ${mess.group}`);
-                    let groupList = [];
-                    if (mess.group) {
-                        groupList = mess.group;
-                    }
                     messarea = document.getElementById("imessage");
-                    // Prefer previously-selected partners saved in localStorage.peerList
-                    let peerListCsv = localStorage.getItem("peerList");
-                    let displayPeers = [];
-                    if (peerListCsv) {
-                        let sids = peerListCsv.split(",").map(s => s.trim()).filter(Boolean);
-                        let sel = document.getElementById("assignment_group");
-                        for (let sid of sids) {
-                            let name = sid;
-                            if (sel) {
-                                let opt = sel.querySelector(`option[value="${sid}"]`);
-                                if (opt) name = opt.textContent || opt.innerText || sid;
-                            }
-                            displayPeers.push(name);
-                        }
-                    }
-
                     messarea.innerHTML = `<h3>Current Verbal Discussion Group</h3><p>Please have a verbal discussion with your group, then select who you talked to below.</p>`;
 
                     let facechat = document.getElementById("group_select_panel");

--- a/components/rsptx/templates/staticAssets/js/peer.js
+++ b/components/rsptx/templates/staticAssets/js/peer.js
@@ -236,7 +236,7 @@ function connect(event) {
                                 }
                             } else {
                                 if (getVoteNum() < 2) {
-                                    messarea.innerHTML = `<h3>Please give an explanation for your answer.</h3><p>Then, discuss your answer with your group members.</p>`;
+                                    messarea.innerHTML = `<h3>Wait for your instructor to start the discussion.</h3>`;
                                 } else {
                                     messarea.innerHTML = `<h3>Voting for this question is complete.</h3>`;
                                     let feedbackDiv = document.getElementById(`${currentQuestion}_feedback`);
@@ -354,20 +354,7 @@ function connect(event) {
                         }
                     }
 
-                    if (displayPeers.length > 0) {
-                        messarea.innerHTML = `<h3>Current Verbal Discussion Group</h3><p>Please have a verbal discussion with your selected partners:</p><ul>`;
-                        for (const p of displayPeers) {
-                            messarea.innerHTML += `<li>${p}</li>`;
-                        }
-                        messarea.innerHTML += `</ul>`;
-                    } else {
-                        // fallback to server-provided group list
-                        messarea.innerHTML = `<h3>Current Verbal Discussion Group</h3><p>Please have a verbal discussion with the following group:</p><ul>`;
-                        for (const peer of groupList) {
-                            messarea.innerHTML += `<li>${peer}</li>`;
-                        }
-                        messarea.innerHTML += `</ul>`;
-                    }
+                    messarea.innerHTML = `<h3>Current Verbal Discussion Group</h3><p>Please have a verbal discussion with your group, then select who you talked to below.</p>`;
 
                     let facechat = document.getElementById("group_select_panel");
                     if (facechat) {
@@ -805,7 +792,7 @@ async function setupPeerGroup() {
     }
     // Make the select element searchable with multiple selections
     $('.assignment_partner_select').select2({
-        placeholder: "Select up to 4 team members",
+        placeholder: "Click to search or select by name",
         allowClear: true,
         maximumSelectionLength: 4,
     });


### PR DESCRIPTION
Fixed several sync PI issues from testing feedback:
- Show real student names in the verbal group select dropdown instead of anonymous names
- Fixed premature "discuss" message after vote 1 stops
- Added line numbers to code blocks displayed in PI questions (does not touch the actual questions, just adds them visually during a PI session based on instructor feedback that it makes discussion easier)
- Improved group select placeholder text

Also, some PI pages still seem to route to web2py instead of FastAPI. I think it's because nginx serves /staticAssets/ from the web2py static directory, but if it's something else on my end let me know and I can fix it.