### PR TITLE
Fix/1259 pi websocket state

### DIFF
--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -222,6 +222,7 @@ async def get_peer_dashboard(
             "course_name": course.course_name,
         }
         r.publish("peermessages", json.dumps(mess))
+        r.hset(f"{course.course_name}_state", "current_phase", json.dumps(mess))
     except Exception as e:
         rslogger.error(f"Error initializing Redis: {e}")
 
@@ -883,6 +884,15 @@ async def make_pairs(
             }
             r.publish("peermessages", json.dumps(mess))
 
+        # Store current phase so reconnecting students can catch up (see /api/current_state).
+        # Partner data is per-student and is in partnerdb
+        phase_key = "enableFaceChat" if (is_ab and peeps_in_person) else "enableChat"
+        r.hset(
+            f"{course.course_name}_state",
+            "current_phase",
+            json.dumps({"type": "control", "message": phase_key, "broadcast": False, "course_name": course.course_name}),
+        )
+
         # If doing A/B, also send face-chat groups based on in-person groups
         if is_ab and peeps_in_person:
             # Build a map of username -> full name for this course
@@ -1209,6 +1219,12 @@ async def publish_message(
         r = redis.from_url(os.environ.get("REDIS_URI", "redis://redis:6379/0"))
         r.publish("peermessages", json.dumps(data))
 
+        # Store phase-change control messages so reconnecting students can catch up
+        if data.get("type") == "control" and data.get("message") in (
+            "enableVote", "enableNext", "enableChat", "enableFaceChat"
+        ):
+            r.hset(f"{course.course_name}_state", "current_phase", json.dumps(data))
+
         # Track message count for text messages
         if data.get("type") == "text":
             res = r.hget(f"{course.course_name}_state", "mess_count")
@@ -1224,6 +1240,29 @@ async def publish_message(
         return JSONResponse(
             status_code=500, content={"detail": f"Failed to publish message: {str(e)}"}
         )
+
+
+@router.get("/api/current_state")
+@with_course()
+async def get_current_state(
+    request: Request,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """Return the last phase-change control message for this course so a
+    reconnecting student can catch up to the current session state."""
+    import os
+    import redis
+
+    try:
+        r = redis.from_url(os.environ.get("REDIS_URI", "redis://redis:6379/0"))
+        raw = r.hget(f"{course.course_name}_state", "current_phase")
+        if raw:
+            return JSONResponse(content=json.loads(raw))
+        return JSONResponse(content={})
+    except Exception as e:
+        rslogger.error(f"Error fetching current state: {e}")
+        return JSONResponse(content={})
 
 
 @router.post("/api/log_peer_rating")

--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -886,21 +886,22 @@ async def make_pairs(
             }
             r.publish("peermessages", json.dumps(mess))
 
-        # Store current phase so reconnecting students can catch up (see /api/current_state).
-        # Partner data is per-student and is in partnerdb
-        phase_key = "enableFaceChat" if (is_ab and peeps_in_person) else "enableChat"
-        r.hset(
-            f"{course.course_name}_state",
-            "current_phase",
-            json.dumps(
-                {
-                    "type": "control",
-                    "message": phase_key,
-                    "broadcast": False,
-                    "course_name": course.course_name,
-                }
-            ),
-        )
+        # Store per-student phase so reconnecting students catch up to the right UI.
+        # Text-chat and verbal (face-chat) students get different phases in A/B mode,
+        # so we can't store a single course-wide phase here.
+        for sid in gdict:
+            r.hset(
+                f"{course.course_name}_state",
+                f"phase_{sid}",
+                json.dumps(
+                    {
+                        "type": "control",
+                        "message": "enableChat",
+                        "broadcast": False,
+                        "course_name": course.course_name,
+                    }
+                ),
+            )
 
         # If doing A/B, also send face-chat groups based on in-person groups
         if is_ab and peeps_in_person:
@@ -931,6 +932,18 @@ async def make_pairs(
                     "course_name": course.course_name,
                 }
                 r.publish("peermessages", json.dumps(mess))
+                r.hset(
+                    f"{course.course_name}_state",
+                    f"phase_{p}",
+                    json.dumps(
+                        {
+                            "type": "control",
+                            "message": "enableFaceChat",
+                            "broadcast": False,
+                            "course_name": course.course_name,
+                        }
+                    ),
+                )
 
         rslogger.info(f"Created {len(group_list)} chat groups (is_ab={is_ab})")
         return JSONResponse(content={"status": "success", "groups": len(group_list)})
@@ -1270,7 +1283,11 @@ async def get_current_state(
 
     try:
         r = redis.from_url(os.environ.get("REDIS_URI", "redis://redis:6379/0"))
-        raw = r.hget(f"{course.course_name}_state", "current_phase")
+        # Per-student key set during make_pairs (handles A/B where phases differ).
+        # Falls back to course-wide current_phase for broadcast phases (enableVote, enableNext).
+        raw = r.hget(f"{course.course_name}_state", f"phase_{user.username}") or r.hget(
+            f"{course.course_name}_state", "current_phase"
+        )
         if raw:
             return JSONResponse(content=json.loads(raw))
         return JSONResponse(content={})

--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -735,6 +735,7 @@ async def make_pairs(
     start_time: str = Body(...),
     group_size: int = Body(2),
     is_ab: bool = Body(False),
+    assignment_id: Optional[int] = Body(None),
     user=Depends(auth_manager),
     course=None,
 ):
@@ -888,11 +889,16 @@ async def make_pairs(
 
         # Store per-student phase so reconnecting students catch up to the right UI.
         # Text-chat and verbal (face-chat) students get different phases in A/B mode,
-        # so we can't store a single course-wide phase here.
+        # so we store per-student under an assignment-scoped key to avoid cross-session bleed.
+        state_key = (
+            f"assignment_{assignment_id}_state"
+            if assignment_id
+            else f"{course.course_name}_state"
+        )
         for sid in gdict:
             r.hset(
-                f"{course.course_name}_state",
-                f"phase_{sid}",
+                state_key,
+                sid,
                 json.dumps(
                     {
                         "type": "control",
@@ -933,8 +939,8 @@ async def make_pairs(
                 }
                 r.publish("peermessages", json.dumps(mess))
                 r.hset(
-                    f"{course.course_name}_state",
-                    f"phase_{p}",
+                    state_key,
+                    p,
                     json.dumps(
                         {
                             "type": "control",
@@ -1272,10 +1278,11 @@ async def publish_message(
 @with_course()
 async def get_current_state(
     request: Request,
+    assignment_id: Optional[int] = None,
     user=Depends(auth_manager),
     course=None,
 ):
-    """Return the last phase-change control message for this course so a
+    """Return the last phase-change control message for this student so a
     reconnecting student can catch up to the current session state."""
     import os
 
@@ -1283,9 +1290,14 @@ async def get_current_state(
 
     try:
         r = redis.from_url(os.environ.get("REDIS_URI", "redis://redis:6379/0"))
-        # Per-student key set during make_pairs (handles A/B where phases differ).
+        # Per-student key stored during make_pairs (handles A/B where phases differ per student).
         # Falls back to course-wide current_phase for broadcast phases (enableVote, enableNext).
-        raw = r.hget(f"{course.course_name}_state", f"phase_{user.username}") or r.hget(
+        state_key = (
+            f"assignment_{assignment_id}_state"
+            if assignment_id
+            else f"{course.course_name}_state"
+        )
+        raw = r.hget(state_key, user.username) or r.hget(
             f"{course.course_name}_state", "current_phase"
         )
         if raw:

--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -10,49 +10,49 @@
 # Standard library
 # ----------------
 import datetime
+import json
+import random
 import sys
 from typing import Optional
 
+import pandas as pd
+
 # Third-party imports
 # -------------------
-from fastapi import APIRouter, Depends, Request, Body
+from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from rsptx.auth.session import auth_manager
+from rsptx.configuration import settings
+from rsptx.db.async_session import async_session
+from rsptx.db.crud import (
+    count_distinct_student_answers,
+    count_peer_messages,
+    create_useinfo_entry,
+    fetch_all_course_attributes,
+    fetch_api_token,
+    fetch_assignment_questions,
+    fetch_assignments,
+    fetch_course_students,
+    fetch_last_useinfo_peergroup,
+    fetch_lti_version,
+    fetch_one_assignment,
+    fetch_question,
+    fetch_recent_student_answers,
+    fetch_student_answers_in_timerange,
+    replace_user_experiment_entries,
+    update_assignment,
+)
+from rsptx.db.models import Useinfo, UseinfoValidation
+from rsptx.endpoint_validators import instructor_role_required, with_course
 
 # Local application imports
 # -------------------------
 from rsptx.logging import rslogger
-from rsptx.db.crud import (
-    fetch_assignments,
-    fetch_one_assignment,
-    update_assignment,
-    fetch_assignment_questions,
-    fetch_all_course_attributes,
-    create_useinfo_entry,
-    fetch_lti_version,
-    fetch_recent_student_answers,
-    fetch_student_answers_in_timerange,
-    count_distinct_student_answers,
-    count_peer_messages,
-    fetch_last_useinfo_peergroup,
-    fetch_course_students,
-    fetch_api_token,
-    fetch_question,
-    replace_user_experiment_entries,
-)
-from rsptx.db.models import UseinfoValidation, Useinfo
-from rsptx.db.async_session import async_session
-from rsptx.auth.session import auth_manager
-import pandas as pd
-import random
-import json
-from rsptx.templates import template_folder
-from rsptx.endpoint_validators import with_course, instructor_role_required
-from rsptx.configuration import settings
-
 from rsptx.response_helpers.core import (
     get_webpack_static_imports,
 )
+from rsptx.templates import template_folder
 
 # Analogy themes for async LLM mode
 # ==================================
@@ -207,9 +207,10 @@ async def get_peer_dashboard(
     await create_useinfo_entry(log_entry)
 
     # Initialize Redis state and publish enableNext message
-    import os
-    import redis
     import json
+    import os
+
+    import redis
 
     try:
         r = redis.from_url(os.environ.get("REDIS_URI", "redis://redis:6379/0"))
@@ -744,6 +745,7 @@ async def make_pairs(
     mimicking the legacy web2py behavior.
     """
     import os
+
     import redis
     from dateutil.parser import parse
 
@@ -890,7 +892,14 @@ async def make_pairs(
         r.hset(
             f"{course.course_name}_state",
             "current_phase",
-            json.dumps({"type": "control", "message": phase_key, "broadcast": False, "course_name": course.course_name}),
+            json.dumps(
+                {
+                    "type": "control",
+                    "message": phase_key,
+                    "broadcast": False,
+                    "course_name": course.course_name,
+                }
+            ),
         )
 
         # If doing A/B, also send face-chat groups based on in-person groups
@@ -1208,9 +1217,10 @@ async def publish_message(
     Publish a message to the Redis pub/sub for peer instruction.
     Used for both text chat and control messages.
     """
-    import os
-    import redis
     import json
+    import os
+
+    import redis
 
     data = await request.json()
     rslogger.info(f"Publishing peer message: {data}")
@@ -1221,7 +1231,10 @@ async def publish_message(
 
         # Store phase-change control messages so reconnecting students can catch up
         if data.get("type") == "control" and data.get("message") in (
-            "enableVote", "enableNext", "enableChat", "enableFaceChat"
+            "enableVote",
+            "enableNext",
+            "enableChat",
+            "enableFaceChat",
         ):
             r.hset(f"{course.course_name}_state", "current_phase", json.dumps(data))
 
@@ -1252,6 +1265,7 @@ async def get_current_state(
     """Return the last phase-change control message for this course so a
     reconnecting student can catch up to the current session state."""
     import os
+
     import redis
 
     try:
@@ -1279,6 +1293,7 @@ async def log_peer_rating(
     Log a student's rating of their peer interaction.
     """
     import datetime
+
     from rsptx.validation.schemas import UseinfoValidation
 
     rslogger.info(
@@ -1321,6 +1336,7 @@ async def clear_pairs(
     Called when the instructor switches to face-chat mode.
     """
     import os
+
     import redis as redis_lib
 
     r = redis_lib.from_url(os.environ.get("REDIS_URI", "redis://redis:6379/0"))
@@ -1580,6 +1596,7 @@ async def _generate_analogy_mapping_async(
 
     try:
         import os
+
         import aiohttp
 
         token_row = await fetch_api_token(course_id, "openai")

--- a/components/rsptx/templates/staticAssets/js/peer.js
+++ b/components/rsptx/templates/staticAssets/js/peer.js
@@ -170,7 +170,9 @@ function connect(event) {
     // only happen on a live message (vote counting, page navigation).
     ws.onopen = async function () {
         try {
-            let resp = await fetch("/assignment/peer/api/current_state");
+            let urlParams = new URLSearchParams(window.location.search);
+            let assignmentId = urlParams.get('assignment_id');
+            let resp = await fetch(`/assignment/peer/api/current_state?assignment_id=${assignmentId}`);
             if (!resp.ok) return;
             let phase = await resp.json();
             if (phase && phase.message) {
@@ -345,11 +347,12 @@ function connect(event) {
                     }
                     let peerlist = document.getElementById("peerlist");
                     const ordA = 65;
-                    // Remove any partner rows from a previous enableChat
-                    while (peerlist.children.length > 1) {
-                        peerlist.removeChild(peerlist.lastChild);
+                    // On catch-up the per-partner payload isn't stored, so keep existing rows
+                    if (!mess._catchup) {
+                        while (peerlist.children.length > 1) {
+                            peerlist.removeChild(peerlist.lastChild);
+                        }
                     }
-                    // On catch-up the per-partner payload isn't stored, so the existing rows are kept
                     adict = mess.answer ? JSON.parse(mess.answer) : {};
                     for (const key in adict) {
                         let currAnswer = adict[key];

--- a/components/rsptx/templates/staticAssets/js/peer.js
+++ b/components/rsptx/templates/staticAssets/js/peer.js
@@ -558,11 +558,14 @@ async function makePartners(event, is_ab) {
     let butt = document.querySelector("#makep");
     butt.classList.replace("btn-info", "btn-secondary");
     let gs = document.getElementById("groupsize").value;
+    let urlParams = new URLSearchParams(window.location.search);
+    let assignmentId = urlParams.get('assignment_id');
     let data = {
         div_id: currentQuestion,
         start_time: startTime, // set in dashboard.html when loaded
         group_size: gs,
         is_ab: is_ab,
+        assignment_id: assignmentId ? parseInt(assignmentId) : null,
     };
     let jsheaders = new Headers({
         "Content-type": "application/json; charset=utf-8",

--- a/components/rsptx/templates/staticAssets/js/peer.js
+++ b/components/rsptx/templates/staticAssets/js/peer.js
@@ -164,6 +164,25 @@ function connect(event) {
         connect();
     };
 
+    // On connect/reconnect fetch the current session phase and re-apply it so a 
+    // student who briefly dropped catches up to whatever the class is doing.
+    // _catchup flag tells the handlers to skip side effects that should
+    // only happen on a live message (vote counting, page navigation).
+    ws.onopen = async function () {
+        try {
+            let resp = await fetch("/assignment/peer/api/current_state");
+            if (!resp.ok) return;
+            let phase = await resp.json();
+            if (phase && phase.message) {
+                console.log(`Catch-up: re-applying phase ${phase.message}`);
+                phase._catchup = true;
+                ws.onmessage({ data: JSON.stringify(phase) });
+            }
+        } catch (e) {
+            console.log(`current_state catch-up failed: ${e}`);
+        }
+    };
+
     ws.onmessage = function (event) {
         const messages = document.getElementById("messages");
         let mess = JSON.parse(event.data);
@@ -282,7 +301,7 @@ function connect(event) {
                     window.componentMap[currentQuestion].submitButton.innerHTML =
                         "Submit";
                     window.componentMap[currentQuestion].enableInteraction();
-                    if (typeof studentVoteCount !== "undefined") {
+                    if (typeof studentVoteCount !== "undefined" && !mess._catchup) {
                         studentVoteCount += 1;
                         if (studentVoteCount > 2) {
                             studentVoteCount = 2;
@@ -309,6 +328,7 @@ function connect(event) {
                     break;
                 case "enableNext":
                     console.log("Got enableNext message");
+                    if (mess._catchup) break;
                     // This moves the student to the next question in the assignment
                     // first disable the handler to prevent leaving the page.
                     $(window).off("beforeunload");
@@ -329,7 +349,8 @@ function connect(event) {
                     while (peerlist.children.length > 1) {
                         peerlist.removeChild(peerlist.lastChild);
                     }
-                    adict = JSON.parse(mess.answer);
+                    // On catch-up the per-partner payload isn't stored, so the existing rows are kept
+                    adict = mess.answer ? JSON.parse(mess.answer) : {};
                     for (const key in adict) {
                         let currAnswer = adict[key];
                         let newpeer = document.createElement("p");


### PR DESCRIPTION
Fixes #1259.

This stores the current PI phase in Redis on each phase change and exposes it via `/peer/api/current_state`. On websocket connect/reconnect the client fetches and re-applies the phase, so students who briefly disconnect see the correct UI. A `_catchup` flag prevents side effects (no double vote counts, no `enableNext` navigation).

This also works if a student reloads the page, though I think they should still be discouraged to do that.

I was not sure the best way to test since I cant organically recreate the issue but I tested locally by using `ws.close()` in the console broweser and a full page reload mid-session. If you have any suggestions on testing it I would be open to trying @bnmnetp. 