### PR TITLE
FITB: Import local libraries

### DIFF
--- a/bases/rsptx/interactives/runestone/fitb/js/fitb.js
+++ b/bases/rsptx/interactives/runestone/fitb/js/fitb.js
@@ -145,9 +145,11 @@ export default class FITB extends RunestoneBase {
                         );
                         break;
                     // Allow for local imports, usually from problems defined outside the Runestone Components.
+                    // Relative URL should be relative to document base, not this library
                     default:
-                        import_promises.push(
-                            import(/* webpackIgnore: true */ import_),
+                        const absoluteUrl = new URL(import_, document.baseURI).href;
+                        import_promises.push( 
+                            import(/* webpackIgnore: true */ absoluteUrl),
                         );
                         break;
                 }


### PR DESCRIPTION
The RS component code defining FITB questions had the option to define additional libraries that would be loaded when the problem is injected into the surrounding HTML. As far as I know, this had not been used beyond the default loading of `BTM` libraries. PreTeXt did not yet have any way to define those libraries.

When adding the support on the PreTeXt side, I realized that any JS files that were attempting to be loaded from the assets were in the wrong relative location, since `import()` looks relative to the calling library, which in this case is the RS component itself. So that relative locations based on PreTeXt projects is preserved, this pull request adds the document context to create an absolute URL rather than remain in a relative URL that points the wrong location.