### PR TITLE
Fix matching component leaking answers across users via localStorage (#1316)

### DIFF
--- a/bases/rsptx/interactives/runestone/matching/js/matching.js
+++ b/bases/rsptx/interactives/runestone/matching/js/matching.js
@@ -186,14 +186,14 @@ export class MatchingProblem extends RunestoneBase {
         if (this.graderactive) {
             return;
         }
-        const data = localStorage.getItem(this.divid);
+        const data = localStorage.getItem(this.localStorageKey());
         if (data) {
             const parsedData = JSON.parse(data);
             if (
                 parsedData.timestamp &&
                 parsedData.timestamp < eBookConfig.termStartDate
             ) {
-                localStorage.removeItem(this.divid);
+                localStorage.removeItem(this.localStorageKey());
                 return;
             }
             this.connections = parsedData.connections.map((conn) => ({
@@ -224,7 +224,7 @@ export class MatchingProblem extends RunestoneBase {
             missingCount: this.missingCount,
             timestamp: timeStamp,
         };
-        localStorage.setItem(this.divid, JSON.stringify(data));
+        localStorage.setItem(this.localStorageKey(), JSON.stringify(data));
     }
 
     disableInteraction() {}


### PR DESCRIPTION
## Problem

`MatchingProblem.checkLocalStorage()` / `setLocalStorage()` key their entry by the bare `this.divid`:

```js
localStorage.getItem(this.divid)
localStorage.setItem(this.divid, ...)
localStorage.removeItem(this.divid)
```

Every other answer-bearing component keys through the inherited `RunestoneBase.localStorageKey()`:

```js
localStorageKey() { return eBookConfig.email + ":" + eBookConfig.course + ":" + this.divid + "-given"; }
```

Because the matching key has no per-user segment, a saved matching answer is shared by every identity using the same browser. `checkLocalStorage()` is the fallback taken when there's no server answer (`repopulateFromStorage` → `checkLocalStorage`), so this is mostly latent on runestone.academy but **fully exposed on self-hosted / offline deployments** and whenever two users share a machine — student B sees student A's matching answers restored.

Detailed diagnosis in #1316.

## Fix

Use the inherited `localStorageKey()` for the three localStorage calls, exactly like every other component. Server restore (`checkServer` / `restoreAnswers`) is unaffected — only the localStorage fallback key changes.

**No backward-compatible read of the old bare-`divid` key.** That key is the defect (shared across users), so orphaning previously-saved values is intentional, not a regression.

## Testing

`matching/js/` has no existing test harness (unlike `timed`/`webwork`/`shortanswer`), so this is a source-only change, verified with `node --check`. Manually: with the fix, a matching answer saved under one identity no longer restores under a different identity in the same browser. Happy to add a test if you point me at the preferred harness.
