### PR TITLE
Fix: avoid greedy selection in parsons line grader LIS calculation

### DIFF
--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -9,7 +9,6 @@
             "version": "2.0.0",
             "license": "ISC",
             "dependencies": {
-                "-": "0.0.1",
                 "@mapbox/node-pre-gyp": "^1.0.11",
                 "bootstrap": "3.4.1",
                 "btm-expressions": "^0.1.12",
@@ -47,12 +46,10 @@
                 "webpack": "^5.97.1",
                 "webpack-bundle-analyzer": "^4.0.0",
                 "webpack-cli": "^4.10.0"
+            },
+            "optionalDependencies": {
+                "canvas": "^3.2.3"
             }
-        },
-        "node_modules/-": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/-/-/--0.0.1.tgz",
-            "integrity": "sha512-3HfneK3DGAm05fpyj20sT3apkNcvPpCuccOThOPdzz8sY7GgQGe0l93XH9bt+YzibcTIgUAIMoyVJI740RtgyQ=="
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
@@ -3552,7 +3549,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3567,8 +3563,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/bessel": {
             "version": "1.0.2",
@@ -3710,9 +3706,8 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -3723,9 +3718,8 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3812,7 +3806,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3827,8 +3820,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -3901,10 +3894,9 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
             "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
-            "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "node-addon-api": "^7.0.0",
                 "prebuild-install": "^7.1.3"
@@ -3967,8 +3959,7 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "license": "ISC",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
@@ -4781,9 +4772,8 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "mimic-response": "^3.1.0"
             },
@@ -4800,7 +4790,6 @@
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -5168,9 +5157,8 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "dev": true,
+            "license": "(MIT OR WTFPL)",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5312,9 +5300,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fs-extra": {
             "version": "10.1.0",
@@ -5438,9 +5425,8 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -5751,7 +5737,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5766,8 +5751,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "optional": true,
-            "peer": true
+            "license": "BSD-3-Clause",
+            "optional": true
         },
         "node_modules/ignore": {
             "version": "5.2.0",
@@ -5840,8 +5825,7 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "license": "ISC",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/internmap": {
             "version": "1.0.1",
@@ -6849,9 +6833,8 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6895,7 +6878,6 @@
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6949,9 +6931,8 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/moment": {
             "version": "2.20.1",
@@ -7005,9 +6986,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/needle": {
             "version": "2.9.1",
@@ -7053,9 +7033,8 @@
             "version": "3.94.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
             "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -7067,9 +7046,8 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/node-fetch": {
             "version": "2.6.7",
@@ -8064,9 +8042,8 @@
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
             "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
@@ -8092,9 +8069,8 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8177,7 +8153,6 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -8608,7 +8583,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8623,14 +8597,13 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/simple-get": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
             "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8645,8 +8618,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
@@ -8803,7 +8776,6 @@
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8920,9 +8892,8 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
             "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -8934,9 +8905,8 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -8952,9 +8922,8 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -9233,9 +9202,8 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -10142,23 +10110,6 @@
                 }
             }
         },
-        "node_modules/vitest/node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
-        },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -10643,11 +10594,6 @@
         }
     },
     "dependencies": {
-        "-": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/-/-/--0.0.1.tgz",
-            "integrity": "sha512-3HfneK3DGAm05fpyj20sT3apkNcvPpCuccOThOPdzz8sY7GgQGe0l93XH9bt+YzibcTIgUAIMoyVJI740RtgyQ=="
-        },
         "@ampproject/remapping": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -13107,9 +13053,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "bessel": {
             "version": "1.0.2",
@@ -13217,9 +13161,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -13230,9 +13172,7 @@
                     "version": "3.6.2",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
                     "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-                    "dev": true,
                     "optional": true,
-                    "peer": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -13291,9 +13231,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -13348,9 +13286,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
             "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "node-addon-api": "^7.0.0",
                 "prebuild-install": "^7.1.3"
@@ -13397,8 +13333,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "chrome-trace-event": {
             "version": "1.0.3",
@@ -14025,9 +13960,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "mimic-response": "^3.1.0"
             }
@@ -14036,8 +13969,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "delegates": {
             "version": "1.0.0",
@@ -14312,9 +14244,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "expect-type": {
             "version": "1.4.0",
@@ -14424,9 +14354,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "fs-extra": {
             "version": "10.1.0",
@@ -14525,9 +14453,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "glob": {
             "version": "7.2.3",
@@ -14746,9 +14672,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "ignore": {
             "version": "5.2.0",
@@ -14801,8 +14725,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "internmap": {
             "version": "1.0.1",
@@ -15469,9 +15392,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "mini-css-extract-plugin": {
             "version": "2.6.1",
@@ -15494,8 +15415,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "minipass": {
             "version": "2.9.0",
@@ -15541,9 +15461,7 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "moment": {
             "version": "2.20.1",
@@ -15579,9 +15497,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "needle": {
             "version": "2.9.1",
@@ -15620,9 +15536,7 @@
             "version": "3.94.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
             "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "semver": "^7.3.5"
             }
@@ -15631,9 +15545,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node-fetch": {
             "version": "2.6.7",
@@ -16305,9 +16217,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
             "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
@@ -16327,9 +16237,7 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
                     "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "optional": true
                 }
             }
         },
@@ -16392,7 +16300,6 @@
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "optional": true,
-            "peer": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -16714,17 +16621,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "simple-get": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
             "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
@@ -16855,8 +16758,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "stylehacks": {
             "version": "5.1.0",
@@ -16947,9 +16849,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
             "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -16961,9 +16861,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -16976,9 +16874,7 @@
                     "version": "3.6.2",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
                     "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-                    "dev": true,
                     "optional": true,
-                    "peer": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -17169,9 +17065,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dev": true,
             "optional": true,
-            "peer": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -17832,14 +17726,6 @@
                         "rolldown": "~1.1.3",
                         "tinyglobby": "^0.2.17"
                     }
-                },
-                "yaml": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-                    "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
                 }
             }
         },

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -40,7 +40,6 @@
         "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "-": "0.0.1",
         "@mapbox/node-pre-gyp": "^1.0.11",
         "bootstrap": "3.4.1",
         "btm-expressions": "^0.1.12",
@@ -56,5 +55,8 @@
         "sql.js": "1.5.0",
         "vega-embed": "3.14.0",
         "wavedrom": "^2.0.0"
+    },
+    "optionalDependencies": {
+        "canvas": "^3.2.3"
     }
 }

--- a/bases/rsptx/interactives/runestone/hparsons/js/blockGrader.js
+++ b/bases/rsptx/interactives/runestone/hparsons/js/blockGrader.js
@@ -14,14 +14,13 @@ export default class BlockBasedGrader {
         // Get all subsequences
         var allSubsequences = [];
         for (var i = 0; i < arr.length; i++) {
-            var subsequenceForCurrent = [arr[i]],
-                current = arr[i],
-                lastElementAdded = -1;
-            for (var j = i; j < arr.length; j++) {
-                var subsequent = arr[j];
-                if (subsequent > current && lastElementAdded < subsequent) {
-                    subsequenceForCurrent.push(subsequent);
-                    lastElementAdded = subsequent;
+            var subsequenceForCurrent = [arr[i]];
+            for (var j = 0; j < i; j++) {
+                if (
+                    arr[j] < arr[i] &&
+                    allSubsequences[j].length + 1 > subsequenceForCurrent.length
+                ) {
+                    subsequenceForCurrent = allSubsequences[j].concat(arr[i]);
                 }
             }
             allSubsequences.push(subsequenceForCurrent);

--- a/bases/rsptx/interactives/runestone/parsons/js/lineGrader.js
+++ b/bases/rsptx/interactives/runestone/parsons/js/lineGrader.js
@@ -8,14 +8,13 @@ export default class LineBasedGrader {
         // Get all subsequences
         var allSubsequences = [];
         for (var i = 0; i < arr.length; i++) {
-            var subsequenceForCurrent = [arr[i]],
-                current = arr[i],
-                lastElementAdded = -1;
-            for (var j = i; j < arr.length; j++) {
-                var subsequent = arr[j];
-                if (subsequent > current && lastElementAdded < subsequent) {
-                    subsequenceForCurrent.push(subsequent);
-                    lastElementAdded = subsequent;
+            var subsequenceForCurrent = [arr[i]];
+            for (var j = 0; j < i; j++) {
+                if (
+                    arr[j] < arr[i] &&
+                    allSubsequences[j].length + 1 > subsequenceForCurrent.length
+                ) {
+                    subsequenceForCurrent = allSubsequences[j].concat(arr[i]);
                 }
             }
             allSubsequences.push(subsequenceForCurrent);

--- a/bases/rsptx/interactives/runestone/parsons/test/parsons.test.js
+++ b/bases/rsptx/interactives/runestone/parsons/test/parsons.test.js
@@ -334,6 +334,13 @@ describe("grading", () => {
         expect(p.percent).toBeCloseTo(0.2 + 0.4 / 3 + 0.4 / 3, 5);
     });
 
+    it("linegrader reports correct LIS for incorrect order", async () => {
+        const p = await makeParsons();
+        // longest increasing subsequence has values 1, 2, 3, 4, excludes indexes 0 and 2
+        const inverseLIS1 = p.grader.inverseLISIndices([5, 1, 6, 2, 3, 4]);
+        expect(inverseLIS1).toEqual([0, 2]);
+    });
+
     it("reports correct, locks the check button and records the solve", async () => {
         const p = await makeParsons({ blocks: FLAT_BLOCKS, attrs: FLAT_ATTRS });
         answer(p, [0, 1, 2]);


### PR DESCRIPTION
Jan Pearce introduced me to Lori Postner this morning. Lori identified inconsistencies and confusing behavior with block highlighting for solutions with incorrect ordering. I took a look at the longest increasing sequence generation code and it does appear there is an issue. 

Given [5, 1, 6, 2, 3, 4], it would identify [2, 3, 4] as the LIS sequence instead of [1, 2, 3, 4]. The algorithm is greedy - when starting at 1, once it identifies [1, 6] as a possibility, it rejects considering [1, 2, ....] as 2 doesn't continue the first possible sequence discovered. Thus the longest sequence if finds for 1 is [1, 6] and the final LSI identified is [2, 3, 4]. 

