### PR TITLE
Extract A/B verbal-cluster splitting into a testable helper

### DIFF
--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -627,6 +627,92 @@ async def get_peer_async(
     return templates.TemplateResponse("assignment/student/peer_async.html", context)
 
 
+def split_ab_conditions(
+    answerers: list[str],
+    in_person_groups: list[set[str]],
+    rng: random.Random = random,
+) -> tuple[list[str], list[str]]:
+    """Split answering students into the verbal (in-person) and chat conditions
+    for an A/B peer-instruction experiment.
+
+    Students recorded in the same verbal-discussion group share a single
+    condition so that verbal partners are never split into text chat. The full
+    recorded group is kept, including partners who did not vote on this question,
+    so a non-voting partner is still assigned the same condition.
+
+    :param answerers: students who voted on this question, in the order they
+        should be considered when forming clusters (callers typically shuffle).
+    :param in_person_groups: recorded verbal-discussion groups, each a set of
+        student ids, derived from prior ``peergroup`` useinfo events.
+    :param rng: random source; injectable so tests can pass a seeded
+        ``random.Random`` for deterministic results. Defaults to the module's
+        ``random``.
+    :return: ``(peeps_in_person, peeps_in_chat)`` — disjoint lists of student
+        ids assigned to the verbal and chat conditions respectively.
+    """
+
+    def find_set_containing_string(
+        list_of_sets: list[set[str]], target: str
+    ) -> set[str]:
+        result: set[str] = set()
+        for s in list_of_sets:
+            if target in s:
+                result |= s
+        return result
+
+    # Group the answering students into their recorded verbal-discussion
+    # clusters. A cluster is assigned to a condition as a whole and is never
+    # split, because verbal discussion depends on physical seating.
+    clusters: list[list[str]] = []
+    clustered: set[str] = set()
+    for p in answerers:
+        if p in clustered:
+            continue
+        # Keep the full recorded verbal group, including partners who did not
+        # vote on this question. Students should stay in the same condition as
+        # their verbal partners so they aren't split into text chat. Subtract
+        # already-clustered students so clusters stay disjoint when recorded
+        # groups overlap.
+        grp = set(find_set_containing_string(in_person_groups, p))
+        grp -= clustered
+        grp.add(p)
+        clustered |= grp
+        clusters.append(sorted(grp))
+
+    # Assign clusters to conditions with an approximately balanced (~50/50)
+    # split rather than an independent per-cluster coin flip. Shuffle for
+    # randomness, then use a greedy algorithm to place each cluster into
+    # whichever condition currently has fewer students. Singletons (no recorded
+    # verbal partner) can only go to text chat, since they have no one to
+    # discuss with verbally.
+    rng.shuffle(clusters)
+    peeps_in_person: list[str] = []
+    peeps_in_chat: list[str] = []
+    for grp in clusters:
+        if len(grp) == 1:
+            peeps_in_chat.extend(grp)
+            continue
+        if len(peeps_in_person) <= len(peeps_in_chat):
+            peeps_in_person.extend(grp)
+        else:
+            peeps_in_chat.extend(grp)
+
+    # Make sure there is at least one student in each condition whenever that is
+    # actually possible (i.e. there is more than one cluster, or a multi-person
+    # cluster exists to seed the verbal side).
+    multi_clusters = [g for g in clusters if len(g) > 1]
+    if not peeps_in_person and multi_clusters:
+        promote = multi_clusters[0]
+        peeps_in_chat = [s for s in peeps_in_chat if s not in promote]
+        peeps_in_person.extend(promote)
+    if not peeps_in_chat and len(clusters) > 1:
+        demote = clusters[-1]
+        peeps_in_person = [s for s in peeps_in_person if s not in demote]
+        peeps_in_chat.extend(demote)
+
+    return peeps_in_person, peeps_in_chat
+
+
 # API Endpoints
 # =============
 
@@ -698,61 +784,13 @@ async def make_pairs(
                 except Exception:  # defensive; malformed rows shouldn't break pairing
                     continue
 
-            def find_set_containing_string(
-                list_of_sets: list[set[str]], target: str
-            ) -> set[str]:
-                result: set[str] = set()
-                for s in list_of_sets:
-                    if target in s:
-                        result |= s
-                return result
-
-            # Group the answering students into their recorded verbal-discussion
-            # clusters. A cluster is assigned to a condition as a whole and is
-            # never split, because verbal discussion depends on physical seating.
+            # Group answering students into their recorded verbal clusters and
+            # split those clusters across the two conditions. See
+            # split_ab_conditions for the clustering and balancing rules.
             answerers = [p for p in peeps if p in sid_ans]
-            clusters: list[list[str]] = []
-            clustered: set[str] = set()
-            for p in answerers:
-                if p in clustered:
-                    continue
-                # Keep the full recorded verbal group, including partners who did
-                # not vote on this question. Students should stay in the same condition
-                # as their verbal partners so they aren't split into text chat.
-                grp = set(find_set_containing_string(in_person_groups, p))
-                grp -= clustered
-                grp.add(p)
-                clustered |= grp
-                clusters.append(sorted(grp))
-
-            # Assign clusters to conditions with an approximately balanced (~50/50)
-            # split rather than an independent per-cluster coin flip. Shuffle for randomness, then use greedy algorithm to place
-            # each cluster into whichever condition currently has fewer students.
-            # Singletons (no recorded verbal partner) can only go to text chat,
-            # since they have no one to discuss with verbally.
-            random.shuffle(clusters)
-            peeps_in_chat: list[str] = []
-            for grp in clusters:
-                if len(grp) == 1:
-                    peeps_in_chat.extend(grp)
-                    continue
-                if len(peeps_in_person) <= len(peeps_in_chat):
-                    peeps_in_person.extend(grp)
-                else:
-                    peeps_in_chat.extend(grp)
-
-            # make sure that  at least one student in each condition whenever
-            # that is actually possible (i.e. there is more than one cluster, or a
-            # multi-person cluster exists to seed the verbal side).
-            multi_clusters = [g for g in clusters if len(g) > 1]
-            if not peeps_in_person and multi_clusters:
-                promote = multi_clusters[0]
-                peeps_in_chat = [s for s in peeps_in_chat if s not in promote]
-                peeps_in_person.extend(promote)
-            if not peeps_in_chat and len(clusters) > 1:
-                demote = clusters[-1]
-                peeps_in_person = [s for s in peeps_in_person if s not in demote]
-                peeps_in_chat.extend(demote)
+            peeps_in_person, peeps_in_chat = split_ab_conditions(
+                answerers, in_person_groups
+            )
 
             peeps = [p for p in peeps_in_chat if p in sid_ans]
             rslogger.debug(f"FINAL PEEPS IN CHAT = {peeps}")

--- a/test/bases/rsptx/assignment_server_api/test_make_pairs.py
+++ b/test/bases/rsptx/assignment_server_api/test_make_pairs.py
@@ -1,0 +1,133 @@
+"""
+Unit tests for ``split_ab_conditions`` — the verbal-cluster / A-B condition
+splitting helper extracted from ``make_pairs``.
+
+The helper is a pure function (no DB, no async), so these tests import it
+directly and pass a seeded ``random.Random`` for deterministic results.
+"""
+
+import random
+
+from rsptx.assignment_server_api.routers.peer import split_ab_conditions
+
+
+def _group_of(sid, peeps_in_person, peeps_in_chat):
+    """Return 'person', 'chat', or None for where ``sid`` landed."""
+    if sid in peeps_in_person:
+        return "person"
+    if sid in peeps_in_chat:
+        return "chat"
+    return None
+
+
+def _assert_partition(answerers, in_person_groups, peeps_in_person, peeps_in_chat):
+    """Common invariants: the result is a disjoint partition with no dups, and
+    every answerer is placed somewhere."""
+    assert not (
+        set(peeps_in_person) & set(peeps_in_chat)
+    ), "conditions must be disjoint"
+    assert len(peeps_in_person) == len(set(peeps_in_person)), "no dup in person"
+    assert len(peeps_in_chat) == len(set(peeps_in_chat)), "no dup in chat"
+    for a in answerers:
+        assert _group_of(a, peeps_in_person, peeps_in_chat) is not None
+
+
+def test_singletons_go_to_chat():
+    """Students with no recorded verbal partner can only go to text chat."""
+    answerers = ["A", "B"]
+    person, chat = split_ab_conditions(answerers, [], rng=random.Random(0))
+    assert person == []
+    assert sorted(chat) == ["A", "B"]
+
+
+def test_nonvoting_partner_kept_in_same_condition():
+    """A recorded verbal partner who did not vote is still assigned the same
+    condition as the voter, never split into text chat."""
+    answerers = ["A"]  # B is in A's verbal group but did not vote
+    in_person_groups = [{"A", "B"}]
+    person, chat = split_ab_conditions(
+        answerers, in_person_groups, rng=random.Random(0)
+    )
+    # A single multi-person cluster: both land in the verbal condition together.
+    assert sorted(person) == ["A", "B"]
+    assert chat == []
+    assert _group_of("A", person, chat) == _group_of("B", person, chat)
+
+
+def test_verbal_partners_share_a_condition():
+    """Every member of a recorded verbal group ends up in the same condition."""
+    in_person_groups = [{"A", "B"}, {"C", "D"}]
+    answerers = ["A", "B", "C", "D"]
+    person, chat = split_ab_conditions(
+        answerers, in_person_groups, rng=random.Random(1)
+    )
+    _assert_partition(answerers, in_person_groups, person, chat)
+    for grp in in_person_groups:
+        conditions = {_group_of(s, person, chat) for s in grp}
+        assert len(conditions) == 1, f"group {grp} was split across conditions"
+
+
+def test_overlapping_groups_stay_disjoint():
+    """Overlapping recorded groups must not duplicate a student across clusters
+    or conditions (the ``grp -= clustered`` guard)."""
+    in_person_groups = [{"A", "B"}, {"B", "C"}]
+    answerers = ["A", "B", "C"]
+    person, chat = split_ab_conditions(
+        answerers, in_person_groups, rng=random.Random(2)
+    )
+    _assert_partition(answerers, in_person_groups, person, chat)
+    assert sorted(person + chat) == ["A", "B", "C"]
+    # A and B were seeded together; they must share a condition.
+    assert _group_of("A", person, chat) == _group_of("B", person, chat)
+
+
+def test_at_least_one_in_each_condition_when_possible():
+    """With two multi-person clusters, both conditions are populated."""
+    in_person_groups = [{"A", "B"}, {"C", "D"}]
+    answerers = ["A", "B", "C", "D"]
+    person, chat = split_ab_conditions(
+        answerers, in_person_groups, rng=random.Random(3)
+    )
+    assert person, "verbal condition should not be empty"
+    assert chat, "chat condition should not be empty"
+
+
+def test_single_multi_cluster_not_left_chat_only():
+    """A lone multi-person cluster seeds the verbal side rather than going to
+    chat, so the verbal condition is never empty when it could be populated."""
+    in_person_groups = [{"A", "B", "C"}]
+    answerers = ["A", "B", "C"]
+    person, chat = split_ab_conditions(
+        answerers, in_person_groups, rng=random.Random(4)
+    )
+    assert sorted(person) == ["A", "B", "C"]
+    assert chat == []
+
+
+def test_balanced_split_across_many_groups():
+    """Greedy placement keeps the two conditions roughly balanced in size."""
+    in_person_groups = [{f"s{i}", f"s{i}b"} for i in range(10)]
+    answerers = [s for grp in in_person_groups for s in grp]
+    person, chat = split_ab_conditions(
+        answerers, in_person_groups, rng=random.Random(5)
+    )
+    _assert_partition(answerers, in_person_groups, person, chat)
+    # 10 two-person clusters, 20 students; greedy keeps the halves within one
+    # cluster (2 students) of each other.
+    assert abs(len(person) - len(chat)) <= 2
+
+
+def test_deterministic_with_seeded_rng():
+    """Same inputs + same seed produce identical output."""
+    in_person_groups = [{"A", "B"}, {"C", "D"}, {"E"}]
+    answerers = ["A", "B", "C", "D", "E"]
+    r1 = split_ab_conditions(answerers, in_person_groups, rng=random.Random(7))
+    r2 = split_ab_conditions(answerers, in_person_groups, rng=random.Random(7))
+    assert r1 == r2
+
+
+def test_empty_input():
+    """No answerers yields two empty conditions."""
+    person, chat = split_ab_conditions([], [], rng=random.Random(0))
+    assert person == []
+    assert chat == []


### PR DESCRIPTION
## Summary

Follow-up to the `ab-fixes` merge. The A/B verbal-cluster building and
condition-balancing logic was inline inside the `make_pairs` request handler,
which made it impossible to unit test (it needs a DB, auth, and a live request).
This PR extracts that logic into a pure `split_ab_conditions()` function and
adds unit tests.

**No behavior change** in `make_pairs` — the inline block is replaced by a call
to the new helper.

## What changed

- `split_ab_conditions(answerers, in_person_groups, rng=random)` returns the
  `(peeps_in_person, peeps_in_chat)` partition. It contains the cluster-building
  (`find_set_containing_string` + `grp -= clustered`), greedy ~50/50 balancing,
  and the "seed each condition when possible" adjustment.
- Randomness is injectable via the `rng` parameter so tests can pass a seeded
  `random.Random` for deterministic results.
- `make_pairs` now calls the helper instead of inlining ~55 lines.

## Tests

New `test/bases/rsptx/assignment_server_api/test_make_pairs.py` (9 tests,
pure/sync, no DB) covering:

- singletons (no verbal partner) go to chat
- a non-voting recorded partner stays in the same condition as the voter
- recorded verbal groups are never split across conditions
- overlapping recorded groups stay disjoint with no duplicates (the
  `grp -= clustered` guard)
- both conditions are populated when possible
- a lone multi-person cluster seeds the verbal side
- greedy placement keeps the two conditions roughly balanced
- determinism with a seeded rng

All 9 pass; `black`/`flake8` clean on the changed files; assignment service
rebuild (`uv run build -s assignment dev`) passes including the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)