### PR TITLE
Change stringparam to stringparams in docs

### DIFF
--- a/docs/source/javascript_feature.rst
+++ b/docs/source/javascript_feature.rst
@@ -13,11 +13,11 @@ The following is what you need to do to work on the javascript for a component t
 
    To have webpack monitor for changes, and rebuild the Runestone assets on file change, use ``npm run watch -- --env builddir=PATH_TO_BOOK_OUTPUT/_static``
 
-4. Set a ``stringparam`` in the PreteXt book for ``debug.rs.dev`` to ``true``. This will cause the book to load the development version of the Runestone assets. Without this flag, PreTeXt will look to download production assets from the Runestone CDN.  Note that it is not enough to just copy the new files to ``_static``; the PreTeXt must be built with the flag set for the pages to know what to load.
+4. Set a ``stringparams`` in the PreteXt book for ``debug.rs.dev`` to ``true``. This will cause the book to load the development version of the Runestone assets. Without this flag, PreTeXt will look to download production assets from the Runestone CDN.  Note that it is not enough to just copy the new files to ``_static``; the PreTeXt must be built with the flag set for the pages to know what to load.
    
-   If using the PreTeXt CLI, version 2.0 or greater, you can add a string param to a build target in your project file (i.e. as a child of the appropriate ``project/targets/target``) by adding the following: ``<stringparam debug.rs.dev="yes"/>``.  
+   If using the PreTeXt CLI, version 2.0 or greater, you can add a string param to a build target in your project file (i.e. as a child of the appropriate ``project/targets/target``) by adding the following: ``<stringparams debug.rs.dev="yes"/>``.  
    
-   If you don't already have a stringparam element, you might have to change the target from a self-closing tag to an element that can have a child.  Change ``<target name="web" format="html"/>`` to ``<target name="web" format="html"><stringparam debug.rs.dev="yes"/></target>``.
+   If you don't already have a stringparams element, you might have to change the target from a self-closing tag to an element that can have a child.  Change ``<target name="web" format="html"/>`` to ``<target name="web" format="html"><stringparams debug.rs.dev="yes"/></target>``.
 
 5. Run ``pretext build`` in the root folder of the book
 


### PR DESCRIPTION
In the section "Developing the Javascript for Runestone Components", the documentation references setting `stringparam` in the PreTeXt textbook, when it should be `stringparams`.