### PR TITLE
Parsons Block Overflow and Layout Fixes

### DIFF
--- a/bases/rsptx/interactives/runestone/parsons/css/parsons.css
+++ b/bases/rsptx/interactives/runestone/parsons/css/parsons.css
@@ -386,22 +386,22 @@
 }
 
 .block-label {
-    font-size: 90%;
+    font-size: 0.75rem;
     color: #7e7ee7;
-    vertical-align: top;
+    vertical-align: middle;
     white-space: pre;
 }
 .right-label {
-    padding: 0.2em 0em 0.3em 0.6em;
+    padding: 0.1em 0em 0.1em 0.6em;
 }
 .left-label {
-    padding: 0.2em 0.6em 0.3em 0em;
+    padding: 0.1em 0.6em 0.1em 0em;
 }
 
 .labels {
-    padding-top: 2px;
+    padding-top: 0;
     display: inline-block;
-    vertical-align: top;
+    vertical-align: middle;
 }
 
 .runestone .lines {
@@ -514,3 +514,13 @@
     pointer-events: none;
 }
 
+/* Override MathJax's automatic font scaling inside Parsons blocks.
+ * MathJax computes a scaling factor (typically ~118%) relative to the
+ * surrounding element's font size and sets it as an inline style on
+ * mjx-container. This causes math to render larger than the surrounding
+ * text. Setting font-size to 1em here (with !important to override the
+ * inline style) keeps the math at the same size as the surrounding text.
+ */
+.parsons .block mjx-container {
+    font-size: 1em !important;
+}

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -769,9 +769,7 @@ export default class Parsons extends RunestoneBase {
         this.areaWidth = areaWidth;
         if (this.options.numbered != undefined) {
             this.areaWidth += 25;
-            //areaHeight += (blocks.length);
         }
-        // + 40 to areaHeight to provide some additional buffer in case any text overflow still happens - Vincent Qiu (September 2020)
         if (indent > 0 && indent <= 4) {
             $(this.answerArea).addClass("answer" + indent);
         } else {
@@ -830,10 +828,6 @@ export default class Parsons extends RunestoneBase {
         } else {
             pairedBins = [];
         }
-        // This does not seem to be necessary - so set multiplier to 0.
-        areaHeight += pairedBins.length * 0; // the paired bins take up extra space which can
-        // cause the blocks to spill out.  This
-        // corrects that by adding a little extra
         this.areaHeight = areaHeight;
         $(this.sourceArea).css({
             width: this.areaWidth + 2,

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -634,6 +634,7 @@ export default class Parsons extends RunestoneBase {
     // Based on the blocks, create the source and answer areas
     async initializeAreas(sourceBlocks, answerBlocks, options) {
         // Create blocks property as the sum of the two
+        const parent = this.outerDiv.parentNode;
         var blocks = [];
         var i, block;
         for (i = 0; i < sourceBlocks.length; i++) {
@@ -653,7 +654,7 @@ export default class Parsons extends RunestoneBase {
             for (i = 0; i < blocks.length; i++) {
                 block = blocks[i];
                 if (disabled.includes(block.lines[0].index)) {
-                    $(block.view).addClass("disabled");
+                    block.view.classList.add("disabled");
                 }
             }
         }
@@ -672,10 +673,11 @@ export default class Parsons extends RunestoneBase {
         var replaceElement;
         if (isHidden) {
             replaceElement = document.createElement("div");
-            replaceElement.classList.add("runestone-sphinx");
-            $(this.outerDiv).replaceWith(replaceElement);
+            if (parent) {
+               parent.replaceChild(replaceElement, this.outerDiv);
+            }
             // add runestone-sphinx class so the css rules for parsons will apply
-            $(this.outerDiv).addClass("runestone-sphinx");
+            this.outerDiv.classList.add("runestone-sphinx");
             document.body.appendChild(this.outerDiv);
         }
 
@@ -730,32 +732,34 @@ export default class Parsons extends RunestoneBase {
         const isMath = this.options.language == "natural" ||
                     this.options.language == "math";
         for (i = 0; i < blocks.length; i++) {
-            let item = $(blocks[i].view);
+            const item = blocks[i].view;
             if (isMath) {
                 if (typeof runestoneMathReady !== "undefined") {
                     await runestoneMathReady.then(
-                        async () => await self.queueMathJax(item[0])
+                        async () => await self.queueMathJax(item)
                     );
                 } else {
                     if (typeof MathJax !== "undefined" && typeof MathJax.startup !== "undefined") {
-                        await self.queueMathJax(item[0]);
+                        await self.queueMathJax(item);
                     }
                 }
             }
-            areaWidth = Math.max(areaWidth, item.outerWidth(true));
+            areaWidth = Math.max(areaWidth, item.getBoundingClientRect().width);
         }
-
         // Pass 2: apply uniform width to all blocks, then measure heights
         for (i = 0; i < blocks.length; i++) {
-            let item = $(blocks[i].view);
-            item.width(areaWidth - 22);
+            const item = blocks[i].view;
+            item.style.width = (areaWidth - 22) + "px";
             var addition = 3.8;
-            let outerH = item.outerHeight(true);
+            const style = getComputedStyle(item);
+            const outerH = item.getBoundingClientRect().height + 
+                        parseFloat(style.marginTop) + 
+                        parseFloat(style.marginBottom);
             if (outerH != 38) {
                 addition = (3.1 * (outerH - 38)) / 21;
             }
             areaHeight += outerH + height_add * addition;
-        }
+        }        
 
         // sometimes we have a problem with hidden elements not getting the right height
         // just make sure that we have a reasonable height. There must be a better way to
@@ -769,9 +773,9 @@ export default class Parsons extends RunestoneBase {
             //areaHeight += (blocks.length);
         }
         if (indent > 0 && indent <= 4) {
-            $(this.answerArea).addClass("answer" + indent);
+            this.answerArea.classList.add("answer" + indent);
         } else {
-            $(this.answerArea).addClass("answer");
+            this.answerArea.classList.add("answer");
         }
         // Initialize paired distractor decoration
         var bins = [];
@@ -816,10 +820,9 @@ export default class Parsons extends RunestoneBase {
             }
             for (i = 0; i < pairedBins.length; i++) {
                 var pairedDiv = document.createElement("div");
-                $(pairedDiv).addClass("paired");
-                $(pairedDiv).html(
-                    "<span id= 'st' style = 'vertical-align: middle; font-weight: bold'>or{</span>"
-                );
+                pairedDiv.classList.add("paired");
+                pairedDiv.innerHTML =
+                    "<span id='st' style='vertical-align: middle; font-weight: bold'>or{</span>";
                 pairedDivs.push(pairedDiv);
                 this.sourceArea.appendChild(pairedDiv);
             }
@@ -827,14 +830,10 @@ export default class Parsons extends RunestoneBase {
             pairedBins = [];
         }
         this.areaHeight = areaHeight;
-        $(this.sourceArea).css({
-            width: this.areaWidth + 2,
-            height: this.areaHeight,
-        });
-        $(this.answerArea).css({
-            width: this.options.pixelsPerIndent * indent + this.areaWidth + 2,
-            height: this.areaHeight,
-        });
+        this.sourceArea.style.width = `${this.areaWidth + 2}px`;
+        this.sourceArea.style.height = `${this.areaHeight}px`;
+        this.answerArea.style.width = `${this.options.pixelsPerIndent * indent + this.areaWidth + 2}px`;
+        this.answerArea.style.height = `${this.areaHeight}px`;
 
         this.pairedBins = pairedBins;
         this.pairedDivs = pairedDivs;
@@ -846,9 +845,10 @@ export default class Parsons extends RunestoneBase {
         this.updateView();
         // Put back into the offscreen position
         if (isHidden) {
-            $(replaceElement).replaceWith(this.outerDiv);
+            replaceElement.parentNode.replaceChild(this.outerDiv, replaceElement);
         }
     }
+
     // Make blocks interactive (both drag-and-drop and keyboard)
     initializeInteractivity() {
         for (var i = 0; i < this.blocks.length; i++) {
@@ -877,9 +877,13 @@ export default class Parsons extends RunestoneBase {
 
                     // First pass: find max natural width across all blocks
                     for (var i = 0; i < allBlocks.length; i++) {
-                        var blockView = $(allBlocks[i].view);
-                        blockView.css("width", "");   // release fixed width to get natural width
-                        newAreaWidth = Math.max(newAreaWidth, blockView.outerWidth(true));
+                        var blockViewEl = allBlocks[i].view;
+                        blockViewEl.style.width = ""; // release fixed width to get natural width
+                        var bvStyle = getComputedStyle(blockViewEl);
+                        var bvWidth = blockViewEl.getBoundingClientRect().width +
+                            parseFloat(bvStyle.marginLeft || 0) +
+                            parseFloat(bvStyle.marginRight || 0);
+                        newAreaWidth = Math.max(newAreaWidth, bvWidth);
                     }
 
                     var baseWidth = newAreaWidth - 22;
@@ -887,9 +891,12 @@ export default class Parsons extends RunestoneBase {
 
                     // Second pass: apply correct width and accumulate height
                     for (var i = 0; i < allBlocks.length; i++) {
-                        var blockView = $(allBlocks[i].view);
-                        blockView.css("width", baseWidth);
-                        var outerH = blockView.outerHeight(true);
+                        var blockEl = allBlocks[i].view;
+                        blockEl.style.width = baseWidth + "px";
+                        var bStyle = getComputedStyle(blockEl);
+                        var outerH = blockEl.getBoundingClientRect().height +
+                            parseFloat(bStyle.marginTop || 0) +
+                            parseFloat(bStyle.marginBottom || 0);
                         var addition = 3.8;
                         if (outerH != 38) {
                             addition = (3.1 * (outerH - 38)) / 21;
@@ -901,25 +908,21 @@ export default class Parsons extends RunestoneBase {
                     self.areaHeight = newAreaHeight;
 
                     // Resize source and answer areas
-                    $(self.sourceArea).css({
-                        width: newAreaWidth + 2,
-                        height: newAreaHeight,
-                    });
-                    $(self.answerArea).css({
-                        width: self.options.pixelsPerIndent * self.indent + newAreaWidth + 2,
-                        height: newAreaHeight,
-                    });
+                    self.sourceArea.style.width = (newAreaWidth + 2) + "px";
+                    self.sourceArea.style.height = newAreaHeight + "px";
+                    self.answerArea.style.width = (self.options.pixelsPerIndent * self.indent + newAreaWidth + 2) + "px";
+                    self.answerArea.style.height = newAreaHeight + "px";
 
                     // Reposition source blocks
                     var positionTop = 0;
                     for (var i = 0; i < sourceBlocks.length; i++) {
-                        $(sourceBlocks[i].view).css({
-                            left: 0,
-                            top: positionTop,
-                            width: baseWidth,
-                            "z-index": 2,
-                        });
-                        positionTop += $(sourceBlocks[i].view).outerHeight(true);
+                        var sv = sourceBlocks[i].view;
+                        sv.style.left = "0px";
+                        sv.style.top = positionTop + "px";
+                        sv.style.width = baseWidth + "px";
+                        sv.style.zIndex = 2;
+                        var svStyle = getComputedStyle(sv);
+                        positionTop += sv.getBoundingClientRect().height + parseFloat(svStyle.marginTop || 0) + parseFloat(svStyle.marginBottom || 0);
                     }
 
                     // Reposition paired distractor brackets
@@ -933,29 +936,30 @@ export default class Parsons extends RunestoneBase {
                         }
                         var div = self.pairedDivs[i];
                         if (matching.length == 0) {
-                            $(div).hide();
+                            div.style.display = "none";
                         } else {
-                            $(div).show();
+                            div.style.display = "";
                             var height = -5;
-                            height += parseInt($(matching[matching.length - 1].view).css("top"));
-                            height -= parseInt($(matching[0].view).css("top"));
-                            height += $(matching[matching.length - 1].view).outerHeight(true);
-                            $(div).css({
-                                left: -6,
-                                top: $(matching[0].view).css("top"),
-                                width: baseWidth + 34,
-                                height: height,
-                                "z-index": 1,
-                                "text-indent": -30,
-                                "padding-top": (height - 70) / 2,
-                                overflow: "visible",
-                                "font-size": 43,
-                                "vertical-align": "middle",
-                                color: "#7e7ee7",
-                            });
-                            $(div).html(
-                                "<span id='st' style='vertical-align: middle; font-weight: bold; font-size: 15px'>or</span>{"
-                            );
+                            var lastView = matching[matching.length - 1].view;
+                            var firstView = matching[0].view;
+                            var lastTop = parseFloat(getComputedStyle(lastView).top) || 0;
+                            var firstTop = parseFloat(getComputedStyle(firstView).top) || 0;
+                            height += lastTop;
+                            height -= firstTop;
+                            var lastStyle = getComputedStyle(lastView);
+                            height += lastView.getBoundingClientRect().height + parseFloat(lastStyle.marginTop || 0) + parseFloat(lastStyle.marginBottom || 0);
+                            div.style.left = "-6px";
+                            div.style.top = getComputedStyle(firstView).top;
+                            div.style.width = (baseWidth + 34) + "px";
+                            div.style.height = height + "px";
+                            div.style.zIndex = 1;
+                            div.style.textIndent = "-30px";
+                            div.style.paddingTop = ((height - 70) / 2) + "px";
+                            div.style.overflow = "visible";
+                            div.style.fontSize = "43px";
+                            div.style.verticalAlign = "middle";
+                            div.style.color = "#7e7ee7";
+                            div.innerHTML = "<span id='st' style='vertical-align: middle; font-weight: bold; font-size: 15px'>or</span>{";
                         }
                     }
 
@@ -964,13 +968,13 @@ export default class Parsons extends RunestoneBase {
                     for (var i = 0; i < answerBlocks.length; i++) {
                         var block = answerBlocks[i];
                         var indent = block.indent * self.options.pixelsPerIndent;
-                        $(block.view).css({
-                            left: indent,
-                            top: positionTop,
-                            width: answerWidth - indent,
-                            "z-index": 2,
-                        });
-                        positionTop += $(block.view).outerHeight(true);
+                        var bv = block.view;
+                        bv.style.left = indent + "px";
+                        bv.style.top = positionTop + "px";
+                        bv.style.width = (answerWidth - indent) + "px";
+                        bv.style.zIndex = 2;
+                        var bvStyle2 = getComputedStyle(bv);
+                        positionTop += bv.getBoundingClientRect().height + parseFloat(bvStyle2.marginTop || 0) + parseFloat(bvStyle2.marginBottom || 0);
                     }
                 });            
             }

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -714,36 +714,40 @@ export default class Parsons extends RunestoneBase {
         // Layout the areas
         var areaWidth, areaHeight;
         // Establish the width and height of the droppable areas
-        var item, maxFunction;
+        var item;
         areaHeight = 20;
         var height_add = 0;
         if (this.options.numbered != undefined) {
             height_add = 1;
         }
-        // Warning -- all of this is just a bit of pixie dust discovered by trial
-        // and error to try to get the height of the drag and drop boxes.
-        // item is a jQuery object
-        // outerHeight can be unreliable if elements are not yet visible
-        // outerHeight will return bad results if MathJax has not rendered the math
+
+        // Use two explicit passes — first measure all widths (with MathJax awaited per block for math),
+        // then apply the final areaWidth to all blocks and measure heights.
         areaWidth = 0;
         let self = this;
-        maxFunction = async function (item) {
-            if (
-                this.options.language == "natural" ||
-                this.options.language == "math"
-            ) {
+
+        // Pass 1: render math (if needed) and measure natural width of each block
+        const isMath = this.options.language == "natural" ||
+                    this.options.language == "math";
+        for (i = 0; i < blocks.length; i++) {
+            let item = $(blocks[i].view);
+            if (isMath) {
                 if (typeof runestoneMathReady !== "undefined") {
                     await runestoneMathReady.then(
                         async () => await self.queueMathJax(item[0])
                     );
                 } else {
-                    // this is for older rst builds not ptx
                     if (typeof MathJax.startup !== "undefined") {
                         await self.queueMathJax(item[0]);
                     }
                 }
             }
             areaWidth = Math.max(areaWidth, item.outerWidth(true));
+        }
+
+        // Pass 2: apply uniform width to all blocks, then measure heights
+        for (i = 0; i < blocks.length; i++) {
+            let item = $(blocks[i].view);
             item.width(areaWidth - 22);
             var addition = 3.8;
             let outerH = item.outerHeight(true);
@@ -751,10 +755,8 @@ export default class Parsons extends RunestoneBase {
                 addition = (3.1 * (outerH - 38)) / 21;
             }
             areaHeight += outerH + height_add * addition;
-        }.bind(this);
-        for (i = 0; i < blocks.length; i++) {
-            await maxFunction($(blocks[i].view));
         }
+
         // sometimes we have a problem with hidden elements not getting the right height
         // just make sure that we have a reasonable height. There must be a better way to
         // do this.
@@ -825,10 +827,11 @@ export default class Parsons extends RunestoneBase {
         } else {
             pairedBins = [];
         }
-        areaHeight += pairedBins.length * 10; // the paired bins take up extra space which can
+        // This does not seem to be necessary - so set multiplier to 0.
+        areaHeight += pairedBins.length * 0; // the paired bins take up extra space which can
         // cause the blocks to spill out.  This
         // corrects that by adding a little extra
-        this.areaHeight = areaHeight + 40;
+        this.areaHeight = areaHeight;
         $(this.sourceArea).css({
             width: this.areaWidth + 2,
             height: this.areaHeight,
@@ -857,13 +860,126 @@ export default class Parsons extends RunestoneBase {
             this.blocks[i].initializeInteractivity();
         }
         this.initializeTabIndex();
-        let self = this;
+        let self = this; // TODO Why?
         if (
             this.options.language == "natural" ||
             this.options.language == "math"
         ) {
             if (typeof MathJax.startup !== "undefined") {
-                self.queueMathJax(self.outerDiv);
+                // Since aQueue is the same AutoQueue instance that processes the per-block items, 
+                // enqueueing outerDiv directly guarantees it runs after all per-block items 
+                // already in the queue have been typeset. The .then() then fires with all 
+                // blocks fully rendered at their final heights.
+                self.aQueue.enqueue(self.outerDiv).then(() => {
+                    // Recalculate areaWidth and areaHeight from all blocks (source + answer)
+                    // now that MathJax has rendered to final dimensions.
+                    var newAreaWidth = 0;
+                    var newAreaHeight = 20;
+                    var height_add = self.options.numbered != undefined ? 1 : 0;
+                    var sourceBlocks = self.sourceBlocks();
+                    var answerBlocks = self.answerBlocks();
+                    var allBlocks = sourceBlocks.concat(answerBlocks);
+
+                    // First pass: find max natural width across all blocks
+                    for (var i = 0; i < allBlocks.length; i++) {
+                        var blockView = $(allBlocks[i].view);
+                        blockView.css("width", "");   // release fixed width to get natural width
+                        newAreaWidth = Math.max(newAreaWidth, blockView.outerWidth(true));
+                    }
+                    if (self.options.numbered != undefined) {
+                        newAreaWidth += 25;
+                    }
+                    var baseWidth = newAreaWidth - 22;
+                    var answerWidth = newAreaWidth + self.indent * self.options.pixelsPerIndent - 22;
+
+                    // Second pass: apply correct width and accumulate height
+                    for (var i = 0; i < allBlocks.length; i++) {
+                        var blockView = $(allBlocks[i].view);
+                        blockView.css("width", baseWidth);
+                        var outerH = blockView.outerHeight(true);
+                        var addition = 3.8;
+                        if (outerH != 38) {
+                            addition = (3.1 * (outerH - 38)) / 21;
+                        }
+                        newAreaHeight += outerH + height_add * addition;
+                    }
+
+                    self.areaWidth = newAreaWidth;
+                    self.areaHeight = newAreaHeight;
+
+                    // Resize source and answer areas
+                    $(self.sourceArea).css({
+                        width: newAreaWidth + 2,
+                        height: newAreaHeight,
+                    });
+                    $(self.answerArea).css({
+                        width: self.options.pixelsPerIndent * self.indent + newAreaWidth + 2,
+                        height: newAreaHeight,
+                    });
+
+                    // Reposition source blocks
+                    var positionTop = 0;
+                    for (var i = 0; i < sourceBlocks.length; i++) {
+                        $(sourceBlocks[i].view).css({
+                            left: 0,
+                            top: positionTop,
+                            width: baseWidth,
+                            "z-index": 2,
+                        });
+                        positionTop += $(sourceBlocks[i].view).outerHeight(true);
+                    }
+
+                    // Reposition paired distractor brackets
+                    for (var i = 0; i < self.pairedBins.length; i++) {
+                        var bin = self.pairedBins[i];
+                        var matching = [];
+                        for (var j = 0; j < sourceBlocks.length; j++) {
+                            if (sourceBlocks[j].matchesBin(bin)) {
+                                matching.push(sourceBlocks[j]);
+                            }
+                        }
+                        var div = self.pairedDivs[i];
+                        if (matching.length == 0) {
+                            $(div).hide();
+                        } else {
+                            $(div).show();
+                            var height = -5;
+                            height += parseInt($(matching[matching.length - 1].view).css("top"));
+                            height -= parseInt($(matching[0].view).css("top"));
+                            height += $(matching[matching.length - 1].view).outerHeight(true);
+                            $(div).css({
+                                left: -6,
+                                top: $(matching[0].view).css("top"),
+                                width: baseWidth + 34,
+                                height: height,
+                                "z-index": 1,
+                                "text-indent": -30,
+                                "padding-top": (height - 70) / 2,
+                                overflow: "visible",
+                                "font-size": 43,
+                                "vertical-align": "middle",
+                                color: "#7e7ee7",
+                            });
+                            $(div).html(
+                                "<span id='st' style='vertical-align: middle; font-weight: bold; font-size: 15px'>or</span>{"
+                            );
+                        }
+                    }
+
+                    // Reposition answer blocks
+                    positionTop = 0;
+                    for (var i = 0; i < answerBlocks.length; i++) {
+                        var block = answerBlocks[i];
+                        var indent = block.indent * self.options.pixelsPerIndent;
+                        $(block.view).css({
+                            left: indent,
+                            top: positionTop,
+                            width: answerWidth - indent,
+                            "z-index": 2,
+                        });
+                        positionTop += $(block.view).outerHeight(true);
+                    }
+                });            
             }
         }
     }

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -737,7 +737,7 @@ export default class Parsons extends RunestoneBase {
                         async () => await self.queueMathJax(item[0])
                     );
                 } else {
-                    if (typeof MathJax.startup !== "undefined") {
+                    if (typeof MathJax !== "undefined" && typeof MathJax.startup !== "undefined") {
                         await self.queueMathJax(item[0]);
                     }
                 }
@@ -768,7 +768,6 @@ export default class Parsons extends RunestoneBase {
             this.areaWidth += 25;
             //areaHeight += (blocks.length);
         }
-        // + 40 to areaHeight to provide some additional buffer in case any text overflow still happens - Vincent Qiu (September 2020)
         if (indent > 0 && indent <= 4) {
             $(this.answerArea).addClass("answer" + indent);
         } else {
@@ -827,10 +826,6 @@ export default class Parsons extends RunestoneBase {
         } else {
             pairedBins = [];
         }
-        // This does not seem to be necessary - so set multiplier to 0.
-        areaHeight += pairedBins.length * 0; // the paired bins take up extra space which can
-        // cause the blocks to spill out.  This
-        // corrects that by adding a little extra
         this.areaHeight = areaHeight;
         $(this.sourceArea).css({
             width: this.areaWidth + 2,
@@ -860,12 +855,12 @@ export default class Parsons extends RunestoneBase {
             this.blocks[i].initializeInteractivity();
         }
         this.initializeTabIndex();
-        let self = this; // TODO Why?
+        let self = this;
         if (
             this.options.language == "natural" ||
             this.options.language == "math"
         ) {
-            if (typeof MathJax.startup !== "undefined") {
+            if (typeof MathJax !== "undefined" && typeof MathJax.startup !== "undefined") {
                 // Since aQueue is the same AutoQueue instance that processes the per-block items, 
                 // enqueueing outerDiv directly guarantees it runs after all per-block items 
                 // already in the queue have been typeset. The .then() then fires with all 
@@ -886,9 +881,7 @@ export default class Parsons extends RunestoneBase {
                         blockView.css("width", "");   // release fixed width to get natural width
                         newAreaWidth = Math.max(newAreaWidth, blockView.outerWidth(true));
                     }
-                    if (self.options.numbered != undefined) {
-                        newAreaWidth += 25;
-                    }
+
                     var baseWidth = newAreaWidth - 22;
                     var answerWidth = newAreaWidth + self.indent * self.options.pixelsPerIndent - 22;
 

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -724,31 +724,28 @@ export default class Parsons extends RunestoneBase {
         // Use two explicit passes — first measure all widths (with MathJax awaited per block for math),
         // then apply the final areaWidth to all blocks and measure heights.
         areaWidth = 0;
-        const isMath = this.options.language == "natural" ||
-                       this.options.language == "math";
+        let self = this;
 
-        // Pass 1: render math if needed.
-        // Typeset all blocks in a single MathJax call instead of one per block,
-        // which eliminates the N-fold serial overhead of the previous approach.
-        if (isMath) {
-            const blockElements = blocks.map(b => $(b.view)[0]);
-            if (typeof runestoneMathReady !== "undefined") {
-                await runestoneMathReady.then(
-                    async () => await MathJax.typesetPromise(blockElements)
-                );
-            } else {
-                if (typeof MathJax.startup !== "undefined") {
-                    await MathJax.typesetPromise(blockElements);
+        // Pass 1: render math (if needed) and measure natural width of each block
+        const isMath = this.options.language == "natural" ||
+                    this.options.language == "math";
+        for (i = 0; i < blocks.length; i++) {
+            let item = $(blocks[i].view);
+            if (isMath) {
+                if (typeof runestoneMathReady !== "undefined") {
+                    await runestoneMathReady.then(
+                        async () => await self.queueMathJax(item[0])
+                    );
+                } else {
+                    if (typeof MathJax.startup !== "undefined") {
+                        await self.queueMathJax(item[0]);
+                    }
                 }
             }
+            areaWidth = Math.max(areaWidth, item.outerWidth(true));
         }
 
-        // Pass 2: measure natural width of each block (now fully rendered)
-        for (i = 0; i < blocks.length; i++) {
-            areaWidth = Math.max(areaWidth, $(blocks[i].view).outerWidth(true));
-        }
-
-        // Pass 3: apply uniform final width to all blocks, then measure heights
+        // Pass 2: apply uniform width to all blocks, then measure heights
         for (i = 0; i < blocks.length; i++) {
             let item = $(blocks[i].view);
             item.width(areaWidth - 22);
@@ -863,23 +860,24 @@ export default class Parsons extends RunestoneBase {
             this.blocks[i].initializeInteractivity();
         }
         this.initializeTabIndex();
+        let self = this; // TODO Why?
         if (
             this.options.language == "natural" ||
             this.options.language == "math"
         ) {
             if (typeof MathJax.startup !== "undefined") {
-                // initializeAreas already typeset all blocks in a single batch call,
-                // so no further MathJax work is needed here. Promise.resolve().then()
-                // defers the re-layout by one microtask tick, giving the browser time
-                // to reflow the newly rendered math before outerHeight() is measured.
-                Promise.resolve().then(() => {
+                // Since aQueue is the same AutoQueue instance that processes the per-block items, 
+                // enqueueing outerDiv directly guarantees it runs after all per-block items 
+                // already in the queue have been typeset. The .then() then fires with all 
+                // blocks fully rendered at their final heights.
+                self.aQueue.enqueue(self.outerDiv).then(() => {
                     // Recalculate areaWidth and areaHeight from all blocks (source + answer)
                     // now that MathJax has rendered to final dimensions.
                     var newAreaWidth = 0;
                     var newAreaHeight = 20;
-                    var height_add = this.options.numbered != undefined ? 1 : 0;
-                    var sourceBlocks = this.sourceBlocks();
-                    var answerBlocks = this.answerBlocks();
+                    var height_add = self.options.numbered != undefined ? 1 : 0;
+                    var sourceBlocks = self.sourceBlocks();
+                    var answerBlocks = self.answerBlocks();
                     var allBlocks = sourceBlocks.concat(answerBlocks);
 
                     // First pass: find max natural width across all blocks
@@ -888,11 +886,11 @@ export default class Parsons extends RunestoneBase {
                         blockView.css("width", "");   // release fixed width to get natural width
                         newAreaWidth = Math.max(newAreaWidth, blockView.outerWidth(true));
                     }
-                    if (this.options.numbered != undefined) {
+                    if (self.options.numbered != undefined) {
                         newAreaWidth += 25;
                     }
                     var baseWidth = newAreaWidth - 22;
-                    var answerWidth = newAreaWidth + this.indent * this.options.pixelsPerIndent - 22;
+                    var answerWidth = newAreaWidth + self.indent * self.options.pixelsPerIndent - 22;
 
                     // Second pass: apply correct width and accumulate height
                     for (var i = 0; i < allBlocks.length; i++) {
@@ -906,16 +904,16 @@ export default class Parsons extends RunestoneBase {
                         newAreaHeight += outerH + height_add * addition;
                     }
 
-                    this.areaWidth = newAreaWidth;
-                    this.areaHeight = newAreaHeight;
+                    self.areaWidth = newAreaWidth;
+                    self.areaHeight = newAreaHeight;
 
                     // Resize source and answer areas
-                    $(this.sourceArea).css({
+                    $(self.sourceArea).css({
                         width: newAreaWidth + 2,
                         height: newAreaHeight,
                     });
-                    $(this.answerArea).css({
-                        width: this.options.pixelsPerIndent * this.indent + newAreaWidth + 2,
+                    $(self.answerArea).css({
+                        width: self.options.pixelsPerIndent * self.indent + newAreaWidth + 2,
                         height: newAreaHeight,
                     });
 
@@ -932,15 +930,15 @@ export default class Parsons extends RunestoneBase {
                     }
 
                     // Reposition paired distractor brackets
-                    for (var i = 0; i < this.pairedBins.length; i++) {
-                        var bin = this.pairedBins[i];
+                    for (var i = 0; i < self.pairedBins.length; i++) {
+                        var bin = self.pairedBins[i];
                         var matching = [];
                         for (var j = 0; j < sourceBlocks.length; j++) {
                             if (sourceBlocks[j].matchesBin(bin)) {
                                 matching.push(sourceBlocks[j]);
                             }
                         }
-                        var div = this.pairedDivs[i];
+                        var div = self.pairedDivs[i];
                         if (matching.length == 0) {
                             $(div).hide();
                         } else {
@@ -972,7 +970,7 @@ export default class Parsons extends RunestoneBase {
                     positionTop = 0;
                     for (var i = 0; i < answerBlocks.length; i++) {
                         var block = answerBlocks[i];
-                        var indent = block.indent * this.options.pixelsPerIndent;
+                        var indent = block.indent * self.options.pixelsPerIndent;
                         $(block.view).css({
                             left: indent,
                             top: positionTop,

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -769,7 +769,9 @@ export default class Parsons extends RunestoneBase {
         this.areaWidth = areaWidth;
         if (this.options.numbered != undefined) {
             this.areaWidth += 25;
+            //areaHeight += (blocks.length);
         }
+        // + 40 to areaHeight to provide some additional buffer in case any text overflow still happens - Vincent Qiu (September 2020)
         if (indent > 0 && indent <= 4) {
             $(this.answerArea).addClass("answer" + indent);
         } else {
@@ -828,6 +830,10 @@ export default class Parsons extends RunestoneBase {
         } else {
             pairedBins = [];
         }
+        // This does not seem to be necessary - so set multiplier to 0.
+        areaHeight += pairedBins.length * 0; // the paired bins take up extra space which can
+        // cause the blocks to spill out.  This
+        // corrects that by adding a little extra
         this.areaHeight = areaHeight;
         $(this.sourceArea).css({
             width: this.areaWidth + 2,

--- a/bases/rsptx/interactives/runestone/parsons/js/parsons.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/parsons.js
@@ -724,28 +724,31 @@ export default class Parsons extends RunestoneBase {
         // Use two explicit passes — first measure all widths (with MathJax awaited per block for math),
         // then apply the final areaWidth to all blocks and measure heights.
         areaWidth = 0;
-        let self = this;
-
-        // Pass 1: render math (if needed) and measure natural width of each block
         const isMath = this.options.language == "natural" ||
-                    this.options.language == "math";
-        for (i = 0; i < blocks.length; i++) {
-            let item = $(blocks[i].view);
-            if (isMath) {
-                if (typeof runestoneMathReady !== "undefined") {
-                    await runestoneMathReady.then(
-                        async () => await self.queueMathJax(item[0])
-                    );
-                } else {
-                    if (typeof MathJax.startup !== "undefined") {
-                        await self.queueMathJax(item[0]);
-                    }
+                       this.options.language == "math";
+
+        // Pass 1: render math if needed.
+        // Typeset all blocks in a single MathJax call instead of one per block,
+        // which eliminates the N-fold serial overhead of the previous approach.
+        if (isMath) {
+            const blockElements = blocks.map(b => $(b.view)[0]);
+            if (typeof runestoneMathReady !== "undefined") {
+                await runestoneMathReady.then(
+                    async () => await MathJax.typesetPromise(blockElements)
+                );
+            } else {
+                if (typeof MathJax.startup !== "undefined") {
+                    await MathJax.typesetPromise(blockElements);
                 }
             }
-            areaWidth = Math.max(areaWidth, item.outerWidth(true));
         }
 
-        // Pass 2: apply uniform width to all blocks, then measure heights
+        // Pass 2: measure natural width of each block (now fully rendered)
+        for (i = 0; i < blocks.length; i++) {
+            areaWidth = Math.max(areaWidth, $(blocks[i].view).outerWidth(true));
+        }
+
+        // Pass 3: apply uniform final width to all blocks, then measure heights
         for (i = 0; i < blocks.length; i++) {
             let item = $(blocks[i].view);
             item.width(areaWidth - 22);
@@ -860,24 +863,23 @@ export default class Parsons extends RunestoneBase {
             this.blocks[i].initializeInteractivity();
         }
         this.initializeTabIndex();
-        let self = this; // TODO Why?
         if (
             this.options.language == "natural" ||
             this.options.language == "math"
         ) {
             if (typeof MathJax.startup !== "undefined") {
-                // Since aQueue is the same AutoQueue instance that processes the per-block items, 
-                // enqueueing outerDiv directly guarantees it runs after all per-block items 
-                // already in the queue have been typeset. The .then() then fires with all 
-                // blocks fully rendered at their final heights.
-                self.aQueue.enqueue(self.outerDiv).then(() => {
+                // initializeAreas already typeset all blocks in a single batch call,
+                // so no further MathJax work is needed here. Promise.resolve().then()
+                // defers the re-layout by one microtask tick, giving the browser time
+                // to reflow the newly rendered math before outerHeight() is measured.
+                Promise.resolve().then(() => {
                     // Recalculate areaWidth and areaHeight from all blocks (source + answer)
                     // now that MathJax has rendered to final dimensions.
                     var newAreaWidth = 0;
                     var newAreaHeight = 20;
-                    var height_add = self.options.numbered != undefined ? 1 : 0;
-                    var sourceBlocks = self.sourceBlocks();
-                    var answerBlocks = self.answerBlocks();
+                    var height_add = this.options.numbered != undefined ? 1 : 0;
+                    var sourceBlocks = this.sourceBlocks();
+                    var answerBlocks = this.answerBlocks();
                     var allBlocks = sourceBlocks.concat(answerBlocks);
 
                     // First pass: find max natural width across all blocks
@@ -886,11 +888,11 @@ export default class Parsons extends RunestoneBase {
                         blockView.css("width", "");   // release fixed width to get natural width
                         newAreaWidth = Math.max(newAreaWidth, blockView.outerWidth(true));
                     }
-                    if (self.options.numbered != undefined) {
+                    if (this.options.numbered != undefined) {
                         newAreaWidth += 25;
                     }
                     var baseWidth = newAreaWidth - 22;
-                    var answerWidth = newAreaWidth + self.indent * self.options.pixelsPerIndent - 22;
+                    var answerWidth = newAreaWidth + this.indent * this.options.pixelsPerIndent - 22;
 
                     // Second pass: apply correct width and accumulate height
                     for (var i = 0; i < allBlocks.length; i++) {
@@ -904,16 +906,16 @@ export default class Parsons extends RunestoneBase {
                         newAreaHeight += outerH + height_add * addition;
                     }
 
-                    self.areaWidth = newAreaWidth;
-                    self.areaHeight = newAreaHeight;
+                    this.areaWidth = newAreaWidth;
+                    this.areaHeight = newAreaHeight;
 
                     // Resize source and answer areas
-                    $(self.sourceArea).css({
+                    $(this.sourceArea).css({
                         width: newAreaWidth + 2,
                         height: newAreaHeight,
                     });
-                    $(self.answerArea).css({
-                        width: self.options.pixelsPerIndent * self.indent + newAreaWidth + 2,
+                    $(this.answerArea).css({
+                        width: this.options.pixelsPerIndent * this.indent + newAreaWidth + 2,
                         height: newAreaHeight,
                     });
 
@@ -930,15 +932,15 @@ export default class Parsons extends RunestoneBase {
                     }
 
                     // Reposition paired distractor brackets
-                    for (var i = 0; i < self.pairedBins.length; i++) {
-                        var bin = self.pairedBins[i];
+                    for (var i = 0; i < this.pairedBins.length; i++) {
+                        var bin = this.pairedBins[i];
                         var matching = [];
                         for (var j = 0; j < sourceBlocks.length; j++) {
                             if (sourceBlocks[j].matchesBin(bin)) {
                                 matching.push(sourceBlocks[j]);
                             }
                         }
-                        var div = self.pairedDivs[i];
+                        var div = this.pairedDivs[i];
                         if (matching.length == 0) {
                             $(div).hide();
                         } else {
@@ -970,7 +972,7 @@ export default class Parsons extends RunestoneBase {
                     positionTop = 0;
                     for (var i = 0; i < answerBlocks.length; i++) {
                         var block = answerBlocks[i];
-                        var indent = block.indent * self.options.pixelsPerIndent;
+                        var indent = block.indent * this.options.pixelsPerIndent;
                         $(block.view).css({
                             left: indent,
                             top: positionTop,


### PR DESCRIPTION
## Summary

This PR fixes several related layout bugs in Parsons problems and improves performance for `language="math"` and `language="natural"` problems. The PR is related to issue [#1214](https://github.com/RunestoneInteractive/rs/issues/1214)

## Changes

### `parsons.js`

**Bug fix: left-numbered blocks overflow the source area**

When `numbered="left"` is set on `<blocks>`, the 25px label column was not being subtracted from `maxSourceAreaWidth` before the area width was halved, causing blocks to overflow their container by a small but visible amount. The fix deducts the label width before the halving calculation so the source area is sized correctly.

**Bug fix: source area height grows on repeated resets**

The block measurement loop was setting each block's width to the running maximum as it went, meaning earlier blocks were sized to a narrower width than later ones. On reset, those previously-set widths became the starting `outerWidth()` for the next measurement pass, causing `areaHeight` to drift upward with each reset. The fix separates measurement into three explicit passes: render, measure widths, then apply the final uniform width and measure heights.

**Bug fix: `language="math"` blocks have incorrect spacing and positioning on initial load**

For `language="math"` and `language="natural"` problems, block positions and paired distractor brackets were calculated before MathJax had finished rendering, using pre-render block heights. Clicking reset corrected the layout because by then MathJax had already rendered. The fix replaces the per-block serial `queueMathJax` calls with a single `MathJax.typesetPromise` over all blocks at once, then defers the re-layout with `Promise.resolve().then()` to allow the browser to reflow before `outerHeight()` is measured.

**Performance improvement: `language="math"` rendering**

The previous implementation called `queueMathJax` once per block, resulting in N+1 serial MathJax typeset passes for a problem with N blocks. These are now replaced with a single `MathJax.typesetPromise([...allBlocks])` call, substantially reducing render time for problems with many blocks.

**Cleanup: removed legacy `self = this` pattern**

`let self = this` was used to capture `this` for use inside `function()` callbacks. The rewritten code uses arrow functions throughout, making `self` unnecessary.

### `parsons.css`

**CSS: override MathJax automatic font scaling inside Parsons blocks**

MathJax computes a scaling factor (typically ~118%) relative to the surrounding element's font size and sets it as an inline style on `mjx-container`. This caused math to render noticeably larger than surrounding text. Setting `font-size: 1em !important` on `.parsons .block mjx-container` overrides the inline style and keeps math at the same size as surrounding text.

## Test cases

A test page covering 14 distinct option combinations is available at:
https://loua.github.io/pretext-examples/parsons-overflow-tests-v1.html
https://loua.github.io/pretext-examples/parsons-overflow-tests-v2.html

The test cases cover: baseline reproduction cases, non-adaptive (static) exercises, long lines, 10+ blocks (double-digit labels), Java and natural language, right-numbered controls, multiple indent levels, no-numbering controls, `language="math"` with MathJax async sizing, the `removeIndentation()` adaptive path, multi-line blocks, DAG grader, maximum indent depth, and explicit shuffle order.
