### PR TITLE
Fix: checking for multiple choice multiple answer with 10+ answers

### DIFF
--- a/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
+++ b/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
@@ -457,7 +457,7 @@ export default class MultipleChoice extends RunestoneBase {
         var buttonObjs = this.optsForm.elements.group1;
         for (var i = 0; i < buttonObjs.length; i++) {
             if (buttonObjs[i].checked) {
-                given = buttonObjs[i].value;
+                given = parseInt(buttonObjs[i].value);
                 this.givenArray.push(given);
                 this.feedbackString += `<li value="${i + 1}">${
                     this.feedbackList[i]
@@ -466,7 +466,7 @@ export default class MultipleChoice extends RunestoneBase {
                 this.singlefeedback = this.feedbackList[i];
             }
         }
-        this.givenArray.sort();
+        this.givenArray.sort((a, b) => a - b);
     }
 
     checkCurrentAnswer() {

--- a/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
+++ b/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
@@ -457,7 +457,7 @@ export default class MultipleChoice extends RunestoneBase {
         var buttonObjs = this.optsForm.elements.group1;
         for (var i = 0; i < buttonObjs.length; i++) {
             if (buttonObjs[i].checked) {
-                given = parseInt(buttonObjs[i].value);
+                given = parseInt(buttonObjs[i].value, 10);
                 this.givenArray.push(given);
                 this.feedbackString += `<li value="${i + 1}">${
                     this.feedbackList[i]


### PR DESCRIPTION
Fixes bug identified here:
https://groups.google.com/g/pretext-support/c/ISou4CfBfVw/m/piB8hKo_EgAJ?utm_medium=email&utm_source=footer

MCMA with 10+ answers stores the `givenAnswers` as strings and compare those to ints. Doesn't necessarily cause a problem on its own, but sorting with 10+ answers produces an ordering like `1, 10, 2...`.

This fixes the `givenArray` sort and also makes sure that the code does int <--> int comparisons when checking answers.

If only there was some way to specify whether something was supposed to be a number or a string... ;)