### PR TITLE
Store assignment due dates in UTC

### DIFF
--- a/bases/rsptx/admin_server_api/routers/analytics.py
+++ b/bases/rsptx/admin_server_api/routers/analytics.py
@@ -22,14 +22,13 @@ from fastapi import (
     status,
 )
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy import create_engine
 
 from rsptx.auth.session import auth_manager
 from rsptx.configuration import settings
 from rsptx.endpoint_validators import instructor_role_required, with_course
 from rsptx.logging import rslogger
-from rsptx.templates import template_folder
+from rsptx.templates import format_course_datetime, get_shared_templates
 
 # ---------------------------------------------------------------------------
 # Router
@@ -40,9 +39,26 @@ router = APIRouter(
     tags=["analytics"],
 )
 
-templates = Jinja2Templates(directory=template_folder)
+templates = get_shared_templates()
+
 
 # ---------------------------------------------------------------------------
+def _format_duedate(value, course_timezone: Optional[str]) -> str:
+    """Render a duedate read via pandas as a course-local date string.
+
+    ``pd.read_sql_query`` yields ``pd.Timestamp`` (a ``datetime`` subclass) and
+    ``pd.NaT`` for nulls, and ``NaT`` is not caught by an ``is None`` check, so
+    screen for it before handing off to the shared formatter.
+    """
+    if value is None or pd.isna(value):
+        return ""
+    if hasattr(value, "to_pydatetime"):
+        value = value.to_pydatetime()
+    return format_course_datetime(
+        value, course_timezone, fmt="%Y-%m-%d", show_timezone=False
+    )
+
+
 # Redis helpers
 # ---------------------------------------------------------------------------
 
@@ -1213,16 +1229,12 @@ async def get_assignmentoverview(
         params={"course_name": course.course_name},
     )
     assignments = assignments_df.to_dict(orient="records")
-    # Convert Timestamps to strings for template rendering
+    # Convert Timestamps to strings for template rendering. duedate is stored
+    # as naive UTC, so it has to be shifted into the course timezone before the
+    # date is taken -- a late-evening deadline lands on the following day in
+    # UTC. No zone label: only the date is shown.
     for row in assignments:
-        dt = row.get("duedate")
-        if dt is not None and pd.notna(dt):
-            try:
-                row["duedate"] = dt.strftime("%Y-%m-%d")
-            except Exception:
-                row["duedate"] = str(dt)
-        else:
-            row["duedate"] = ""
+        row["duedate"] = _format_duedate(row.get("duedate"), course.timezone)
 
     context = {
         "request": request,
@@ -1381,14 +1393,7 @@ async def get_assignment_student_detail(
             detail=f"Assignment {assignment_id} not found",
         )
     assignment = assignment_row.iloc[0].to_dict()
-    dt = assignment.get("duedate")
-    if dt is not None and pd.notna(dt):
-        try:
-            assignment["duedate"] = dt.strftime("%Y-%m-%d")
-        except Exception:
-            assignment["duedate"] = str(dt)
-    else:
-        assignment["duedate"] = ""
+    assignment["duedate"] = _format_duedate(assignment.get("duedate"), course.timezone)
 
     detail = _build_assignment_student_detail(
         engine, assignment_id, course.course_name, sid, tz_offset_hours

--- a/bases/rsptx/admin_server_api/routers/auth.py
+++ b/bases/rsptx/admin_server_api/routers/auth.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 from fastapi import APIRouter, Form, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from pydal.validators import CRYPT
 
 from rsptx.auth.email import send_email
@@ -31,14 +30,14 @@ from rsptx.db.crud import (
 from rsptx.db.models import AuthUserValidator
 from rsptx.logging import rslogger
 from rsptx.response_helpers.core import canonical_utcnow
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 router = APIRouter(
     prefix="/auth",
     tags=["auth"],
 )
 
-templates = Jinja2Templates(directory=template_folder)
+templates = get_shared_templates()
 
 # All browser-facing URLs use /admin/auth/... (nginx routes /admin/auth/ → container /auth/)
 _LOGIN = "/admin/auth/login"

--- a/bases/rsptx/admin_server_api/routers/instructor.py
+++ b/bases/rsptx/admin_server_api/routers/instructor.py
@@ -12,10 +12,11 @@ from fastapi.responses import (
     HTMLResponse,
     JSONResponse,
 )
-from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 import csv
 from io import StringIO
+from typing import Optional
+from zoneinfo import ZoneInfo
 
 # Local application imports
 # -------------------------
@@ -60,7 +61,7 @@ from rsptx.db.crud import (
 )
 from rsptx.auth.session import auth_manager
 from rsptx.auth.email import send_welcome_email
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 from rsptx.configuration import settings
 from rsptx.endpoint_validators import with_course, instructor_role_required
 from rsptx.logging import rslogger
@@ -117,7 +118,7 @@ async def get_instructor_menu(
     Display the main instructor menu dashboard.
     """
     rslogger.info(f"Rendering instructor menu for course: {course.course_name}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     context = {
         "course": course,
         "user": user,
@@ -142,7 +143,7 @@ async def get_manage_students(
     """
     Display the student management interface.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Get all students in the course
     students = {}  # This would normally be populated from the database
@@ -173,7 +174,7 @@ async def get_copy_assignments(
     """
     Display the copy assignments interface.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Get instructor's available courses for copying from
     instructor_course_relationships = await fetch_instructor_courses(user.id)
@@ -393,7 +394,7 @@ async def get_course_settings(
     """
     Display the course settings interface.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Get all course attributes
     course_attrs = await fetch_all_course_attributes(course.id)
@@ -447,7 +448,7 @@ async def get_lti_config(
     management (the LTI 1.3 pieces are configured elsewhere and are only surfaced
     here for informational purposes and to allow removing an association).
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     lti_key = await fetch_lti1p1_config(course.id)
     course_attrs = await fetch_all_course_attributes(course.id)
@@ -528,7 +529,7 @@ async def get_assessment_reset(
     """
     Display the assessment reset interface.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Get all students in the course
     students = await fetch_users_for_course(course.course_name)
@@ -625,7 +626,7 @@ async def get_course_delete(
         rslogger.info(
             f"Rendering course deletion page for course: {course.course_name}"
         )
-        templates = Jinja2Templates(directory=template_folder)
+        templates = get_shared_templates()
         context = {
             "course": course,
             "student_count": student_count,
@@ -720,7 +721,7 @@ async def get_add_instructor(
     """
     Render the Add Instructor page.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     context = {
         "course": course,
         "user": user,
@@ -821,7 +822,7 @@ async def remove_student(
     Remove one or more students from the current course.
     Expects form data with student_id (can be a single value or a list).
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     try:
         form = await request.form()
@@ -1055,7 +1056,7 @@ async def enroll_students(
         mess = f"Enrollment completed with {enrolled} successful enrollments and {failed} failures."
     else:
         mess = f"All {enrolled} students enrolled successfully."
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     return templates.TemplateResponse(
         "admin/instructor/enroll_results.html",
         {
@@ -1162,6 +1163,24 @@ async def copy_assignment(
         )
 
 
+def _term_start_utc(term_start_date, timezone: Optional[str]) -> datetime.datetime:
+    """Midnight local time on the first day of term, expressed as naive UTC.
+
+    ``term_start_date`` is a bare date, so on its own it has no timezone. Due
+    dates are stored as naive UTC, so the term start has to be anchored in the
+    course timezone before the two can be subtracted -- otherwise the offset
+    from the start of term is wrong by the course's UTC offset. A course with
+    no timezone is treated as UTC, matching the ``duedate`` migration.
+    """
+    midnight = datetime.datetime.combine(term_start_date, datetime.time())
+    tz = ZoneInfo(timezone) if timezone else datetime.timezone.utc
+    return (
+        midnight.replace(tzinfo=tz)
+        .astimezone(datetime.timezone.utc)
+        .replace(tzinfo=None)
+    )
+
+
 async def _copy_one_assignment(
     source_course_name: str, old_assignment_id: int, target_course
 ) -> str:
@@ -1179,15 +1198,16 @@ async def _copy_one_assignment(
         source_course = await fetch_course(source_course_name)
         old_assignment = await fetch_one_assignment(old_assignment_id)
 
-        # Calculate due date adjustment based on course start dates
+        # Calculate due date adjustment based on course start dates. Both term
+        # starts are anchored in their own course timezone so the offset from
+        # the start of term is preserved as local wall clock time, even when
+        # the two terms fall on opposite sides of a DST change.
         if source_course.term_start_date and target_course.term_start_date:
-            due_delta = old_assignment.duedate - datetime.datetime.combine(
-                source_course.term_start_date, datetime.time()
+            due_delta = old_assignment.duedate - _term_start_utc(
+                source_course.term_start_date, source_course.timezone
             )
             due_date = (
-                datetime.datetime.combine(
-                    target_course.term_start_date, datetime.time()
-                )
+                _term_start_utc(target_course.term_start_date, target_course.timezone)
                 + due_delta
             )
         else:
@@ -1313,7 +1333,7 @@ async def get_create_course_page(request: Request, user=Depends(auth_manager)):
     """
     Display the course designer form for instructors.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     # Fetch real course list from the library table
     course = user.course_name
 
@@ -1369,7 +1389,7 @@ async def post_create_course_page(
     """
     Process the course designer form submission.
     """
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     # Prepare course data for validator
     try:
         course_data = {

--- a/bases/rsptx/admin_server_api/routers/legal.py
+++ b/bases/rsptx/admin_server_api/routers/legal.py
@@ -13,16 +13,15 @@ visitors and crawlers, so none of them depend on ``auth_manager``.
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
 
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 router = APIRouter(
     prefix="/legal",
     tags=["legal"],
 )
 
-templates = Jinja2Templates(directory=template_folder)
+templates = get_shared_templates()
 
 # ---------------------------------------------------------------------------
 # Document registry

--- a/bases/rsptx/admin_server_api/routers/lti1p1.py
+++ b/bases/rsptx/admin_server_api/routers/lti1p1.py
@@ -23,7 +23,6 @@ from typing import Optional
 import oauth2
 from fastapi import APIRouter, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
-from fastapi.templating import Jinja2Templates
 from pydantic import ValidationError
 
 # Local application imports
@@ -54,7 +53,7 @@ from rsptx.lti1p1.core import (
 )
 from rsptx.logging import rslogger
 from rsptx.response_helpers.core import canonical_utcnow
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 from .lti1p3 import add_w2py_session_cookie, get_domain, get_web2py_session_cookie
 
@@ -98,7 +97,7 @@ def _launch_url(request: Request) -> str:
 
 def _render_error(request: Request, errors: list) -> HTMLResponse:
     """Render the LTI launch error page."""
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     context = {"request": request, "lti_errors": errors}
     return templates.TemplateResponse(
         "admin/lti1p1/launch_error.html", context, status_code=400

--- a/bases/rsptx/admin_server_api/routers/lti1p3.py
+++ b/bases/rsptx/admin_server_api/routers/lti1p3.py
@@ -36,7 +36,6 @@ from fastapi.responses import (
     RedirectResponse,
     HTMLResponse,
 )
-from fastapi.templating import Jinja2Templates
 from pydantic import ValidationError
 import jwt
 
@@ -86,7 +85,7 @@ from rsptx.configuration import settings
 from rsptx.logging import rslogger
 from rsptx.auth.session import auth_manager
 from rsptx.response_helpers.core import canonical_utcnow
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 from rsptx.endpoint_validators import with_course, instructor_role_required
 
 from rsptx.lti1p3.pylti1p3.lineitem import LineItem
@@ -542,13 +541,16 @@ async def update_rsassignment_from_lti(
         )
         lms_due = datetime.datetime.fromisoformat(normalized_due_string)
 
-        # If LMS provided timezone info and course has a timezone, convert to course local time.
-        if lms_due.tzinfo is not None and course.timezone:
-            lms_due = lms_due.astimezone(ZoneInfo(course.timezone))
-            rslogger.info(
-                f"LTI1p3 - Converted to {lms_due} in timezone {course.timezone}"
-            )
-        lms_due = lms_due.replace(tzinfo=None)
+        # duedate is stored as naive UTC. A timestamp carrying an offset can be
+        # converted straight to UTC; a naive one has to be read as course-local
+        # wall clock first, which is what such a value meant before due dates
+        # moved to UTC. A course with no timezone is treated as UTC, matching
+        # the duedate migration.
+        if lms_due.tzinfo is None:
+            tz = ZoneInfo(course.timezone) if course.timezone else datetime.timezone.utc
+            lms_due = lms_due.replace(tzinfo=tz)
+        lms_due = lms_due.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        rslogger.info(f"LTI1p3 - Storing {lms_due} UTC for assignment {assign.name}")
         if (
             lms_due is not None
             and lms_due != assign.duedate
@@ -605,7 +607,7 @@ async def register(
 
     await upsert_lti1p3_config(lti_conf)
 
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     return templates.TemplateResponse(
         "admin/lti1p3/registration_confirm.html",
         request=request,
@@ -829,7 +831,7 @@ async def deep_link_login(request: Request):
         fapi_request, tool_conf, launch_data_storage=get_launch_data_storage()
     )
     rslogger.debug(f"LTI1p3 - rs-login request: {fapi_request.__dict__}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     tpl_kwargs = {
         "request": request,
         "launch_id": message_launch.get_launch_id(),
@@ -979,7 +981,7 @@ async def dynamic_link_entry(request: Request):
         "authentication_nonce": authentication_nonce,
     }
 
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     resp = templates.TemplateResponse(
         name="admin/lti1p3/pick_links.html", context=tpl_kwargs
     )

--- a/bases/rsptx/admin_server_api/routers/problem_report.py
+++ b/bases/rsptx/admin_server_api/routers/problem_report.py
@@ -16,21 +16,20 @@ import httpx
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
 
 from rsptx.auth.session import auth_manager
 from rsptx.configuration import settings
 from rsptx.db.crud import fetch_course, fetch_instructor_courses
 from rsptx.logging import rslogger
 from rsptx.response_helpers.core import canonical_utcnow
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 router = APIRouter(
     prefix="/problem",
     tags=["problem-report"],
 )
 
-templates = Jinja2Templates(directory=template_folder)
+templates = get_shared_templates()
 
 # Browser-facing URL: nginx/caddy route /admin/problem/ -> container /problem/
 _REPORT_URL = "/admin/problem/report"

--- a/bases/rsptx/admin_server_api/routers/start.py
+++ b/bases/rsptx/admin_server_api/routers/start.py
@@ -12,16 +12,15 @@ does not depend on ``auth_manager``.
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
 
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 router = APIRouter(
     prefix="/get-started",
     tags=["get-started"],
 )
 
-templates = Jinja2Templates(directory=template_folder)
+templates = get_shared_templates()
 
 
 @router.get("", response_class=HTMLResponse)

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/AssignmentEdit.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/AssignmentEdit.tsx
@@ -24,6 +24,8 @@ import { Assignment, KindOfAssignment } from "@/types/assignment";
 
 import { DateTimePicker } from "../../../../ui/DateTimePicker";
 
+import { CourseTimezoneNotice } from "./CourseTimezoneNotice";
+
 import { AssignmentReadings } from "../reading/AssignmentReadings";
 import { VisibilityControl } from "./VisibilityControl";
 
@@ -164,11 +166,14 @@ export const AssignmentEdit = ({
             control={control}
             defaultValue=""
             render={({ field }) => (
-              <DateTimePicker
-                id="edit-due-date"
-                value={field.value}
-                onChange={(val) => field.onChange(val)}
-              />
+              <>
+                <DateTimePicker
+                  id="edit-due-date"
+                  value={field.value}
+                  onChange={(val) => field.onChange(val)}
+                />
+                <CourseTimezoneNotice value={field.value} />
+              </>
             )}
           />
         </div>

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/CourseTimezoneNotice.spec.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/CourseTimezoneNotice.spec.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithMantine, screen } from "@/test/renderWithMantine";
+
+import { CourseTimezoneNotice } from "./CourseTimezoneNotice";
+
+const setCourseTimezone = (timezone: string | undefined) => {
+  window.eBookConfig = { ...(window.eBookConfig || {}), courseTimezone: timezone };
+};
+
+/** Pin the browser timezone Intl reports, since the test host varies. */
+const setBrowserTimezone = (timeZone: string) => {
+  const original = Intl.DateTimeFormat;
+
+  vi.spyOn(Intl, "DateTimeFormat").mockImplementation(((
+    locales?: Intl.LocalesArgument,
+    options?: Intl.DateTimeFormatOptions
+  ) => {
+    const formatter = new original(locales, { timeZone, ...options });
+    const resolved = formatter.resolvedOptions.bind(formatter);
+
+    formatter.resolvedOptions = () => ({ ...resolved(), timeZone });
+    return formatter;
+  }) as unknown as typeof Intl.DateTimeFormat);
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setCourseTimezone(undefined);
+});
+
+describe("CourseTimezoneNotice", () => {
+  it("renders nothing when the browser matches the course", () => {
+    setCourseTimezone("America/Chicago");
+    setBrowserTimezone("America/Chicago");
+
+    renderWithMantine(<CourseTimezoneNotice value="2026-09-02T04:59:00" />);
+
+    expect(screen.queryByTestId("course-timezone-notice")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the course has no timezone and the browser is UTC", () => {
+    setCourseTimezone(undefined);
+    setBrowserTimezone("UTC");
+
+    renderWithMantine(<CourseTimezoneNotice value="2026-09-02T04:59:00" />);
+
+    expect(screen.queryByTestId("course-timezone-notice")).not.toBeInTheDocument();
+  });
+
+  it("warns when the instructor is east of the course", () => {
+    setCourseTimezone("America/Los_Angeles");
+    setBrowserTimezone("America/Chicago");
+
+    renderWithMantine(<CourseTimezoneNotice value="2026-09-02T04:59:00" />);
+
+    const notice = screen.getByTestId("course-timezone-notice");
+
+    expect(notice).toHaveTextContent("America/Chicago");
+    expect(notice).toHaveTextContent("2 hours ahead of");
+    expect(notice).toHaveTextContent("America/Los_Angeles");
+  });
+
+  it("warns when the instructor is west of the course", () => {
+    setCourseTimezone("America/Chicago");
+    setBrowserTimezone("America/Los_Angeles");
+
+    renderWithMantine(<CourseTimezoneNotice value="2026-09-02T04:59:00" />);
+
+    expect(screen.getByTestId("course-timezone-notice")).toHaveTextContent("2 hours behind");
+  });
+
+  it("uses a singular hour label for a one hour gap", () => {
+    setCourseTimezone("America/Chicago");
+    setBrowserTimezone("America/New_York");
+
+    renderWithMantine(<CourseTimezoneNotice value="2026-09-02T04:59:00" />);
+
+    expect(screen.getByTestId("course-timezone-notice")).toHaveTextContent("1 hour ahead");
+  });
+
+  it("shows the chosen deadline in course time", () => {
+    setCourseTimezone("America/Los_Angeles");
+    setBrowserTimezone("America/Chicago");
+
+    // 2026-09-02 04:59 UTC is 09:59 PM on Sep 1 in Los Angeles.
+    renderWithMantine(<CourseTimezoneNotice value="2026-09-02T04:59:00" />);
+
+    const notice = screen.getByTestId("course-timezone-notice");
+
+    expect(notice).toHaveTextContent("in course time");
+    expect(notice).toHaveTextContent("09:59");
+  });
+
+  it("still warns with no due date chosen yet, omitting the course time line", () => {
+    setCourseTimezone("America/Los_Angeles");
+    setBrowserTimezone("America/Chicago");
+
+    renderWithMantine(<CourseTimezoneNotice />);
+
+    const notice = screen.getByTestId("course-timezone-notice");
+
+    expect(notice).toHaveTextContent("America/Los_Angeles");
+    expect(notice).not.toHaveTextContent("in course time");
+  });
+});

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/CourseTimezoneNotice.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/CourseTimezoneNotice.tsx
@@ -1,0 +1,54 @@
+import { Icon } from "@components/ui/Icon";
+import { Alert } from "@mantine/core";
+
+import { formatInTimezone, getCourseTimezoneMismatch } from "@/utils/courseTimezone";
+import { parseUTCDate } from "@/utils/date";
+
+interface CourseTimezoneNoticeProps {
+  /** The due date currently in the form, as a naive UTC string. */
+  value?: string | null;
+}
+
+/**
+ * Warn an instructor who is setting deadlines from a different timezone than
+ * the course runs in.
+ *
+ * The picker edits in the browser's timezone, so "11:59 PM" typed in Chicago
+ * for a Los Angeles course is 9:59 PM for the students. Showing what the
+ * chosen instant actually is in course time makes that visible at the moment
+ * the deadline is set, rather than after someone misses it.
+ */
+export const CourseTimezoneNotice = ({ value }: CourseTimezoneNoticeProps) => {
+  const courseTimezone = window.eBookConfig?.courseTimezone;
+  const chosen = value ? parseUTCDate(value) : null;
+  const at = chosen && !isNaN(chosen.getTime()) ? chosen : new Date();
+  const mismatch = getCourseTimezoneMismatch(courseTimezone, at);
+
+  if (!mismatch) {
+    return null;
+  }
+
+  const direction = mismatch.hoursAhead > 0 ? "ahead of" : "behind";
+  const hours = Math.abs(mismatch.hoursAhead);
+  const hourLabel = hours === 1 ? "hour" : "hours";
+
+  return (
+    <Alert
+      variant="light"
+      color="yellow"
+      icon={<Icon name="exclamation-triangle" size={16} />}
+      title="Your timezone differs from the course timezone"
+      data-testid="course-timezone-notice"
+    >
+      You are in {mismatch.browserTimezone}, {hours} {hourLabel} {direction} the course timezone (
+      {mismatch.courseTimezone}). Dates here are shown on your clock.
+      {chosen && !isNaN(chosen.getTime()) && (
+        <>
+          {" "}
+          This deadline is <strong>{formatInTimezone(chosen, mismatch.courseTimezone)}</strong> in
+          course time.
+        </>
+      )}
+    </Alert>
+  );
+};

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/VisibilityControl.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/edit/VisibilityControl.tsx
@@ -139,7 +139,6 @@ export const VisibilityControl = ({ control, watch, setValue }: VisibilityContro
               <DateTimePicker
                 value={dateField.value}
                 onChange={(val) => dateField.onChange(val)}
-                utc
                 ariaLabel="Visible on date"
               />
             )}
@@ -158,7 +157,6 @@ export const VisibilityControl = ({ control, watch, setValue }: VisibilityContro
               <DateTimePicker
                 value={dateField.value}
                 onChange={(val) => dateField.onChange(val)}
-                utc
                 ariaLabel="Hidden on date"
               />
             )}
@@ -182,7 +180,6 @@ export const VisibilityControl = ({ control, watch, setValue }: VisibilityContro
                   id="visibility-visible-from"
                   value={dateField.value}
                   onChange={(val) => handleVisibleOnChange(val)}
-                  utc
                 />
               )}
             />
@@ -199,7 +196,6 @@ export const VisibilityControl = ({ control, watch, setValue }: VisibilityContro
                   id="visibility-hidden-after"
                   value={dateField.value}
                   onChange={(val) => handleHiddenOnChange(val)}
-                  utc
                 />
               )}
             />

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/AssignmentList.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/AssignmentList.tsx
@@ -9,7 +9,7 @@ import { ColumnDef, OnChangeFn, SortingState } from "@tanstack/react-table";
 import classNames from "classnames";
 
 import { Assignment } from "@/types/assignment";
-import { formatLocalDateForDisplay, formatUTCDateForDisplay } from "@/utils/date";
+import { formatUTCDateForDisplay } from "@/utils/date";
 
 import { VisibilityDropdown } from "./VisibilityDropdown";
 
@@ -169,7 +169,7 @@ export const AssignmentList = ({
           cellClassName: classNames(styles.dateCell, styles.clickableCell),
           onCellClick: onEdit
         },
-        cell: ({ row }) => formatLocalDateForDisplay(row.original.duedate, DATE_FORMAT)
+        cell: ({ row }) => formatUTCDateForDisplay(row.original.duedate, DATE_FORMAT)
       },
       {
         accessorKey: "updated_date",

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/VisibilityDropdown.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/VisibilityDropdown.tsx
@@ -172,7 +172,6 @@ export const VisibilityDropdown = ({ assignment, onChange }: VisibilityDropdownP
                 <DateTimePicker
                   value={visibleOn}
                   onChange={handleVisibleOnChange}
-                  utc
                   withinPortal={false}
                   ariaLabel="Visible on date"
                 />
@@ -185,7 +184,6 @@ export const VisibilityDropdown = ({ assignment, onChange }: VisibilityDropdownP
                 <DateTimePicker
                   value={hiddenOn}
                   onChange={handleHiddenOnChange}
-                  utc
                   withinPortal={false}
                   ariaLabel="Hidden on date"
                 />
@@ -202,7 +200,6 @@ export const VisibilityDropdown = ({ assignment, onChange }: VisibilityDropdownP
                   <DateTimePicker
                     value={visibleOn}
                     onChange={handleVisibleOnChange}
-                    utc
                     withinPortal={false}
                     ariaLabel="Visible from date"
                   />
@@ -214,7 +211,6 @@ export const VisibilityDropdown = ({ assignment, onChange }: VisibilityDropdownP
                   <DateTimePicker
                     value={hiddenOn}
                     onChange={handleHiddenOnChange}
-                    utc
                     withinPortal={false}
                     ariaLabel="Hidden after date"
                   />

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/wizard/AssignmentWizard.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/wizard/AssignmentWizard.tsx
@@ -16,6 +16,8 @@ import { Assignment, KindOfAssignment } from "@/types/assignment";
 
 import { DateTimePicker } from "../../../../ui/DateTimePicker";
 
+import { CourseTimezoneNotice } from "../edit/CourseTimezoneNotice";
+
 import { VisibilityControl } from "../edit/VisibilityControl";
 
 import stepperStyles from "@/components/ui/WizardStepper.module.css";
@@ -149,11 +151,14 @@ export const AssignmentWizard = ({
             control={control}
             defaultValue=""
             render={({ field }) => (
-              <DateTimePicker
-                id="wizard-due-date"
-                value={field.value}
-                onChange={(val) => field.onChange(val)}
-              />
+              <>
+                <DateTimePicker
+                  id="wizard-due-date"
+                  value={field.value}
+                  onChange={(val) => field.onChange(val)}
+                />
+                <CourseTimezoneNotice value={field.value} />
+              </>
             )}
           />
         </div>

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/defaultAssignment.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/defaultAssignment.ts
@@ -1,10 +1,10 @@
 import { CreateAssignmentPayload } from "@/types/assignment";
-import { convertDateToLocalISO } from "@/utils/date";
+import { convertDateToISO } from "@/utils/date";
 
 export const defaultAssignment: CreateAssignmentPayload = {
   name: "",
   description: "",
-  duedate: convertDateToLocalISO(new Date()),
+  duedate: convertDateToISO(new Date()),
   points: 0,
   kind: "Regular",
   time_limit: null,

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/Grader/pages/GraderAssignmentsPage.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/Grader/pages/GraderAssignmentsPage.tsx
@@ -7,6 +7,7 @@ import { Link, useNavigate } from "react-router-dom";
 
 import { DataGrid } from "@/components/ui/DataGrid";
 import { Icon } from "@/components/ui/Icon";
+import { parseUTCDate } from "@/utils/date";
 import { useGetAssignmentsQuery } from "@store/assignment/assignment.logic.api";
 
 import { ReleaseStatusBadge } from "../components/ReleaseStatusBadge";
@@ -23,7 +24,9 @@ const VIEW_MODE_STORAGE_KEY = "grader.assignmentsViewMode";
 const formatDate = (iso?: string | null) => {
   if (!iso) return "No due date";
   try {
-    return new Date(iso).toLocaleDateString(undefined, {
+    // duedate arrives as a naive UTC string; parseUTCDate renders it in the
+    // viewer's local timezone rather than reading it as already-local.
+    return parseUTCDate(iso).toLocaleDateString(undefined, {
       month: "short",
       day: "numeric",
       year: "numeric"
@@ -202,7 +205,7 @@ export const GraderAssignmentsPage: React.FC = () => {
 
   const allRows: AssignmentRow[] = assignments.map((a) => ({
     ...a,
-    duedateDate: a.duedate ? new Date(a.duedate) : null,
+    duedateDate: a.duedate ? parseUTCDate(a.duedate) : null,
     duedateDisplay: formatDate(a.duedate)
   })) as AssignmentRow[];
 

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/ui/DateTimePicker/DateTimePicker.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/ui/DateTimePicker/DateTimePicker.tsx
@@ -4,23 +4,20 @@ import { Icon } from "@components/ui/Icon";
 import classNames from "classnames";
 import DatePicker from "react-datepicker";
 
-import {
-  convertDateToISO,
-  convertDateToLocalISO,
-  getDatePickerFormat,
-  parseUTCDate,
-  parseLocalDate
-} from "@/utils/date";
+import { convertDateToISO, getDatePickerFormat, parseUTCDate } from "@/utils/date";
 
 import styles from "./DateTimePicker.module.css";
 
+/**
+ * The picker shows and edits dates in the viewer's local timezone, but every
+ * datetime the backend stores -- duedate, visible_on, hidden_on -- is naive
+ * UTC, so values always cross this boundary as UTC.
+ */
 interface DateTimePickerProps {
   value: string | null | undefined;
   onChange: (isoString: string) => void;
   placeholder?: string;
   className?: string;
-  /** If true, treat dates as UTC. If false (default), treat as local time. */
-  utc?: boolean;
   /** If false, render the calendar inline instead of portaling it to #root. */
   withinPortal?: boolean;
   id?: string;
@@ -32,18 +29,17 @@ export const DateTimePicker = ({
   onChange,
   placeholder = "Select date and time",
   className,
-  utc = false,
   withinPortal = true,
   id,
   ariaLabel
 }: DateTimePickerProps) => {
   const handleChange = (date: Date | null) => {
     if (date) {
-      onChange(utc ? convertDateToISO(date) : convertDateToLocalISO(date));
+      onChange(convertDateToISO(date));
     }
   };
 
-  const parseDate = (val: string) => (utc ? parseUTCDate(val) : parseLocalDate(val));
+  const parseDate = (val: string) => parseUTCDate(val);
 
   return (
     <div className={classNames(styles.wrapper, className)}>

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/global.d.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/global.d.ts
@@ -7,6 +7,8 @@ declare global {
     username: string;
     isLoggedIn: boolean;
     author: string;
+    /** IANA timezone of the course, e.g. "America/Chicago". */
+    courseTimezone: string;
   }>;
 
   interface Window {

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/utils/courseTimezone.spec.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/utils/courseTimezone.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { formatInTimezone, getCourseTimezoneMismatch } from "./courseTimezone";
+
+// A summer instant, so US zones are on daylight time.
+const SUMMER = new Date("2026-07-15T12:00:00Z");
+// A winter instant, so they are not.
+const WINTER = new Date("2026-01-15T12:00:00Z");
+
+describe("getCourseTimezoneMismatch", () => {
+  it("returns null when the browser matches the course", () => {
+    expect(getCourseTimezoneMismatch("America/Chicago", SUMMER, "America/Chicago")).toBeNull();
+  });
+
+  it("reports how far ahead the browser is", () => {
+    // Chicago (CDT, -5) is 2 hours ahead of Los Angeles (PDT, -7).
+    const result = getCourseTimezoneMismatch("America/Los_Angeles", SUMMER, "America/Chicago");
+
+    expect(result).toEqual({
+      courseTimezone: "America/Los_Angeles",
+      browserTimezone: "America/Chicago",
+      hoursAhead: 2
+    });
+  });
+
+  it("reports a negative offset when the browser is behind", () => {
+    const result = getCourseTimezoneMismatch("America/Chicago", SUMMER, "America/Los_Angeles");
+
+    expect(result?.hoursAhead).toBe(-2);
+  });
+
+  it("handles zones on the other side of the world", () => {
+    // Tokyo (+9) vs Chicago (CDT, -5) is 14 hours.
+    const result = getCourseTimezoneMismatch("America/Chicago", SUMMER, "Asia/Tokyo");
+
+    expect(result?.hoursAhead).toBe(14);
+  });
+
+  it("handles half hour offsets", () => {
+    const result = getCourseTimezoneMismatch("UTC", SUMMER, "Asia/Kolkata");
+
+    expect(result?.hoursAhead).toBe(5.5);
+  });
+
+  it("treats a course with no timezone as UTC", () => {
+    expect(getCourseTimezoneMismatch(null, SUMMER, "UTC")).toBeNull();
+    expect(getCourseTimezoneMismatch("", SUMMER, "UTC")).toBeNull();
+    expect(getCourseTimezoneMismatch(undefined, SUMMER, "Asia/Tokyo")?.hoursAhead).toBe(9);
+  });
+
+  it("does not warn when two differently named zones share an offset", () => {
+    // Same clock, different name -- warning about this would be noise.
+    expect(getCourseTimezoneMismatch("America/Chicago", WINTER, "America/Mexico_City")).toBeNull();
+  });
+
+  it("uses the offset in effect at the given instant, not today's", () => {
+    // Phoenix does not observe DST, so its gap with Chicago changes by season.
+    const summer = getCourseTimezoneMismatch("America/Phoenix", SUMMER, "America/Chicago");
+    const winter = getCourseTimezoneMismatch("America/Phoenix", WINTER, "America/Chicago");
+
+    expect(summer?.hoursAhead).toBe(2);
+    expect(winter?.hoursAhead).toBe(1);
+  });
+
+  it("returns null when the browser timezone is unknown", () => {
+    expect(getCourseTimezoneMismatch("America/Chicago", SUMMER, "")).toBeNull();
+  });
+
+  it("returns null rather than throwing on an unrecognized zone", () => {
+    expect(getCourseTimezoneMismatch("Mars/Olympus", SUMMER, "America/Chicago")).toBeNull();
+  });
+});
+
+describe("formatInTimezone", () => {
+  it("renders the instant as wall clock time in the requested zone", () => {
+    // 2026-09-02 04:59 UTC is 2026-09-01 21:59 in Los Angeles.
+    const result = formatInTimezone(new Date("2026-09-02T04:59:00Z"), "America/Los_Angeles");
+
+    expect(result).toContain("Sep");
+    expect(result).toContain("01");
+    expect(result).toContain("09:59");
+    expect(result).toMatch(/PDT|GMT-7/);
+  });
+
+  it("falls back to a plain locale string on a bad zone", () => {
+    const date = new Date("2026-09-02T04:59:00Z");
+
+    expect(formatInTimezone(date, "Mars/Olympus")).toBe(date.toLocaleString());
+  });
+});

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/utils/courseTimezone.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/utils/courseTimezone.ts
@@ -1,0 +1,110 @@
+/**
+ * Detecting when an instructor is authoring deadlines from a different
+ * timezone than the course runs in.
+ *
+ * The date picker works in the browser's timezone, so an instructor in Chicago
+ * setting "11:59 PM" for a Los Angeles course is really setting 9:59 PM for
+ * their students. That is easy to do by accident and hard to notice, so the
+ * builder warns when the two zones disagree.
+ */
+
+export interface CourseTimezoneMismatch {
+  courseTimezone: string;
+  browserTimezone: string;
+  /** Offset difference in hours at the given instant, browser minus course. */
+  hoursAhead: number;
+}
+
+export const getBrowserTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+  } catch {
+    return "";
+  }
+};
+
+/** Offset of a timezone from UTC, in minutes, at a given instant. */
+const offsetMinutes = (timeZone: string, at: Date): number | null => {
+  try {
+    // Formatting the same instant as if it were UTC gives back the wall clock
+    // in that zone; the difference from the real instant is the offset.
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit"
+    }).formatToParts(at);
+
+    const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+    const asUTC = Date.UTC(
+      get("year"),
+      get("month") - 1,
+      get("day"),
+      get("hour") % 24,
+      get("minute"),
+      get("second")
+    );
+
+    return Math.round((asUTC - at.getTime()) / 60000);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Compare the course timezone against the browser's.
+ *
+ * Returns null when they agree, when either is unknown, or when they differ in
+ * name but not in actual offset at `at` -- "America/Chicago" and
+ * "America/Mexico_City" may be the same clock, and warning about that would be
+ * noise. A course with no timezone set is treated as UTC, matching the
+ * backend.
+ */
+export const getCourseTimezoneMismatch = (
+  courseTimezone: string | undefined | null,
+  at: Date = new Date(),
+  browserTimezone: string = getBrowserTimezone()
+): CourseTimezoneMismatch | null => {
+  const course = courseTimezone || "UTC";
+  if (!browserTimezone || browserTimezone === course) {
+    return null;
+  }
+
+  const courseOffset = offsetMinutes(course, at);
+  const browserOffset = offsetMinutes(browserTimezone, at);
+  if (courseOffset === null || browserOffset === null) {
+    return null;
+  }
+
+  const diff = browserOffset - courseOffset;
+  if (diff === 0) {
+    return null;
+  }
+
+  return {
+    courseTimezone: course,
+    browserTimezone,
+    hoursAhead: diff / 60
+  };
+};
+
+/** Render an instant as wall clock time in a specific timezone. */
+export const formatInTimezone = (date: Date, timeZone: string): string => {
+  try {
+    return date.toLocaleString(undefined, {
+      timeZone,
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short"
+    });
+  } catch {
+    return date.toLocaleString();
+  }
+};

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/utils/date.spec.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/utils/date.spec.ts
@@ -1,13 +1,9 @@
 import {
   convertDateToISO,
-  convertDateToLocalISO,
   getDatePickerFormat,
   parseUTCDate,
-  parseLocalDate,
   formatUTCDateForDisplay,
-  formatLocalDateForDisplay,
-  formatUTCDateLocaleString,
-  formatLocalDateLocaleString
+  formatUTCDateLocaleString
 } from "./date";
 
 describe("convertDateToISO", () => {
@@ -27,34 +23,6 @@ describe("convertDateToISO", () => {
   it("returns exactly 19 characters", () => {
     const date = new Date("2000-01-01T00:00:00Z");
     expect(convertDateToISO(date)).toHaveLength(19);
-  });
-});
-
-describe("convertDateToLocalISO", () => {
-  it("formats each date component with zero-padding", () => {
-    const date = new Date(2026, 0, 5, 9, 7, 3);
-    const result = convertDateToLocalISO(date);
-    expect(result).toBe("2026-01-05T09:07:03");
-  });
-
-  it("returns a string matching the ISO-like local pattern", () => {
-    const date = new Date(2026, 11, 31, 23, 59, 59);
-    const result = convertDateToLocalISO(date);
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
-    expect(result).toBe("2026-12-31T23:59:59");
-  });
-
-  it("does not append a timezone designator", () => {
-    const date = new Date(2026, 5, 15, 12, 30, 0);
-    const result = convertDateToLocalISO(date);
-    expect(result.endsWith("Z")).toBe(false);
-    expect(result).not.toMatch(/[+-]\d{2}:\d{2}$/);
-  });
-
-  it("pads single-digit month and day", () => {
-    const date = new Date(2026, 2, 3, 8, 5, 2);
-    const result = convertDateToLocalISO(date);
-    expect(result).toBe("2026-03-03T08:05:02");
   });
 });
 
@@ -113,38 +81,6 @@ describe("parseUTCDate", () => {
   });
 });
 
-describe("parseLocalDate", () => {
-  it("parses a naive date string as local time (no Z appended)", () => {
-    const dateStr = "2026-06-15T10:30:00";
-    const result = parseLocalDate(dateStr);
-    expect(result).toBeInstanceOf(Date);
-    expect(result.getFullYear()).toBe(2026);
-    expect(result.getMonth()).toBe(5);
-    expect(result.getDate()).toBe(15);
-    expect(result.getHours()).toBe(10);
-    expect(result.getMinutes()).toBe(30);
-  });
-
-  it("parses a string ending with Z as-is (UTC)", () => {
-    const result = parseLocalDate("2026-02-24T15:00:00Z");
-    expect(result.getUTCHours()).toBe(15);
-  });
-
-  it("parses a string with positive timezone offset as-is", () => {
-    const result = parseLocalDate("2026-02-24T17:00:00+02:00");
-    expect(result.getUTCHours()).toBe(15);
-  });
-
-  it("parses a string with negative timezone offset as-is", () => {
-    const result = parseLocalDate("2026-02-24T10:00:00-05:00");
-    expect(result.getUTCHours()).toBe(15);
-  });
-
-  it("returns a Date instance", () => {
-    expect(parseLocalDate("2026-01-01T00:00:00")).toBeInstanceOf(Date);
-  });
-});
-
 describe("formatUTCDateForDisplay", () => {
   it("returns a non-empty string for a valid UTC naive string", () => {
     const result = formatUTCDateForDisplay("2026-02-24T15:00:00");
@@ -168,24 +104,6 @@ describe("formatUTCDateForDisplay", () => {
   });
 });
 
-describe("formatLocalDateForDisplay", () => {
-  it("returns a non-empty string for a valid local naive string", () => {
-    const result = formatLocalDateForDisplay("2026-06-15T10:30:00");
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
-  });
-
-  it("accepts custom Intl.DateTimeFormatOptions and uses them", () => {
-    const result = formatLocalDateForDisplay("2026-06-15T10:30:00", {
-      year: "numeric",
-      month: "long",
-      day: "numeric"
-    });
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
-  });
-});
-
 describe("formatUTCDateLocaleString", () => {
   it("returns a non-empty locale string for a valid UTC naive string", () => {
     const result = formatUTCDateLocaleString("2026-02-24T15:00:00");
@@ -195,20 +113,6 @@ describe("formatUTCDateLocaleString", () => {
 
   it("returns a string for a UTC string ending with Z", () => {
     const result = formatUTCDateLocaleString("2026-02-24T15:00:00Z");
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
-  });
-});
-
-describe("formatLocalDateLocaleString", () => {
-  it("returns a non-empty locale string for a valid local naive string", () => {
-    const result = formatLocalDateLocaleString("2026-06-15T10:30:00");
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
-  });
-
-  it("returns a string for a string with timezone info", () => {
-    const result = formatLocalDateLocaleString("2026-06-15T10:30:00Z");
     expect(typeof result).toBe("string");
     expect(result.length).toBeGreaterThan(0);
   });

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/utils/date.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/utils/date.ts
@@ -1,25 +1,10 @@
 /**
  * Converts a local Date object to a UTC ISO string (without 'Z' suffix)
- * for sending to the backend which stores dates in UTC.
+ * for sending to the backend, which stores every datetime -- duedate,
+ * visible_on, hidden_on -- as naive UTC.
  */
 export const convertDateToISO = (date: Date): string => {
   return date.toISOString().slice(0, 19); // UTC ISO string without 'Z' and milliseconds
-};
-
-/**
- * Converts a local Date object to a local ISO-like string (without timezone info)
- * for sending to the backend which stores due dates in local time (naive datetime).
- * This preserves the original behavior where due dates are stored as-is in the instructor's
- * local timezone without any UTC conversion.
- */
-export const convertDateToLocalISO = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  const seconds = String(date.getSeconds()).padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
 };
 
 export const getDatePickerFormat = (locale = navigator.language) => {
@@ -40,21 +25,6 @@ export const parseUTCDate = (dateString: string): Date => {
 };
 
 /**
- * Parses a naive date string from the backend as LOCAL time (not UTC).
- * Backend stores due dates in the instructor's local timezone as naive strings
- * (e.g., "2026-02-24T15:00:00"). We parse them without appending 'Z' so
- * JavaScript interprets them as local time.
- */
-export const parseLocalDate = (dateString: string): Date => {
-  // If the string already has timezone info, parse as-is
-  if (dateString.endsWith("Z") || /[+-]\d{2}:\d{2}$/.test(dateString)) {
-    return new Date(dateString);
-  }
-  // Parse as local time by NOT appending 'Z'
-  return new Date(dateString);
-};
-
-/**
  * Formats a UTC date string from the backend for display in the user's local timezone.
  */
 export const formatUTCDateForDisplay = (
@@ -66,30 +36,9 @@ export const formatUTCDateForDisplay = (
 };
 
 /**
- * Formats a local (naive) date string from the backend for display.
- * Since the date is already in local time, no timezone conversion is needed.
- */
-export const formatLocalDateForDisplay = (
-  localString: string,
-  options?: Intl.DateTimeFormatOptions
-): string => {
-  const date = parseLocalDate(localString);
-  return date.toLocaleDateString(undefined, options);
-};
-
-/**
  * Formats a UTC date string from the backend as a locale string in the user's local timezone.
  */
 export const formatUTCDateLocaleString = (utcString: string): string => {
   const date = parseUTCDate(utcString);
-  return date.toLocaleString();
-};
-
-/**
- * Formats a local (naive) date string from the backend as a locale string.
- * Since the date is already in local time, no timezone conversion is needed.
- */
-export const formatLocalDateLocaleString = (localString: string): string => {
-  const date = parseLocalDate(localString);
   return date.toLocaleString();
 };

--- a/bases/rsptx/assignment_server_api/routers/instructor.py
+++ b/bases/rsptx/assignment_server_api/routers/instructor.py
@@ -21,7 +21,6 @@ from fastapi.responses import (
     JSONResponse,
     StreamingResponse,
 )
-from fastapi.templating import Jinja2Templates
 from sqlalchemy import create_engine
 from pydantic import BaseModel
 from typing import List, Optional, Annotated
@@ -86,7 +85,7 @@ from rsptx.db.crud.assignment import (
     is_assignment_visible_to_students,
 )
 from rsptx.auth.session import auth_manager, is_instructor
-from rsptx.templates import template_folder
+from rsptx.templates import format_course_datetime, get_shared_templates
 from rsptx.configuration import settings
 from rsptx.response_helpers import construct_course_url
 from rsptx.response_helpers.core import (
@@ -245,7 +244,9 @@ async def review_peer_assignment(
         "assignment_details": {
             "id": assignment.id,
             "name": assignment.name,
-            "due_date": assignment.duedate.strftime("%Y-%m-%d %H:%M:%S"),
+            "due_date": format_course_datetime(
+                assignment.duedate, course.timezone, fmt="%Y-%m-%d %H:%M:%S"
+            ),
             "visible": assignment.visible,
             "released": assignment.released,
             "description": assignment.description,
@@ -259,7 +260,7 @@ async def review_peer_assignment(
         "settings": settings,
     }
 
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     response = templates.TemplateResponse(
         "assignment/instructor/reviewPeerAssignment.html", context
     )
@@ -522,7 +523,7 @@ async def get_assignment_gb(
             names[row.username] = row.first_name + " " + row.last_name
 
     # pt = pt.drop(columns=["username"], axis=1)
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     # rename the columns in cols to cols_plus_points
     rename_dict = {old: new for old, new in zip(cols, display_cols)}
     pt = pt.rename(columns=rename_dict)
@@ -1230,7 +1231,7 @@ async def get_builder(
             return RedirectResponse(url="/")
 
     reactdir = pathlib.Path(__file__).parent.parent / "react"
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     wp_imports = get_webpack_static_imports(course)
     react_imports = get_react_imports(reactdir)
     course_attrs = await fetch_all_course_attributes(course.id)
@@ -1337,7 +1338,7 @@ async def make_invoice_request(
         is_instructor=user_is_instructor,
         referer=referer,
     )
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     response = templates.TemplateResponse("assignment/instructor/invoice.html", context)
 
     return response
@@ -1560,7 +1561,7 @@ async def do_assignment_summary(
         "is_instructor": True,
         "student_page": False,
     }
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     response = templates.TemplateResponse(
         "assignment/instructor/assignment_summary.html", context
     )
@@ -1743,7 +1744,7 @@ async def get_add_token_page(
 
     total_tokens = len(tokens)
 
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     context = {
         "course": course,
         "user": user,

--- a/bases/rsptx/assignment_server_api/routers/peer.py
+++ b/bases/rsptx/assignment_server_api/routers/peer.py
@@ -21,7 +21,6 @@ import pandas as pd
 # -------------------
 from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.templating import Jinja2Templates
 from rsptx.auth.session import auth_manager
 from rsptx.configuration import settings
 from rsptx.db.async_session import async_session
@@ -52,7 +51,7 @@ from rsptx.logging import rslogger
 from rsptx.response_helpers.core import (
     get_webpack_static_imports,
 )
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 # Analogy themes for async LLM mode
 # ==================================
@@ -98,7 +97,7 @@ async def get_peer_instructor(
     Display the peer instruction instructor interface showing all peer assignments.
     """
     rslogger.info(f"Rendering peer instructor page for course: {course.course_name}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Fetch all peer assignments for the course
     all_assignments = await fetch_assignments(course.course_name, fetch_all=True)
@@ -140,7 +139,7 @@ async def get_peer_dashboard(
     This is where instructors control the flow of peer instruction.
     """
     rslogger.info(f"Peer dashboard for assignment {assignment_id}, next={next}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Fetch the assignment
     assignment = await fetch_one_assignment(assignment_id)
@@ -285,7 +284,7 @@ async def get_peer_extra(
     Meant to be opened on a separate device so students can't see it.
     """
     rslogger.info(f"Peer extra info for assignment {assignment_id}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     assignment = await fetch_one_assignment(assignment_id)
     questions_result = await fetch_assignment_questions(assignment_id)
@@ -353,7 +352,7 @@ async def get_peer_student(
     Display the peer instruction student interface showing available peer assignments.
     """
     rslogger.info(f"Rendering peer student page for user: {user.username}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Fetch visible peer assignments for the student
     all_assignments = await fetch_assignments(
@@ -393,7 +392,7 @@ async def get_peer_question(
     Display the current peer instruction question for in-class participation.
     """
     rslogger.info(f"Peer question for assignment {assignment_id}, user {user.username}")
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     # Fetch the assignment and its questions
     assignment = await fetch_one_assignment(assignment_id)
@@ -516,7 +515,7 @@ async def get_peer_async(
     rslogger.info(
         f"Peer async for assignment {assignment_id}, question {question_num}, user {user.username}"
     )
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
 
     assignment = await fetch_one_assignment(assignment_id)
     if not assignment:

--- a/bases/rsptx/assignment_server_api/routers/student.py
+++ b/bases/rsptx/assignment_server_api/routers/student.py
@@ -14,7 +14,6 @@
 # Standard library
 # ----------------
 import csv
-import datetime
 import io
 from typing import Optional
 import json
@@ -30,7 +29,6 @@ from fastapi.responses import (
     RedirectResponse,
     StreamingResponse,
 )
-from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 # Local application imports
@@ -67,7 +65,11 @@ from rsptx.grading_helpers.regrade import RegradeOptions, regrade_batch
 from rsptx.db.models import GradeValidator, UseinfoValidation, CoursesValidator
 from rsptx.db.crud.assignment import is_assignment_visible_to_students
 from rsptx.auth.session import auth_manager, is_instructor
-from rsptx.templates import template_folder, get_jinja_templates
+from rsptx.templates import (
+    format_course_datetime,
+    get_jinja_templates,
+    get_shared_templates,
+)
 from rsptx.response_helpers import construct_course_url, safe_join
 from rsptx.response_helpers.core import (
     make_json_response,
@@ -92,7 +94,6 @@ async def get_assignments(
     request: Request,
     user=Depends(auth_manager),
     response_class=HTMLResponse,
-    RS_info: Optional[str] = Cookie(None),
 ):
     """Create the chooseAssignment page for the user.
 
@@ -139,25 +140,16 @@ async def get_assignments(
             ]
             assignments = list(assignments) + exception_assignments
 
-    parsed_js = json.loads(RS_info) if RS_info else {}
-    timezoneoffset = parsed_js.get("tz_offset", None)
+    now = canonical_utcnow()
 
     def sort_key(assignment):
-        deadline = assignment.duedate
-        if timezoneoffset:
-            deadline = deadline + datetime.timedelta(hours=float(timezoneoffset))
-            return (
-                deadline < canonical_utcnow(),
-                abs((deadline - canonical_utcnow()).total_seconds()),
-            )
-        else:
-            return (
-                assignment.duedate < canonical_utcnow(),
-                abs((assignment.duedate - canonical_utcnow()).total_seconds()),
-            )
+        # duedate is stored as naive UTC, so it is directly comparable to now.
+        return (
+            assignment.duedate < now,
+            abs((assignment.duedate - now).total_seconds()),
+        )
 
     # Sort assignments: upcoming assignments first (closest to current date), past due assignments last
-    now = canonical_utcnow()
     assignments.sort(key=sort_key)
     stats_list = await fetch_all_assignment_stats(course.course_name, user.id)
     stats = {}
@@ -190,9 +182,9 @@ async def get_assignments(
                 "Unsafe or invalid book_path computed for course %s; falling back to shared templates",
                 course.course_name,
             )
-            templates = Jinja2Templates(directory=template_folder)
+            templates = get_shared_templates()
     else:
-        templates = Jinja2Templates(directory=template_folder)
+        templates = get_shared_templates()
 
     context = dict(
         course=course,
@@ -301,19 +293,27 @@ def _build_chapter_progress(chapters, subchapters, progress):
     return result
 
 
-async def _build_assignment_grades(course_name, target_id, student_view):
+async def _build_assignment_grades(
+    course_name, target_id, student_view, course_timezone=None
+):
     """Build the per-assignment grade table (score, percent, class average).
 
     :param course_name: The course name.
     :param target_id: The auth_user id of the student being reported on.
     :param student_view: bool, True when a student is viewing their own report;
         unreleased assignments are shown as N/A in that case.
+    :param course_timezone: The course timezone used to render due dates, which
+        are stored as naive UTC.
     :return: dict keyed by assignment name.
     """
     assignments = await fetch_assignments(course_name, fetch_all=True)
     grades = {}
     for assign in assignments:
-        due_date = assign.duedate.date().strftime("%m-%d-%Y")
+        # Shift into course-local time before taking the date: a late-evening
+        # deadline falls on the following day in UTC.
+        due_date = format_course_datetime(
+            assign.duedate, course_timezone, fmt="%m-%d-%Y", show_timezone=False
+        )
         entry = {
             "score": "N/A",
             "pct": "N/A",
@@ -411,13 +411,13 @@ async def studentreport(
 
     # Grades ------------------------------------------------------------------
     grades = await _build_assignment_grades(
-        course.course_name, target_user.id, student_view
+        course.course_name, target_user.id, student_view, course.timezone
     )
 
     # Recent activity ---------------------------------------------------------
     activity = await fetch_recent_useinfo(sid, course.course_name)
 
-    templates = Jinja2Templates(directory=template_folder)
+    templates = get_shared_templates()
     context = dict(
         request=request,
         course=course,
@@ -928,13 +928,11 @@ async def doAssignment(
     else:
         is_graded = False
 
-    timezoneoffset = parsed_js.get("tz_offset", None)
-
     timestamp = canonical_utcnow()
+    # duedate is stored as naive UTC, so it is directly comparable to timestamp.
+    # The template renders it in the course timezone via the course_datetime
+    # filter, so leave the datetime itself intact here.
     deadline = assignment.duedate
-    if timezoneoffset:
-        deadline = deadline + datetime.timedelta(hours=float(timezoneoffset))
-    assignment.duedate = assignment.duedate.strftime("%a %d, %b %Y %I:%M %p")
     enforce_pastdue = False
     if assignment.enforce_due and timestamp > deadline:
         enforce_pastdue = True
@@ -959,11 +957,11 @@ async def doAssignment(
                 "Unsafe or invalid book_path computed for course %s; falling back to shared templates",
                 course.course_name,
             )
-            templates = Jinja2Templates(directory=template_folder)
+            templates = get_shared_templates()
     else:
-        templates = Jinja2Templates(directory=template_folder)
+        templates = get_shared_templates()
 
-    # templates = Jinja2Templates(directory=template_folder)
+    # templates = get_shared_templates()
     # reverse the order of the keys in the preambles dictionary so that the first key I added is now the last
     # this will ensure that when multiple preamble definitions are used the last one is from the current course
     preambles = dict((k, v) for k, v in reversed(preambles.items()))

--- a/bases/rsptx/author_server_api/main.py
+++ b/bases/rsptx/author_server_api/main.py
@@ -26,7 +26,6 @@ import aiofiles
 from fastapi import Body, FastAPI, Request, Depends, status
 from fastapi.responses import JSONResponse, RedirectResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
 from celery.result import AsyncResult
 import pandas as pd
 from sqlalchemy import create_engine
@@ -73,7 +72,7 @@ from rsptx.visualization.authorImpact import (
     get_course_graph,
 )
 from rsptx.auth.session import auth_manager
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates, template_folder
 
 logger = logging.getLogger("runestone")
 handler = logging.StreamHandler(sys.stdout)
@@ -88,7 +87,7 @@ app = FastAPI()
 # We need to create a path that will work inside and outside of docker.
 base_dir = pathlib.Path(template_folder)
 app.mount("/static", StaticFiles(directory=base_dir / "staticAssets"), name="static")
-templates = Jinja2Templates(directory=template_folder)
+templates = get_shared_templates()
 
 add_exception_handlers(app)
 

--- a/bases/rsptx/book_server_api/routers/books.py
+++ b/bases/rsptx/book_server_api/routers/books.py
@@ -315,15 +315,8 @@ async def serve_page(
         activity_info = await fetch_page_activity_counts(
             chapter, subchapter, course_row.base_course, course_name, user.username
         )
-        if not course_row.timezone:
-            if RS_info:
-                tz = json.loads(RS_info).get("timezone", "UTC")
-            else:
-                tz = "UTC"
-        else:
-            tz = course_row.timezone
         assignment__spec = await fetch_reading_assignment_spec(
-            chapter, subchapter, course_row.id, timezone=tz
+            chapter, subchapter, course_row.id
         )
         if assignment__spec:
             activity_info["assignment_spec"] = dict(**assignment__spec._mapping)

--- a/bases/rsptx/book_server_api/routers/course.py
+++ b/bases/rsptx/book_server_api/routers/course.py
@@ -8,20 +8,17 @@
 #
 # Standard library
 # ----------------
-import json
 import datetime
 
 # Third-party imports
 # -------------------
-from typing import Optional
-from fastapi import APIRouter, Cookie, Request, Depends, status
-from fastapi.templating import Jinja2Templates
+from fastapi import APIRouter, Request, Depends, status
 
 # Local application imports
 # -------------------------
 
 from rsptx.auth.session import auth_manager
-from rsptx.templates import get_jinja_templates, template_folder
+from rsptx.templates import get_jinja_templates, get_shared_templates
 from rsptx.db.crud import (
     fetch_assignments,
     fetch_all_assignment_stats,
@@ -58,9 +55,7 @@ router = APIRouter(
 
 
 @router.api_route("/index", methods=["GET", "POST"])
-async def index(
-    request: Request, user=Depends(auth_manager), RS_info: Optional[str] = Cookie(None)
-):
+async def index(request: Request, user=Depends(auth_manager)):
     """Fetch current course information
        Fetch current assignment information
 
@@ -114,24 +109,16 @@ async def index(
             assignments = list(assignments) + exception_assignments
     assignments = adjust_deadlines(assignments, accommodations)
 
-    parsed_js = json.loads(RS_info) if RS_info else {}
-    timezoneoffset = parsed_js.get("tz_offset", None)
+    now = canonical_utcnow()
 
     def sort_key(assignment):
-        deadline = assignment.duedate
-        if timezoneoffset:
-            deadline = deadline + datetime.timedelta(hours=float(timezoneoffset))
-            return (
-                deadline < canonical_utcnow(),
-                abs((deadline - canonical_utcnow()).total_seconds()),
-            )
-        else:
-            return (
-                assignment.duedate < canonical_utcnow(),
-                abs((assignment.duedate - canonical_utcnow()).total_seconds()),
-            )
+        # duedate is stored as naive UTC, so it is directly comparable to now.
+        # Upcoming assignments sort first, closest deadline first.
+        return (
+            assignment.duedate < now,
+            abs((assignment.duedate - now).total_seconds()),
+        )
 
-    now = canonical_utcnow()
     assignments.sort(key=sort_key)
 
     stats_list = await fetch_all_assignment_stats(course_name, user.id)
@@ -160,9 +147,9 @@ async def index(
         if book_path:
             templates = get_jinja_templates(book_path)
         else:
-            templates = Jinja2Templates(directory=template_folder)
+            templates = get_shared_templates()
     else:
-        templates = Jinja2Templates(directory=template_folder)
+        templates = get_shared_templates()
 
     return templates.TemplateResponse(
         "book/course/current_course.html",

--- a/bases/rsptx/book_server_api/routers/rslogging.py
+++ b/bases/rsptx/book_server_api/routers/rslogging.py
@@ -188,16 +188,7 @@ async def log_book_event(
             ans_idx = await create_answer_table_entry(valid_table, entry.event)
             rslogger.debug(ans_idx)
         if entry.event != "timedExam" and entry.event != "selectquestion":
-            course = await fetch_course(user.course_name)
-            if course.timezone:
-                tz = course.timezone
-            else:
-                if hasattr(request.state, "timezone"):
-                    tz = request.state.timezone
-                    rslogger.debug(f"Using timezone {tz} from request state")
-                else:
-                    tz = "UTC"
-            scoreSpec = await grade_submission(user, entry, tz)
+            scoreSpec = await grade_submission(user, entry)
             response_dict.update(scoreSpec.model_dump())
 
     if idx:

--- a/components/rsptx/db/crud/scoring.py
+++ b/components/rsptx/db/crud/scoring.py
@@ -1,7 +1,8 @@
 import datetime
 from typing import List, Optional
 from sqlalchemy import select, and_, or_
-from zoneinfo import ZoneInfo
+
+from rsptx.response_helpers.core import canonical_utcnow
 
 from ..models import (
     Assignment,
@@ -47,7 +48,6 @@ async def is_assigned(
     course_id: int,
     assignment_id: Optional[int] = None,
     accommodation: Optional[DeadlineExceptionValidator] = None,
-    timezone: Optional[str] = "UTC",
 ) -> schemas.ScoringSpecification:
     """
     Check if a question is part of an assignment.
@@ -78,8 +78,7 @@ async def is_assigned(
     visible_exception = False
     if accommodation and accommodation.visible:
         visible_exception = True
-    tz = ZoneInfo(timezone)
-    course_tz_now = datetime.datetime.now(tz)
+    now = canonical_utcnow()
     async with async_session() as session:
         res = await session.execute(query)
         for row in res:
@@ -97,7 +96,7 @@ async def is_assigned(
             )
             if accommodation and accommodation.duedate:
                 row.Assignment.duedate += datetime.timedelta(days=accommodation.duedate)
-            if course_tz_now <= row.Assignment.duedate.replace(tzinfo=tz):
+            if now <= row.Assignment.duedate:
                 if is_assignment_visible_to_students(row.Assignment):
                     scoringSpec.assigned = True
                     return scoringSpec
@@ -116,7 +115,6 @@ async def fetch_reading_assignment_spec(
     chapter: str,
     subchapter: str,
     course_id: int,
-    timezone: Optional[str] = "UTC",
 ) -> Optional[int]:
     """
     Check if a reading assignment is assigned for a given chapter and subchapter.
@@ -126,11 +124,6 @@ async def fetch_reading_assignment_spec(
     :param course_id: int, the id of the course
     :return: The number of required activities or None if not found
     """
-    tz = ZoneInfo(timezone)
-    course_tz_now = datetime.datetime.now(tz)
-    course_tz_now = course_tz_now.replace(tzinfo=None)
-    from rsptx.response_helpers.core import canonical_utcnow
-
     now = canonical_utcnow()
     # Visibility clause that respects visible_on and hidden_on scheduling
     vclause = or_(
@@ -175,7 +168,7 @@ async def fetch_reading_assignment_spec(
                 Question.subchapter == subchapter,
                 vclause,
                 or_(
-                    Assignment.duedate > course_tz_now,
+                    Assignment.duedate > now,
                     Assignment.enforce_due == False,  # noqa: E712
                 ),
             )

--- a/components/rsptx/exceptions/core.py
+++ b/components/rsptx/exceptions/core.py
@@ -7,7 +7,6 @@ from urllib.parse import quote
 from fastapi import Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from pydantic import ValidationError
 
 
@@ -16,7 +15,7 @@ from rsptx.configuration import settings
 from rsptx.db.crud import create_traceback
 from rsptx.logging import rslogger
 from rsptx.response_helpers.core import canonical_utcnow
-from rsptx.templates import template_folder
+from rsptx.templates import get_shared_templates
 
 
 def add_exception_handlers(app):
@@ -146,7 +145,7 @@ def add_exception_handlers(app):
                 "timestamp": date,
             }
 
-            templates = Jinja2Templates(directory=template_folder)
+            templates = get_shared_templates()
             return templates.TemplateResponse("error_page.html", context)
         else:
             return JSONResponse(

--- a/components/rsptx/grading_helpers/core.py
+++ b/components/rsptx/grading_helpers/core.py
@@ -1,6 +1,5 @@
 from typing import Union, List
 from datetime import timedelta
-from zoneinfo import ZoneInfo
 from rsptx.db.models import AuthUserValidator, DeadlineExceptionValidator
 from rsptx.db.crud import (
     is_assigned,
@@ -35,7 +34,7 @@ from rsptx.grading_helpers.scoring import (
 
 
 async def grade_submission(
-    user: AuthUserValidator, submission: LogItemIncoming, timezone: str = "UTC"
+    user: AuthUserValidator, submission: LogItemIncoming
 ) -> ScoringSpecification:
     """
     Grade a submission and store the results in the database.
@@ -64,7 +63,6 @@ async def grade_submission(
         user.course_id,
         submission.assignment_id,
         accommodation=accommodation,
-        timezone=timezone,
     )
     # Skip scoring for interaction events these are just logs that the student
     # did something with a selectquestion.  This is required to get accurate grades
@@ -337,9 +335,7 @@ def adjust_deadlines(
     return assignment_list
 
 
-async def has_late_submission(
-    username: str, assignment_id: int, timezone: str = "UTC"
-) -> bool:
+async def has_late_submission(username: str, assignment_id: int) -> bool:
     """
     Determine whether a student has saved work for any question on an
     assignment after its deadline.
@@ -356,8 +352,6 @@ async def has_late_submission(
 
     :param username: The student's username (``auth_user.username`` / ``sid``).
     :param assignment_id: The id of the assignment to check.
-    :param timezone: The course timezone used to interpret the due date, which
-        is stored in course-local time.
     :return: True if the student saved work after the enforced (and
         accommodated) deadline, False otherwise.
     """
@@ -376,11 +370,6 @@ async def has_late_submission(
     if accommodation and accommodation.duedate:
         deadline += timedelta(days=accommodation.duedate)
 
-    # The due date is stored in the course's local timezone, while useinfo
-    # timestamps are stored as naive UTC, so convert before comparing.
-    tz = ZoneInfo(timezone)
-    deadline_utc = (
-        deadline.replace(tzinfo=tz).astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
-    )
-
-    return await has_submissions_after_deadline(username, assignment_id, deadline_utc)
+    # Both the due date and the useinfo timestamps are naive UTC, so they are
+    # directly comparable.
+    return await has_submissions_after_deadline(username, assignment_id, deadline)

--- a/components/rsptx/grading_helpers/regrade.py
+++ b/components/rsptx/grading_helpers/regrade.py
@@ -98,6 +98,11 @@ async def _fetch_answer_rows(tbl, div_id: str, course_name: str, sid: str):
 
 
 def _effective_deadline(assignment: AssignmentValidator, accommodation):
+    """Return the assignment deadline as naive UTC, with any accommodation applied.
+
+    ``Assignment.duedate`` is stored as naive UTC, the same as the answer table
+    timestamps it gets compared against, so no timezone conversion belongs here.
+    """
     deadline = assignment.duedate
     if deadline is None:
         return None

--- a/components/rsptx/lti1p3/core.py
+++ b/components/rsptx/lti1p3/core.py
@@ -76,7 +76,14 @@ def update_line_item_from_assignment(
         get_assignment_score_resource_id(rs_course, rs_assignment)
     )
     if push_duedate:
-        line_item.set_end_date_time(rs_assignment.duedate.isoformat())
+        # duedate is stored as naive UTC. Send it with an explicit offset,
+        # matching the format time_now() uses -- without one the LMS is free to
+        # read it as its own local time and silently shift the deadline.
+        line_item.set_end_date_time(
+            rs_assignment.duedate.replace(tzinfo=datetime.timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
     line_item.set_tag("grade")
     line_item.set_score_maximum(rs_assignment.points if use_pts else 100)
     return line_item

--- a/components/rsptx/templates/__init__.py
+++ b/components/rsptx/templates/__init__.py
@@ -1,7 +1,19 @@
 from pathlib import Path
 from rsptx.templates import core
-from rsptx.templates.core import get_jinja_templates
+from rsptx.templates.core import (
+    format_course_datetime,
+    get_jinja_templates,
+    get_shared_templates,
+    install_filters,
+)
 
-__all__ = ["core", "get_jinja_templates", "template_folder"]
+__all__ = [
+    "core",
+    "format_course_datetime",
+    "get_jinja_templates",
+    "get_shared_templates",
+    "install_filters",
+    "template_folder",
+]
 
 template_folder = Path(__file__).parent.absolute()

--- a/components/rsptx/templates/assignment/instructor/peer_instructor.html
+++ b/components/rsptx/templates/assignment/instructor/peer_instructor.html
@@ -130,7 +130,7 @@ Peer Instruction - Instructor
                             {{ assignment.name }} - Review
                         </a>
                     </td>
-                    <td>{{ assignment.duedate.strftime('%Y-%m-%d %H:%M') if assignment.duedate else 'N/A' }}</td>
+                    <td>{{ assignment.duedate | course_datetime(course.timezone, '%Y-%m-%d %H:%M') if assignment.duedate else 'N/A' }}</td>
                     <td>{{ assignment.description or '' }}</td>
                 </tr>
                 {% endfor %}

--- a/components/rsptx/templates/assignment/instructor/peer_instructor.html
+++ b/components/rsptx/templates/assignment/instructor/peer_instructor.html
@@ -130,7 +130,7 @@ Peer Instruction - Instructor
                             {{ assignment.name }} - Review
                         </a>
                     </td>
-                    <td>{{ assignment.duedate | course_datetime(course.timezone, '%Y-%m-%d %H:%M') if assignment.duedate else 'N/A' }}</td>
+                    <td>{{ course_datetime_tag(assignment.duedate, course.timezone, style='short', empty='N/A') }}</td>
                     <td>{{ assignment.description or '' }}</td>
                 </tr>
                 {% endfor %}
@@ -145,6 +145,7 @@ Peer Instruction - Instructor
 {% endblock %}
 
 {% block js %}
+{% include 'common/localize_times.html' %}
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const toggles = document.querySelectorAll('.visibility-toggle');

--- a/components/rsptx/templates/assignment/student/assignment_block.html
+++ b/components/rsptx/templates/assignment/student/assignment_block.html
@@ -47,7 +47,7 @@
     </td>
     {% endif %}
       
-      <td {% if assignment.duedate < now %}class="overdue"{% endif %}>{{assignment.duedate.strftime("%b %d, %Y %I:%M %p")}}</td>
+      <td {% if assignment.duedate < now %}class="overdue"{% endif %}>{{ assignment.duedate | course_datetime(course.timezone) }}</td>
       <td>
         {% if assignment.id in stats and stats[assignment.id].score != None %}
         {{ stats[assignment.id].score | round(2) }} / {{ assignment.points }}

--- a/components/rsptx/templates/assignment/student/assignment_block.html
+++ b/components/rsptx/templates/assignment/student/assignment_block.html
@@ -47,7 +47,7 @@
     </td>
     {% endif %}
       
-      <td {% if assignment.duedate < now %}class="overdue"{% endif %}>{{ assignment.duedate | course_datetime(course.timezone) }}</td>
+      <td {% if assignment.duedate < now %}class="overdue"{% endif %}>{{ course_datetime_tag(assignment.duedate, course.timezone) }}</td>
       <td>
         {% if assignment.id in stats and stats[assignment.id].score != None %}
         {{ stats[assignment.id].score | round(2) }} / {{ assignment.points }}

--- a/components/rsptx/templates/assignment/student/chooseAssignment.html
+++ b/components/rsptx/templates/assignment/student/chooseAssignment.html
@@ -31,5 +31,6 @@ Choose Assignment
 
 
 {% block js %}
+{% include 'common/localize_times.html' %}
 <script src="/staticAssets/assignment/student.js"></script>
 {% endblock %}

--- a/components/rsptx/templates/assignment/student/doAssignment.html
+++ b/components/rsptx/templates/assignment/student/doAssignment.html
@@ -40,7 +40,7 @@ Do Assignment
                 class="assignment-due-date notdue"
                 {% endif %}
                 >
-                <strong>Due:</strong> {{ assignment['duedate'] | course_datetime(course.timezone, "%a %d, %b %Y %I:%M %p") }}
+                <strong>Due:</strong> {{ course_datetime_tag(assignment['duedate'], course.timezone) }}
             </div>
             {% if enforce_pastdue %}
                 <em>(Past due and no longer scoring submissions)</em>
@@ -236,4 +236,8 @@ Do Assignment
 
 <script src="/staticAssets/assignment/student.js" type="text/javascript"></script>
 
+{% endblock %}
+
+{% block js %}
+{% include 'common/localize_times.html' %}
 {% endblock %}

--- a/components/rsptx/templates/assignment/student/doAssignment.html
+++ b/components/rsptx/templates/assignment/student/doAssignment.html
@@ -40,7 +40,7 @@ Do Assignment
                 class="assignment-due-date notdue"
                 {% endif %}
                 >
-                <strong>Due:</strong> {{ assignment['duedate'] }}
+                <strong>Due:</strong> {{ assignment['duedate'] | course_datetime(course.timezone, "%a %d, %b %Y %I:%M %p") }}
             </div>
             {% if enforce_pastdue %}
                 <em>(Past due and no longer scoring submissions)</em>

--- a/components/rsptx/templates/assignment/student/peer_student.html
+++ b/components/rsptx/templates/assignment/student/peer_student.html
@@ -122,7 +122,7 @@ Peer Instruction
                         <span class="not-available">Not Available</span>
                         {% endif %}
                     </td>
-                    <td>{{ assignment.duedate | course_datetime(course.timezone, '%Y-%m-%d %H:%M') if assignment.duedate else 'N/A' }}</td>
+                    <td>{{ course_datetime_tag(assignment.duedate, course.timezone, style='short', empty='N/A') }}</td>
                     <td>{{ assignment.description or '' }}</td>
                 </tr>
                 {% endfor %}
@@ -137,5 +137,6 @@ Peer Instruction
 {% endblock %}
 
 {% block js %}
+{% include 'common/localize_times.html' %}
 <!-- Add any peer-specific JavaScript here -->
 {% endblock %}

--- a/components/rsptx/templates/assignment/student/peer_student.html
+++ b/components/rsptx/templates/assignment/student/peer_student.html
@@ -122,7 +122,7 @@ Peer Instruction
                         <span class="not-available">Not Available</span>
                         {% endif %}
                     </td>
-                    <td>{{ assignment.duedate.strftime('%Y-%m-%d %H:%M') if assignment.duedate else 'N/A' }}</td>
+                    <td>{{ assignment.duedate | course_datetime(course.timezone, '%Y-%m-%d %H:%M') if assignment.duedate else 'N/A' }}</td>
                     <td>{{ assignment.description or '' }}</td>
                 </tr>
                 {% endfor %}

--- a/components/rsptx/templates/book/course/current_course.html
+++ b/components/rsptx/templates/book/course/current_course.html
@@ -122,5 +122,6 @@ async function change_course(course_name) {
 {% endblock %}
 
 {% block js %}
+{% include 'common/localize_times.html' %}
 <script src="/staticAssets/assignment/student.js"></script>
 {% endblock %}

--- a/components/rsptx/templates/common/ebook_config.html
+++ b/components/rsptx/templates/common/ebook_config.html
@@ -22,6 +22,10 @@
   {% endif %}
   eBookConfig.useRunestoneServices = true;
   eBookConfig.basecourse = "{{course.base_course}}";
+  // Deadlines are shown on the viewer's own clock. The course timezone is
+  // exposed so the assignment builder can warn an instructor whose browser is
+  // in a different zone than the course they are setting deadlines for.
+  eBookConfig.courseTimezone = "{{ course.timezone | default('', true) }}";
   eBookConfig.course_attrs = {{ course_attrs | default({}) | tojson | safe }};
   eBookConfig.gradeRecordingUrl = `${eBookConfig.app}/assignments/record_grade`;
   eBookConfig.new_server_prefix = "/ns";

--- a/components/rsptx/templates/common/localize_times.html
+++ b/components/rsptx/templates/common/localize_times.html
@@ -1,0 +1,7 @@
+{# Rewrites <time data-rs-localize> elements into the viewer's timezone.
+
+   Included per page rather than from _base.html on purpose: PreTeXt books ship
+   their own _base.html, and get_jinja_templates() searches the book directory
+   first, so a base-template include silently disappears for those courses.
+   Any page that renders course_datetime_tag() needs this include. #}
+<script src="/staticAssets/js/localize-times.js"></script>

--- a/components/rsptx/templates/core.py
+++ b/components/rsptx/templates/core.py
@@ -5,12 +5,20 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import jinja2
 from fastapi.templating import Jinja2Templates
+from markupsafe import Markup, escape
 
 template_folder = Path(__file__).parent.absolute()
 
 # Assignment due dates render as a date and time with no seconds; the timezone
 # abbreviation is appended separately by format_course_datetime.
 DEFAULT_DATETIME_FORMAT = "%b %d, %Y %I:%M %p"
+
+# Formats understood by both course_datetime_tag and staticAssets/js/localize-times.js.
+# The Python side renders the no-JS fallback, the JS side the localized text.
+DATETIME_STYLES = {
+    "long": "%b %d, %Y %I:%M %p",
+    "short": "%Y-%m-%d %H:%M",
+}
 
 
 def _resolve_timezone(name: Optional[str]) -> datetime.tzinfo:
@@ -36,10 +44,15 @@ def format_course_datetime(
 ) -> str:
     """Render a naive UTC datetime as wall clock time in the course timezone.
 
-    Datetimes are stored as naive UTC throughout the database. A deadline is a
-    property of the course rather than of whoever is looking at it, so it is
-    displayed in the course's own timezone, with the abbreviation shown so the
-    reader knows which clock it refers to.
+    Datetimes are stored as naive UTC throughout the database. Deadlines are
+    normally shown on the *reader's* clock (see ``course_datetime_tag``), so
+    this is used where that is not possible or not wanted: the no-JS fallback
+    text and tooltip of a ``<time>`` element, date-only instructor reports
+    where a browser-local shift could move the date onto the neighbouring day,
+    and anything rendered without a browser at all such as a CSV export.
+
+    The timezone abbreviation is appended so the reader always knows which
+    clock the value refers to.
 
     Registered as the ``course_datetime`` Jinja filter::
 
@@ -63,9 +76,60 @@ def format_course_datetime(
     return rendered
 
 
+def course_datetime_tag(
+    value: Union[datetime.datetime, None],
+    course_timezone: Optional[str] = None,
+    style: str = "long",
+    empty: str = "",
+) -> Markup:
+    """Render a ``<time>`` element that JS rewrites into the viewer's timezone.
+
+    Deadlines are shown on the reader's own clock so that a student who is
+    travelling -- or simply enrolled from another timezone -- never has to do
+    the conversion themselves under time pressure.
+
+    The server cannot know the browser's timezone, so the element carries the
+    instant in UTC and ``staticAssets/js/localize-times.js`` rewrites the text
+    on load. The text rendered here is the course-local time, which is what
+    remains visible without JavaScript; the course time is also kept in the
+    ``title`` so a student comparing notes with classmates or an instructor can
+    still see the frame the course itself uses.
+
+    Registered as the ``course_datetime_tag`` Jinja global::
+
+        {{ course_datetime_tag(assignment.duedate, course.timezone) }}
+    """
+    if value is None:
+        return Markup(escape(empty))
+    if not isinstance(value, datetime.datetime):
+        # Already formatted upstream -- nothing to localize.
+        return Markup(escape(value))
+
+    fmt = DATETIME_STYLES.get(style, DATETIME_STYLES["long"])
+    course_text = format_course_datetime(value, course_timezone, fmt=fmt)
+
+    stamp = (
+        value
+        if value.tzinfo is not None
+        else value.replace(tzinfo=datetime.timezone.utc)
+    )
+    iso = stamp.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return Markup(
+        '<time datetime="{iso}" data-rs-localize="{style}" title="{title}">'
+        "{text}</time>"
+    ).format(
+        iso=escape(iso),
+        style=escape(style),
+        title=escape(f"{course_text} course time"),
+        text=escape(course_text),
+    )
+
+
 def install_filters(env: jinja2.Environment) -> jinja2.Environment:
-    """Register Runestone's shared Jinja filters on an environment."""
+    """Register Runestone's shared Jinja filters and globals on an environment."""
     env.filters["course_datetime"] = format_course_datetime
+    env.globals["course_datetime_tag"] = course_datetime_tag
     return env
 
 

--- a/components/rsptx/templates/core.py
+++ b/components/rsptx/templates/core.py
@@ -1,12 +1,87 @@
+import datetime
 from pathlib import Path
+from typing import Optional, Union
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import jinja2
 from fastapi.templating import Jinja2Templates
 
+template_folder = Path(__file__).parent.absolute()
+
+# Assignment due dates render as a date and time with no seconds; the timezone
+# abbreviation is appended separately by format_course_datetime.
+DEFAULT_DATETIME_FORMAT = "%b %d, %Y %I:%M %p"
+
+
+def _resolve_timezone(name: Optional[str]) -> datetime.tzinfo:
+    """Turn a course timezone name into a tzinfo, falling back to UTC.
+
+    A course with no timezone is treated as UTC, matching the due date
+    migration. An unrecognized name also falls back rather than raising -- a
+    bad timezone string should not take a page down.
+    """
+    if not name:
+        return datetime.timezone.utc
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return datetime.timezone.utc
+
+
+def format_course_datetime(
+    value: Union[datetime.datetime, None],
+    course_timezone: Optional[str] = None,
+    fmt: str = DEFAULT_DATETIME_FORMAT,
+    show_timezone: bool = True,
+) -> str:
+    """Render a naive UTC datetime as wall clock time in the course timezone.
+
+    Datetimes are stored as naive UTC throughout the database. A deadline is a
+    property of the course rather than of whoever is looking at it, so it is
+    displayed in the course's own timezone, with the abbreviation shown so the
+    reader knows which clock it refers to.
+
+    Registered as the ``course_datetime`` Jinja filter::
+
+        {{ assignment.duedate | course_datetime(course.timezone) }}
+    """
+    if value is None:
+        return ""
+    if not isinstance(value, datetime.datetime):
+        # Already formatted upstream, or not a datetime at all -- pass through.
+        return str(value)
+
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    local = value.astimezone(_resolve_timezone(course_timezone))
+
+    rendered = local.strftime(fmt)
+    if show_timezone:
+        abbreviation = local.strftime("%Z")
+        if abbreviation:
+            rendered = f"{rendered} {abbreviation}"
+    return rendered
+
+
+def install_filters(env: jinja2.Environment) -> jinja2.Environment:
+    """Register Runestone's shared Jinja filters on an environment."""
+    env.filters["course_datetime"] = format_course_datetime
+    return env
+
+
+def get_shared_templates() -> Jinja2Templates:
+    """Return Jinja templates for the shared template folder.
+
+    Use this instead of constructing ``Jinja2Templates`` directly so that
+    every server gets the shared filters.
+    """
+    templates = Jinja2Templates(directory=template_folder)
+    install_filters(templates.env)
+    return templates
+
 
 def get_jinja_templates(book_path: str) -> Jinja2Templates:
     """Return Jinja templates that search book-specific and shared paths."""
-    template_folder = Path(__file__).parent.absolute()
     loader = jinja2.ChoiceLoader(
         [
             jinja2.FileSystemLoader(book_path),
@@ -17,4 +92,5 @@ def get_jinja_templates(book_path: str) -> Jinja2Templates:
         loader=loader,
         autoescape=jinja2.select_autoescape(["html", "xml"]),
     )
+    install_filters(env)
     return Jinja2Templates(env=env)

--- a/components/rsptx/templates/staticAssets/js/localize-times.js
+++ b/components/rsptx/templates/staticAssets/js/localize-times.js
@@ -1,0 +1,85 @@
+/* Rewrite server-rendered <time> elements into the viewer's local timezone.
+ *
+ * Deadlines are stored and sent as UTC instants. The server renders them in
+ * the course timezone so the page is still correct without JavaScript, and
+ * this script replaces that text with the same instant on the reader's own
+ * clock. A student who is travelling then never has to convert a deadline
+ * themselves.
+ *
+ * Markup produced by templates/core.py::course_datetime_tag:
+ *
+ *   <time datetime="2026-09-02T04:59:00Z"
+ *         data-rs-localize="long"
+ *         title="Sep 01, 2026 11:59 PM CDT course time">Sep 01, 2026 11:59 PM CDT</time>
+ *
+ * The timezone abbreviation is always shown, so the displayed time is never
+ * ambiguous about which clock it refers to.
+ */
+(function () {
+    "use strict";
+
+    // Keep these in sync with DATETIME_STYLES in templates/core.py.
+    var STYLES = {
+        long: {
+            year: "numeric",
+            month: "short",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            timeZoneName: "short",
+        },
+        short: {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZoneName: "short",
+        },
+    };
+
+    function localizeElement(el) {
+        if (el.dataset.rsLocalized === "true") {
+            return;
+        }
+
+        var stamp = el.getAttribute("datetime");
+        if (!stamp) {
+            return;
+        }
+
+        var when = new Date(stamp);
+        if (isNaN(when.getTime())) {
+            // Leave the server-rendered course-local text in place.
+            return;
+        }
+
+        var options = STYLES[el.dataset.rsLocalize] || STYLES.long;
+        try {
+            el.textContent = when.toLocaleString(undefined, options);
+            el.dataset.rsLocalized = "true";
+        } catch (err) {
+            /* Intl rejected the options; the fallback text stays. */
+        }
+    }
+
+    function localizeTimes(root) {
+        var scope = root || document;
+        var nodes = scope.querySelectorAll("time[data-rs-localize]");
+        for (var i = 0; i < nodes.length; i++) {
+            localizeElement(nodes[i]);
+        }
+    }
+
+    // Exposed so pages that inject markup after load can re-run it.
+    window.rsLocalizeTimes = localizeTimes;
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", function () {
+            localizeTimes();
+        });
+    } else {
+        localizeTimes();
+    }
+})();

--- a/migrations/versions/c4e8a1f7b2d9_duedate_to_utc.py
+++ b/migrations/versions/c4e8a1f7b2d9_duedate_to_utc.py
@@ -17,6 +17,16 @@ due dates.  Those rows are left byte-identical and their timezone is backfilled
 to ``'UTC'``, which matches the fallback the application already used when no
 timezone and no browser cookie were available.
 
+Leaving a NULL-timezone course alone is only harmless once its deadlines have
+passed.  A course still running would keep the wall clock its instructor typed
+while that value starts being read as UTC, so ``upgrade()`` refuses to run
+while any NULL-timezone course has a due date in the future.  Setting
+``courses.timezone`` on those courses first converts them correctly along with
+everyone else; doing it afterwards is far more work, because by then the due
+dates are fixed instants and nothing records which zone they were meant to be
+in.  Set ``DUEDATE_UTC_ALLOW_NULL_TIMEZONE=1`` to proceed anyway and have those
+deadlines treated as UTC.
+
 The ids of the courses whose timezone was backfilled are recorded in
 ``duedate_utc_tz_backfill`` so ``downgrade()`` can restore NULL for exactly
 those courses and no others.  That table is dropped by ``downgrade()``.
@@ -28,6 +38,7 @@ changed while the upgrade is in effect.
 """
 
 import logging
+import os
 from typing import Sequence, Union
 
 from alembic import op
@@ -44,6 +55,10 @@ depends_on: Union[str, Sequence[str], None] = None
 logger = logging.getLogger("alembic.runtime.migration")
 
 BACKFILL_TABLE = "duedate_utc_tz_backfill"
+
+# Escape hatch for the live-course guard below, for the case where an
+# operator has decided those courses really should be treated as UTC.
+ALLOW_NULL_TIMEZONE_ENV = "DUEDATE_UTC_ALLOW_NULL_TIMEZONE"
 
 # Postgres ``AT TIME ZONE`` is direction sensitive:
 #   naive timestamp  AT TIME ZONE 'zone' -> timestamptz (reads the naive value as
@@ -113,6 +128,60 @@ def _assert_timezones_are_resolvable(conn) -> None:
         )
 
 
+LIVE_NULL_TIMEZONE_COURSES = sa.text(
+    """
+    SELECT c.id, c.course_name, max(a.duedate) AS latest_duedate
+      FROM courses c
+      JOIN assignments a ON a.course = c.id
+     WHERE c.timezone IS NULL
+     GROUP BY c.id, c.course_name
+    HAVING max(a.duedate) > (now() AT TIME ZONE 'UTC')
+     ORDER BY max(a.duedate) DESC
+    """
+)
+
+
+def _assert_no_live_courses_without_a_timezone(conn) -> None:
+    """Refuse to convert a still-running course that has no timezone.
+
+    A NULL timezone is left alone by this migration and backfilled to 'UTC',
+    which is harmless for a finished course but not for one with deadlines
+    still ahead of it: its due dates keep the wall clock an instructor typed
+    while that value starts being read as UTC.
+
+    Setting ``courses.timezone`` before running this migration converts those
+    courses correctly along with everyone else's. Doing it afterwards is much
+    more work, because by then the due dates are fixed instants and nothing
+    records which zone they were meant to be in -- so block here rather than
+    let the ordering be got wrong silently.
+
+    The comparison is approximate: due dates are still course-local at this
+    point, so a course is judged live to within its UTC offset. That is well
+    inside the granularity this check cares about.
+    """
+    if os.environ.get(ALLOW_NULL_TIMEZONE_ENV) == "1":
+        logger.warning(
+            "%s=1: converting due dates even though some live courses have no "
+            "timezone. Their deadlines will be read as UTC.",
+            ALLOW_NULL_TIMEZONE_ENV,
+        )
+        return
+
+    live = conn.execute(LIVE_NULL_TIMEZONE_COURSES).fetchall()
+    if live:
+        detail = "; ".join(
+            f"course {r.id} ({r.course_name!r}) latest due {r.latest_duedate}"
+            for r in live
+        )
+        raise RuntimeError(
+            "Cannot convert assignment due dates to UTC: these courses have "
+            f"deadlines in the future but no timezone set: {detail}. Set "
+            "courses.timezone for them and re-run -- their due dates will then "
+            "convert correctly. To proceed anyway and have their deadlines "
+            f"treated as UTC, set {ALLOW_NULL_TIMEZONE_ENV}=1."
+        )
+
+
 def _backfill_table_exists(conn) -> bool:
     return (
         conn.execute(
@@ -126,6 +195,7 @@ def upgrade() -> None:
     conn = op.get_bind()
 
     _assert_timezones_are_resolvable(conn)
+    _assert_no_live_courses_without_a_timezone(conn)
 
     shifted = conn.execute(LOCAL_TO_UTC).rowcount
     logger.info("duedate -> UTC: shifted %s assignment(s)", shifted)

--- a/migrations/versions/c4e8a1f7b2d9_duedate_to_utc.py
+++ b/migrations/versions/c4e8a1f7b2d9_duedate_to_utc.py
@@ -1,0 +1,181 @@
+"""store assignment duedate in UTC
+
+Revision ID: c4e8a1f7b2d9
+Revises: 3bfddd662428
+Create Date: 2026-07-27 10:12:04.331902
+
+``assignments.duedate`` has always been a naive datetime holding *course-local*
+wall clock time, while ``visible_on``, ``hidden_on`` and every answer timestamp
+are naive UTC.  This migration shifts ``duedate`` to naive UTC so the column is
+consistent with the rest of the schema and no conversion is needed at grading
+time.
+
+Only courses with an explicit ``courses.timezone`` are shifted.  The column is
+nullable and was added in ``8f857bdfef19`` (2025-10-07) without a backfill, so
+most legacy courses are NULL and have no defensible source timezone for their
+due dates.  Those rows are left byte-identical and their timezone is backfilled
+to ``'UTC'``, which matches the fallback the application already used when no
+timezone and no browser cookie were available.
+
+The ids of the courses whose timezone was backfilled are recorded in
+``duedate_utc_tz_backfill`` so ``downgrade()`` can restore NULL for exactly
+those courses and no others.  That table is dropped by ``downgrade()``.
+
+``downgrade()`` recomputes the local time from the stored UTC value rather than
+restoring a snapshot, so assignments created or edited after the upgrade are
+converted correctly too.  The round trip is exact unless a course's timezone is
+changed while the upgrade is in effect.
+"""
+
+import logging
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c4e8a1f7b2d9"
+down_revision: Union[str, None] = "3bfddd662428"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+BACKFILL_TABLE = "duedate_utc_tz_backfill"
+
+# Postgres ``AT TIME ZONE`` is direction sensitive:
+#   naive timestamp  AT TIME ZONE 'zone' -> timestamptz (reads the naive value as
+#                                           wall clock in 'zone')
+#   timestamptz      AT TIME ZONE 'zone' -> naive timestamp (renders the instant
+#                                           as wall clock in 'zone')
+# so local -> UTC is (duedate AT TIME ZONE course_tz) AT TIME ZONE 'UTC'.
+
+LOCAL_TO_UTC = sa.text(
+    """
+    UPDATE assignments a
+       SET duedate = (a.duedate AT TIME ZONE c.timezone) AT TIME ZONE 'UTC'
+      FROM courses c
+     WHERE a.course = c.id
+       AND a.duedate IS NOT NULL
+       AND c.timezone IS NOT NULL
+       AND c.timezone <> 'UTC'
+    """
+)
+
+UTC_TO_LOCAL = sa.text(
+    """
+    UPDATE assignments a
+       SET duedate = (a.duedate AT TIME ZONE 'UTC') AT TIME ZONE c.timezone
+      FROM courses c
+     WHERE a.course = c.id
+       AND a.duedate IS NOT NULL
+       AND c.timezone IS NOT NULL
+       AND c.timezone <> 'UTC'
+    """
+)
+
+# Only courses that actually own assignments can break the conversion, so a bad
+# timezone on an empty course is not worth blocking a deploy over.
+BAD_TIMEZONES = sa.text(
+    """
+    SELECT c.id, c.course_name, c.timezone
+      FROM courses c
+     WHERE c.timezone IS NOT NULL
+       AND EXISTS (SELECT 1 FROM assignments a WHERE a.course = c.id)
+       AND NOT EXISTS (
+             SELECT 1 FROM pg_timezone_names t
+              WHERE lower(t.name) = lower(c.timezone)
+           )
+     ORDER BY c.id
+    """
+)
+
+
+def _assert_timezones_are_resolvable(conn) -> None:
+    """Fail with an actionable message instead of a bare Postgres error.
+
+    ``AT TIME ZONE`` aborts the whole statement on an unrecognized zone name.
+    ``courses.timezone`` is validated against the IANA database when set through
+    the course settings UI, but the LTI and legacy paths do not go through that
+    validator, so check before touching any rows.
+    """
+    bad = conn.execute(BAD_TIMEZONES).fetchall()
+    if bad:
+        detail = ", ".join(
+            f"course {r.id} ({r.course_name!r}) = {r.timezone!r}" for r in bad
+        )
+        raise RuntimeError(
+            "Cannot convert assignment due dates to UTC: these courses have "
+            f"assignments and a timezone Postgres does not recognize: {detail}. "
+            "Fix or clear courses.timezone for them and re-run the migration."
+        )
+
+
+def _backfill_table_exists(conn) -> bool:
+    return (
+        conn.execute(
+            sa.text("SELECT to_regclass(:name)"), {"name": BACKFILL_TABLE}
+        ).scalar()
+        is not None
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    _assert_timezones_are_resolvable(conn)
+
+    shifted = conn.execute(LOCAL_TO_UTC).rowcount
+    logger.info("duedate -> UTC: shifted %s assignment(s)", shifted)
+
+    # Record which courses we are about to backfill so the downgrade can put
+    # NULL back for exactly those, and not for courses that already said 'UTC'.
+    conn.execute(
+        sa.text(
+            f"CREATE TABLE IF NOT EXISTS {BACKFILL_TABLE} "
+            "(course_id integer PRIMARY KEY)"
+        )
+    )
+    conn.execute(
+        sa.text(
+            f"INSERT INTO {BACKFILL_TABLE} (course_id) "
+            "SELECT id FROM courses WHERE timezone IS NULL "
+            "ON CONFLICT (course_id) DO NOTHING"
+        )
+    )
+    backfilled = conn.execute(
+        sa.text("UPDATE courses SET timezone = 'UTC' WHERE timezone IS NULL")
+    ).rowcount
+    logger.info("duedate -> UTC: backfilled timezone on %s course(s)", backfilled)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    _assert_timezones_are_resolvable(conn)
+
+    # Restore NULL first, so those courses are excluded from the conversion
+    # below exactly as they were excluded on the way up.
+    if _backfill_table_exists(conn):
+        restored = conn.execute(
+            sa.text(
+                "UPDATE courses SET timezone = NULL "
+                f"WHERE id IN (SELECT course_id FROM {BACKFILL_TABLE})"
+            )
+        ).rowcount
+        logger.info(
+            "duedate -> local: restored NULL timezone on %s course(s)", restored
+        )
+    else:
+        logger.warning(
+            "%s is missing; leaving courses.timezone as-is. Due dates will still "
+            "be converted back to course-local time.",
+            BACKFILL_TABLE,
+        )
+
+    shifted = conn.execute(UTC_TO_LOCAL).rowcount
+    logger.info("duedate -> local: shifted %s assignment(s)", shifted)
+
+    op.execute(f"DROP TABLE IF EXISTS {BACKFILL_TABLE}")

--- a/test/bases/rsptx/admin_server_api/test_analytics.py
+++ b/test/bases/rsptx/admin_server_api/test_analytics.py
@@ -5,6 +5,7 @@ Test the analytics report helpers used by the Chapter Activity report.
 import pandas as pd
 
 from rsptx.admin_server_api.routers.analytics import (
+    _format_duedate,
     _pad_with_enrolled,
     _student_label,
 )
@@ -69,3 +70,34 @@ def test_pad_with_enrolled_no_roster_is_a_noop():
 
     assert list(padded.columns) == ["Kussman, Erin (ekussman)"]
     assert padded["Kussman, Erin (ekussman)"].tolist() == [3]
+
+
+# _format_duedate
+# ---------------
+# duedate is stored as naive UTC and these reports show a date only, so the
+# value has to be shifted into the course timezone before the date is taken --
+# a late-evening deadline falls on the following day in UTC.
+
+
+def test_format_duedate_shifts_into_the_course_timezone():
+    # 2026-09-02 04:59 UTC is 2026-09-01 in Chicago.
+    stamp = pd.Timestamp("2026-09-02 04:59:00")
+    assert _format_duedate(stamp, "America/Chicago") == "2026-09-01"
+
+
+def test_format_duedate_without_a_timezone_stays_utc():
+    stamp = pd.Timestamp("2026-09-02 04:59:00")
+    assert _format_duedate(stamp, None) == "2026-09-02"
+
+
+def test_format_duedate_handles_pandas_null():
+    # pd.NaT is not caught by an `is None` check and would otherwise render as
+    # the string "NaT".
+    assert _format_duedate(pd.NaT, "America/Chicago") == ""
+    assert _format_duedate(None, "America/Chicago") == ""
+
+
+def test_format_duedate_omits_any_timezone_label():
+    stamp = pd.Timestamp("2026-09-02 04:59:00")
+    assert _format_duedate(stamp, "America/Chicago") == "2026-09-01"
+    assert "CDT" not in _format_duedate(stamp, "America/Chicago")

--- a/test/bases/rsptx/admin_server_api/test_copy_assignment_dates.py
+++ b/test/bases/rsptx/admin_server_api/test_copy_assignment_dates.py
@@ -1,0 +1,160 @@
+"""Due date arithmetic when copying an assignment between terms.
+
+``_copy_one_assignment`` re-dates an assignment by its offset from the start of
+term. ``duedate`` is stored as naive UTC while ``term_start_date`` is a bare
+date, so the term start has to be anchored in the course timezone before the
+two can be subtracted. Without that, the copy drifts by the course's UTC offset
+and can land on the wrong day.
+"""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from rsptx.admin_server_api.routers import instructor
+from rsptx.admin_server_api.routers.instructor import _term_start_utc
+
+UTC = datetime.timezone.utc
+CHICAGO = ZoneInfo("America/Chicago")
+
+
+def _local_to_stored(year, month, day, hour, minute, tz):
+    """The naive UTC value the database holds for a local wall clock time."""
+    return (
+        datetime.datetime(year, month, day, hour, minute, tzinfo=tz)
+        .astimezone(UTC)
+        .replace(tzinfo=None)
+    )
+
+
+def _stored_to_local(stored, tz):
+    return stored.replace(tzinfo=UTC).astimezone(tz)
+
+
+def _course(id, term_start_date, timezone):
+    return SimpleNamespace(
+        id=id,
+        course_name=f"course{id}",
+        term_start_date=term_start_date,
+        timezone=timezone,
+    )
+
+
+def _assignment(duedate):
+    return SimpleNamespace(
+        id=7,
+        name="Homework 1",
+        description="",
+        duedate=duedate,
+        points=10,
+        threshold_pct=None,
+        is_timed=False,
+        is_peer=False,
+        time_limit=None,
+        from_source=False,
+        nofeedback=False,
+        nopause=False,
+        released=True,
+        allow_self_autograde=False,
+        enforce_due=True,
+        peer_async_visible=False,
+        kind="Regular",
+    )
+
+
+async def _copy(source_course, target_course, assignment):
+    """Run the copy with its collaborators mocked; return the new duedate."""
+    created = AsyncMock(return_value=SimpleNamespace(id=99))
+    with (
+        patch.object(instructor, "fetch_course", AsyncMock(return_value=source_course)),
+        patch.object(
+            instructor, "fetch_one_assignment", AsyncMock(return_value=assignment)
+        ),
+        patch.object(instructor, "create_assignment", created),
+        patch.object(
+            instructor, "fetch_assignment_questions", AsyncMock(return_value=[])
+        ),
+        patch.object(instructor, "create_assignment_question", AsyncMock()),
+    ):
+        result = await instructor._copy_one_assignment(
+            source_course.course_name, assignment.id, target_course
+        )
+    # The function swallows exceptions into a "failed: ..." string, so assert
+    # success rather than silently testing an error path.
+    assert result == "success", result
+    return created.call_args.args[0].duedate
+
+
+# _term_start_utc
+# ---------------
+
+
+def test_term_start_anchors_midnight_in_the_course_timezone():
+    # Midnight on 2026-08-24 in Chicago (CDT, UTC-5) is 05:00 UTC.
+    assert _term_start_utc(datetime.date(2026, 8, 24), "America/Chicago") == (
+        datetime.datetime(2026, 8, 24, 5, 0)
+    )
+
+
+def test_term_start_uses_the_offset_in_effect_on_that_date():
+    # January is CST (UTC-6), August is CDT (UTC-5).
+    assert _term_start_utc(datetime.date(2026, 1, 12), "America/Chicago").hour == 6
+    assert _term_start_utc(datetime.date(2026, 8, 24), "America/Chicago").hour == 5
+
+
+@pytest.mark.parametrize("timezone", [None, "", "UTC"])
+def test_term_start_without_a_timezone_is_utc_midnight(timezone):
+    assert _term_start_utc(datetime.date(2026, 8, 24), timezone) == (
+        datetime.datetime(2026, 8, 24, 0, 0)
+    )
+
+
+# _copy_one_assignment
+# --------------------
+
+
+async def test_copy_preserves_local_wall_clock_across_a_dst_boundary():
+    # Regression: a spring term start (CST) and a fall term start (CDT) used to
+    # produce 2026-09-02 00:59 local instead of 2026-09-01 23:59.
+    source = _course(1, datetime.date(2026, 1, 12), "America/Chicago")
+    target = _course(2, datetime.date(2026, 8, 24), "America/Chicago")
+    stored = _local_to_stored(2026, 1, 20, 23, 59, CHICAGO)
+
+    new_duedate = await _copy(source, target, _assignment(stored))
+
+    local = _stored_to_local(new_duedate, CHICAGO)
+    assert local.strftime("%Y-%m-%d %H:%M") == "2026-09-01 23:59"
+
+
+async def test_copy_preserves_the_offset_from_the_start_of_term():
+    source = _course(1, datetime.date(2026, 1, 12), "America/Chicago")
+    target = _course(2, datetime.date(2026, 8, 24), "America/Chicago")
+    stored = _local_to_stored(2026, 1, 20, 23, 59, CHICAGO)
+
+    new_duedate = await _copy(source, target, _assignment(stored))
+
+    # 8 days and change after the start of term, in both terms.
+    assert new_duedate - _term_start_utc(
+        target.term_start_date, target.timezone
+    ) == stored - _term_start_utc(source.term_start_date, source.timezone)
+
+
+async def test_copy_with_no_course_timezone_behaves_as_utc():
+    source = _course(1, datetime.date(2026, 1, 12), None)
+    target = _course(2, datetime.date(2026, 8, 24), None)
+    stored = datetime.datetime(2026, 1, 20, 23, 59)
+
+    new_duedate = await _copy(source, target, _assignment(stored))
+
+    assert new_duedate == datetime.datetime(2026, 9, 1, 23, 59)
+
+
+async def test_copy_keeps_the_duedate_when_a_term_start_is_missing():
+    source = _course(1, None, "America/Chicago")
+    target = _course(2, datetime.date(2026, 8, 24), "America/Chicago")
+    stored = _local_to_stored(2026, 1, 20, 23, 59, CHICAGO)
+
+    assert await _copy(source, target, _assignment(stored)) == stored

--- a/test/components/rsptx/grading_helpers/test_core.py
+++ b/test/components/rsptx/grading_helpers/test_core.py
@@ -51,10 +51,10 @@ async def test_returns_false_when_no_late_work():
 
 
 async def test_deadline_passed_to_query_in_utc():
-    # UTC course timezone: the naive duedate is used unchanged as the cutoff.
+    # duedate is stored as naive UTC and is used unchanged as the cutoff.
     a, d, h = _patch_crud(_assignment(duedate=datetime(2026, 6, 1, 23, 59, 0)))
     with a, d, h as has_submissions:
-        await core.has_late_submission("student1", 42, timezone="UTC")
+        await core.has_late_submission("student1", 42)
     args = has_submissions.call_args.args
     assert args[0] == "student1"
     assert args[1] == 42
@@ -69,13 +69,16 @@ async def test_accommodation_extends_deadline():
         accommodation=accommodation,
     )
     with a, d, h as has_submissions:
-        await core.has_late_submission("student1", 42, timezone="UTC")
+        await core.has_late_submission("student1", 42)
     assert has_submissions.call_args.args[2] == datetime(2026, 6, 4, 23, 59, 0)
 
 
-async def test_due_date_converted_from_course_timezone_to_utc():
-    # 23:59 on 2026-06-01 in New York (EDT, UTC-4) is 03:59 the next day in UTC.
-    a, d, h = _patch_crud(_assignment(duedate=datetime(2026, 6, 1, 23, 59, 0)))
+async def test_due_date_is_not_shifted_by_any_timezone():
+    # duedate is already UTC, so the cutoff must be passed through untouched no
+    # matter what the ambient local timezone of the process happens to be. This
+    # guards against someone reintroducing a course-local -> UTC conversion.
+    duedate = datetime(2026, 6, 1, 23, 59, 0)
+    a, d, h = _patch_crud(_assignment(duedate=duedate))
     with a, d, h as has_submissions:
-        await core.has_late_submission("student1", 42, timezone="America/New_York")
-    assert has_submissions.call_args.args[2] == datetime(2026, 6, 2, 3, 59, 0)
+        await core.has_late_submission("student1", 42)
+    assert has_submissions.call_args.args[2] == duedate

--- a/test/components/rsptx/grading_helpers/test_regrade_batch.py
+++ b/test/components/rsptx/grading_helpers/test_regrade_batch.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -160,3 +161,51 @@ async def test_rollup_uses_the_graded_course():
     assert fetch_scores.await_args.args == (assignment.id, "testcourse", "student1")
     assert upsert.await_args.args[0].score == 7.0
     assert lti.await_args.args[2] == 7.0
+
+
+# _effective_deadline
+# -------------------
+# duedate is stored as naive UTC, the same frame as the answer timestamps it is
+# compared against in regrade_one. This function previously returned a
+# course-local duedate that was compared straight against UTC timestamps, so
+# batch regrades silently used a cutoff that was off by the course's UTC
+# offset. These tests pin the frame.
+
+
+def _dated_assignment(duedate):
+    return SimpleNamespace(id=42, points=10, threshold_pct=None, duedate=duedate)
+
+
+def test_effective_deadline_returns_the_duedate_unchanged():
+    duedate = datetime(2026, 9, 2, 4, 59)
+    assert regrade._effective_deadline(_dated_assignment(duedate), None) == duedate
+
+
+def test_effective_deadline_applies_accommodation_days():
+    duedate = datetime(2026, 9, 2, 4, 59)
+    accommodation = SimpleNamespace(duedate=3)
+    assert regrade._effective_deadline(
+        _dated_assignment(duedate), accommodation
+    ) == datetime(2026, 9, 5, 4, 59)
+
+
+def test_effective_deadline_ignores_accommodation_without_extra_days():
+    duedate = datetime(2026, 9, 2, 4, 59)
+    for accommodation in (None, SimpleNamespace(duedate=None), SimpleNamespace()):
+        assert (
+            regrade._effective_deadline(_dated_assignment(duedate), accommodation)
+            == duedate
+        )
+
+
+def test_effective_deadline_is_none_when_no_duedate():
+    assert regrade._effective_deadline(_dated_assignment(None), None) is None
+
+
+def test_effective_deadline_does_not_apply_a_timezone_shift():
+    # Guards against reintroducing a course-local -> UTC conversion here. The
+    # cutoff must be usable as-is against naive UTC answer timestamps.
+    duedate = datetime(2026, 9, 2, 4, 59)
+    result = regrade._effective_deadline(_dated_assignment(duedate), None)
+    assert result.tzinfo is None
+    assert result == duedate

--- a/test/components/rsptx/lti1p3/test_duedate_exchange.py
+++ b/test/components/rsptx/lti1p3/test_duedate_exchange.py
@@ -1,0 +1,142 @@
+"""LTI 1.3 due date exchange.
+
+``assignments.duedate`` is stored as naive UTC. On the way in, an LMS timestamp
+carrying an offset converts straight to UTC while a naive one is read as
+course-local wall clock. On the way out the value must carry an explicit
+offset, or the LMS is free to read it as its own local time.
+"""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rsptx.lti1p3.core import update_line_item_from_assignment
+from rsptx.lti1p3.pylti1p3.lineitem import LineItem
+
+
+def _course(timezone="America/Chicago", id=1):
+    return SimpleNamespace(id=id, course_name="course1", timezone=timezone)
+
+
+def _assignment(duedate=None, id=7):
+    return SimpleNamespace(id=id, name="Homework 1", duedate=duedate, points=10)
+
+
+# Ingest
+# ------
+
+
+async def _ingest(lms_string, course):
+    """Run update_rsassignment_from_lti and return the stored duedate."""
+    from rsptx.admin_server_api.routers import lti1p3
+
+    assign = _assignment(duedate=datetime.datetime(2000, 1, 1))
+    line_item = LineItem()
+    line_item.set_end_date_time(lms_string)
+
+    with patch.object(lti1p3, "update_assignment", AsyncMock()) as update:
+        await lti1p3.update_rsassignment_from_lti(assign, line_item, {}, course)
+
+    assert update.await_count == 1, "expected the assignment to be updated"
+    return assign.duedate
+
+
+@pytest.mark.parametrize(
+    "lms_string,expected",
+    [
+        # Explicit offset: converts straight to the same instant in UTC.
+        ("2026-09-01T23:59:00-05:00", datetime.datetime(2026, 9, 2, 4, 59)),
+        # Trailing Z is normalized before parsing.
+        ("2026-09-02T04:59:00Z", datetime.datetime(2026, 9, 2, 4, 59)),
+        # Naive: read as course-local (Chicago, CDT) then converted.
+        ("2026-09-01T23:59:00", datetime.datetime(2026, 9, 2, 4, 59)),
+    ],
+)
+async def test_ingest_stores_naive_utc(lms_string, expected):
+    assert await _ingest(lms_string, _course()) == expected
+
+
+async def test_ingest_of_a_naive_time_without_a_course_timezone_is_utc():
+    stored = await _ingest("2026-09-01T23:59:00", _course(timezone=None))
+    assert stored == datetime.datetime(2026, 9, 1, 23, 59)
+
+
+async def test_ingest_result_is_naive():
+    # A tz-aware value would blow up later comparisons against naive UTC.
+    assert (await _ingest("2026-09-01T23:59:00-05:00", _course())).tzinfo is None
+
+
+async def test_ingest_is_skipped_when_the_course_ignores_lti_dates():
+    from rsptx.admin_server_api.routers import lti1p3
+
+    original = datetime.datetime(2026, 1, 1, 12, 0)
+    assign = _assignment(duedate=original)
+    line_item = LineItem()
+    line_item.set_end_date_time("2026-09-01T23:59:00-05:00")
+
+    with patch.object(lti1p3, "update_assignment", AsyncMock()) as update:
+        await lti1p3.update_rsassignment_from_lti(
+            assign, line_item, {"ignore_lti_dates": "true"}, _course()
+        )
+
+    update.assert_not_awaited()
+    assert assign.duedate == original
+
+
+async def test_ingest_ignores_an_unparseable_date():
+    from rsptx.admin_server_api.routers import lti1p3
+
+    original = datetime.datetime(2026, 1, 1, 12, 0)
+    assign = _assignment(duedate=original)
+    line_item = LineItem()
+    line_item.set_end_date_time("not a date")
+
+    with patch.object(lti1p3, "update_assignment", AsyncMock()) as update:
+        await lti1p3.update_rsassignment_from_lti(assign, line_item, {}, _course())
+
+    update.assert_not_awaited()
+    assert assign.duedate == original
+
+
+# Push
+# ----
+
+
+def test_push_sends_an_explicit_utc_offset():
+    line_item = update_line_item_from_assignment(
+        LineItem(),
+        _assignment(duedate=datetime.datetime(2026, 9, 2, 4, 59)),
+        _course(),
+        push_duedate=True,
+    )
+    assert line_item.get_end_date_time() == "2026-09-02T04:59:00Z"
+
+
+def test_push_is_skipped_unless_requested():
+    line_item = update_line_item_from_assignment(
+        LineItem(),
+        _assignment(duedate=datetime.datetime(2026, 9, 2, 4, 59)),
+        _course(),
+        push_duedate=False,
+    )
+    assert line_item.get_end_date_time() is None
+
+
+# Round trip
+# ----------
+
+
+async def test_ingest_then_push_preserves_the_instant():
+    lms_string = "2026-09-01T23:59:00-05:00"
+    stored = await _ingest(lms_string, _course())
+
+    line_item = update_line_item_from_assignment(
+        LineItem(), _assignment(duedate=stored), _course(), push_duedate=True
+    )
+    sent = line_item.get_end_date_time()
+
+    assert datetime.datetime.fromisoformat(
+        sent.replace("Z", "+00:00")
+    ) == datetime.datetime.fromisoformat(lms_string)

--- a/test/components/rsptx/templates/test_core.py
+++ b/test/components/rsptx/templates/test_core.py
@@ -9,6 +9,7 @@ import jinja2
 
 from rsptx.templates import core
 from rsptx.templates.core import (
+    course_datetime_tag,
     format_course_datetime,
     get_shared_templates,
     install_filters,
@@ -146,3 +147,73 @@ def test_shared_templates_have_the_filter_registered():
         d=STORED_UTC, tz="America/Chicago"
     )
     assert rendered == "Sep 01, 2026 11:59 PM CDT"
+
+
+# course_datetime_tag
+# -------------------
+# Deadlines render on the reader's own clock, so the server emits a <time>
+# element carrying the UTC instant and JS rewrites the text. The text rendered
+# here is the no-JS fallback and must still be correct and labelled.
+
+
+def test_tag_carries_the_utc_instant_and_course_local_fallback():
+    tag = str(course_datetime_tag(STORED_UTC, "America/Chicago"))
+    assert 'datetime="2026-09-02T04:59:00Z"' in tag
+    assert ">Sep 01, 2026 11:59 PM CDT</time>" in tag
+
+
+def test_tag_marks_itself_for_localization_with_a_style():
+    assert 'data-rs-localize="long"' in str(course_datetime_tag(STORED_UTC, "UTC"))
+    assert 'data-rs-localize="short"' in str(
+        course_datetime_tag(STORED_UTC, "UTC", style="short")
+    )
+
+
+def test_tag_short_style_uses_the_short_format():
+    assert ">2026-09-01 23:59 CDT</time>" in str(
+        course_datetime_tag(STORED_UTC, "America/Chicago", style="short")
+    )
+
+
+def test_tag_keeps_course_time_in_the_title():
+    tag = str(course_datetime_tag(STORED_UTC, "America/Chicago"))
+    assert 'title="Sep 01, 2026 11:59 PM CDT course time"' in tag
+
+
+def test_tag_unknown_style_falls_back_to_long():
+    assert ">Sep 01, 2026 11:59 PM CDT</time>" in str(
+        course_datetime_tag(STORED_UTC, "America/Chicago", style="nonsense")
+    )
+
+
+def test_tag_renders_the_empty_placeholder_for_none():
+    assert str(course_datetime_tag(None, "UTC")) == ""
+    assert str(course_datetime_tag(None, "UTC", empty="N/A")) == "N/A"
+
+
+def test_tag_escapes_the_empty_placeholder():
+    assert (
+        str(course_datetime_tag(None, "UTC", empty="<b>x</b>"))
+        == "&lt;b&gt;x&lt;/b&gt;"
+    )
+
+
+def test_tag_passes_through_an_already_formatted_value():
+    assert str(course_datetime_tag("Sep 01", "UTC")) == "Sep 01"
+
+
+def test_tag_does_not_double_shift_an_aware_datetime():
+    aware = STORED_UTC.replace(tzinfo=datetime.timezone.utc)
+    assert str(course_datetime_tag(aware, "America/Chicago")) == str(
+        course_datetime_tag(STORED_UTC, "America/Chicago")
+    )
+
+
+def test_tag_is_registered_as_a_jinja_global():
+    env = get_shared_templates().env
+    assert "course_datetime_tag" in env.globals
+    rendered = env.from_string("{{ course_datetime_tag(d, tz) }}").render(
+        d=STORED_UTC, tz="America/Chicago"
+    )
+    # Markup, so the element is not escaped into text.
+    assert rendered.startswith("<time ")

--- a/test/components/rsptx/templates/test_core.py
+++ b/test/components/rsptx/templates/test_core.py
@@ -2,7 +2,22 @@ from types import SimpleNamespace
 
 import pytest
 
+import datetime
+
+import jinja2
+
+
 from rsptx.templates import core
+from rsptx.templates.core import (
+    format_course_datetime,
+    get_shared_templates,
+    install_filters,
+)
+
+# A deadline of 11:59 PM on 2026-09-01 in America/Chicago (CDT, UTC-5) is
+# stored as 2026-09-02 04:59 UTC. Every case below starts from that stored
+# value, so a correct conversion has to give the wall clock back.
+STORED_UTC = datetime.datetime(2026, 9, 2, 4, 59)
 
 
 def test_sample():
@@ -31,3 +46,103 @@ def test_editlibrary_displays_source_repository(github_url, expected):
     )
 
     assert expected in rendered
+
+
+@pytest.mark.parametrize(
+    "timezone,expected",
+    [
+        ("America/Chicago", "Sep 01, 2026 11:59 PM CDT"),
+        ("Europe/Berlin", "Sep 02, 2026 06:59 AM CEST"),
+        ("Asia/Kolkata", "Sep 02, 2026 10:29 AM IST"),  # half hour offset
+        ("Asia/Tokyo", "Sep 02, 2026 01:59 PM JST"),
+        ("UTC", "Sep 02, 2026 04:59 AM UTC"),
+    ],
+)
+def test_renders_stored_utc_in_the_course_timezone(timezone, expected):
+    assert format_course_datetime(STORED_UTC, timezone) == expected
+
+
+def test_daylight_saving_is_taken_from_the_date_not_the_zone():
+    # The same course is UTC-6 in January and UTC-5 in July. Both render as
+    # 11:59 PM local, which is only true if the offset comes from the date.
+    winter = datetime.datetime(2026, 1, 16, 5, 59)  # 2026-01-15 23:59 CST
+    summer = datetime.datetime(2026, 7, 16, 4, 59)  # 2026-07-15 23:59 CDT
+    assert (
+        format_course_datetime(winter, "America/Chicago") == "Jan 15, 2026 11:59 PM CST"
+    )
+    assert (
+        format_course_datetime(summer, "America/Chicago") == "Jul 15, 2026 11:59 PM CDT"
+    )
+
+
+def test_a_course_with_no_timezone_is_treated_as_utc():
+    # Matches the duedate migration, which backfills NULL to 'UTC'.
+    assert format_course_datetime(STORED_UTC, None) == "Sep 02, 2026 04:59 AM UTC"
+    assert format_course_datetime(STORED_UTC, "") == "Sep 02, 2026 04:59 AM UTC"
+
+
+def test_unrecognized_timezone_falls_back_instead_of_raising():
+    # courses.timezone is only validated when set through the settings UI, so a
+    # bad value must not take the page down.
+    assert (
+        format_course_datetime(STORED_UTC, "Mars/Olympus")
+        == "Sep 02, 2026 04:59 AM UTC"
+    )
+
+
+def test_none_renders_as_empty_string():
+    assert format_course_datetime(None, "America/Chicago") == ""
+
+
+def test_non_datetime_passes_through():
+    # Some callers hand in a value that was already formatted upstream.
+    assert format_course_datetime("Sep 01", "America/Chicago") == "Sep 01"
+
+
+def test_custom_format_is_honored():
+    assert (
+        format_course_datetime(STORED_UTC, "America/Chicago", fmt="%Y-%m-%d %H:%M")
+        == "2026-09-01 23:59 CDT"
+    )
+
+
+def test_show_timezone_false_omits_the_abbreviation():
+    assert (
+        format_course_datetime(
+            STORED_UTC, "America/Chicago", fmt="%Y-%m-%d", show_timezone=False
+        )
+        == "2026-09-01"
+    )
+
+
+def test_date_only_display_still_shifts_the_day():
+    # The reason date-only fields cannot skip the conversion: this deadline is
+    # September 2nd in UTC but September 1st for the course.
+    assert format_course_datetime(
+        STORED_UTC, "America/Chicago", fmt="%Y-%m-%d", show_timezone=False
+    ) != STORED_UTC.strftime("%Y-%m-%d")
+
+
+def test_aware_datetime_is_not_double_shifted():
+    aware = STORED_UTC.replace(tzinfo=datetime.timezone.utc)
+    assert format_course_datetime(aware, "America/Chicago") == format_course_datetime(
+        STORED_UTC, "America/Chicago"
+    )
+
+
+def test_install_filters_registers_course_datetime():
+    env = jinja2.Environment()
+    assert "course_datetime" not in env.filters
+    install_filters(env)
+    assert env.filters["course_datetime"] is format_course_datetime
+
+
+def test_shared_templates_have_the_filter_registered():
+    # Every server builds templates through this factory, so the filter has to
+    # be present or `| course_datetime` raises at render time.
+    env = get_shared_templates().env
+    assert "course_datetime" in env.filters
+    rendered = env.from_string("{{ d | course_datetime(tz) }}").render(
+        d=STORED_UTC, tz="America/Chicago"
+    )
+    assert rendered == "Sep 01, 2026 11:59 PM CDT"

--- a/test/migrations/test_duedate_to_utc.py
+++ b/test/migrations/test_duedate_to_utc.py
@@ -1,0 +1,221 @@
+"""Round trip for the duedate -> UTC migration (c4e8a1f7b2d9).
+
+Runs the real ``upgrade()``/``downgrade()`` bodies against the test database
+inside a transaction that is always rolled back, with a stand-in for alembic's
+``op``. Postgres DDL is transactional, so the backfill table the migration
+creates disappears with the rollback too.
+"""
+
+import datetime
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+MIGRATION = (
+    Path(__file__).resolve().parents[2]
+    / "migrations"
+    / "versions"
+    / "c4e8a1f7b2d9_duedate_to_utc.py"
+)
+
+# (label, timezone, local wall clock, expected stored UTC)
+CASES = [
+    ("chicago-winter", "America/Chicago", "2026-01-15 23:59:00", "2026-01-16 05:59:00"),
+    ("chicago-summer", "America/Chicago", "2026-07-15 23:59:00", "2026-07-16 04:59:00"),
+    ("berlin", "Europe/Berlin", "2026-03-01 12:00:00", "2026-03-01 11:00:00"),
+    ("kolkata", "Asia/Kolkata", "2026-05-10 09:30:00", "2026-05-10 04:00:00"),
+    ("tokyo", "Asia/Tokyo", "2026-02-01 08:00:00", "2026-01-31 23:00:00"),
+    ("explicit-utc", "UTC", "2026-04-01 17:00:00", "2026-04-01 17:00:00"),
+    ("null-tz", None, "2026-04-01 17:00:00", "2026-04-01 17:00:00"),
+]
+
+
+@pytest.fixture
+def conn():
+    """A connection in a transaction that is never committed."""
+    url = os.environ["TEST_DBURL"]
+    engine = sa.create_engine(url, future=True)
+    connection = engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.rollback()
+        connection.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def migration(conn):
+    """The migration module, with ``op`` bound to the test connection."""
+    spec = importlib.util.spec_from_file_location("duedate_mig", MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["duedate_mig"] = mod
+    spec.loader.exec_module(mod)
+
+    class FakeOp:
+        @staticmethod
+        def get_bind():
+            return conn
+
+        @staticmethod
+        def execute(stmt):
+            return conn.execute(sa.text(stmt) if isinstance(stmt, str) else stmt)
+
+    mod.op = FakeOp
+    return mod
+
+
+@pytest.fixture
+def seeded(conn):
+    """Insert one course per timezone plus its assignments. Returns ids."""
+    ids = {}
+    course_ids = {}
+    for label, tz, local, _expected in CASES:
+        if tz not in course_ids:
+            course_ids[tz] = conn.execute(
+                sa.text(
+                    "INSERT INTO courses (course_name, base_course, timezone, "
+                    "     term_start_date, login_required, allow_pairs, "
+                    "     downloads_enabled, courselevel, institution) "
+                    "VALUES (:n, :n, :tz, '2026-01-01', 'F', 'F', 'F', '', '') "
+                    "RETURNING id"
+                ),
+                {"n": f"duedate-utc-test-{tz or 'null'}", "tz": tz},
+            ).scalar()
+        ids[label] = conn.execute(
+            sa.text(
+                "INSERT INTO assignments (course, name, duedate, visible, "
+                "     released, from_source, points) "
+                "VALUES (:c, :n, :d, 'F', 'F', 'F', 10) RETURNING id"
+            ),
+            {
+                "c": course_ids[tz],
+                "n": f"duedate-utc-test-{label}",
+                "d": datetime.datetime.fromisoformat(local),
+            },
+        ).scalar()
+    return ids, course_ids
+
+
+def _duedates(conn, ids):
+    rows = conn.execute(
+        sa.text("SELECT id, duedate FROM assignments WHERE id = ANY(:ids)"),
+        {"ids": list(ids.values())},
+    ).fetchall()
+    by_id = {r.id: r.duedate for r in rows}
+    return {label: by_id[aid] for label, aid in ids.items()}
+
+
+def test_upgrade_converts_course_local_to_utc(conn, migration, seeded):
+    ids, _ = seeded
+    migration.upgrade()
+    after = _duedates(conn, ids)
+    for label, _tz, _local, expected in CASES:
+        assert after[label] == datetime.datetime.fromisoformat(expected), label
+
+
+def test_upgrade_leaves_utc_and_null_timezone_courses_untouched(conn, migration, seeded):
+    ids, _ = seeded
+    before = _duedates(conn, ids)
+    migration.upgrade()
+    after = _duedates(conn, ids)
+    assert after["explicit-utc"] == before["explicit-utc"]
+    assert after["null-tz"] == before["null-tz"]
+
+
+def test_upgrade_backfills_null_timezone_to_utc(conn, migration, seeded):
+    _, course_ids = seeded
+    null_course = course_ids[None]
+    assert conn.execute(
+        sa.text("SELECT timezone FROM courses WHERE id = :id"), {"id": null_course}
+    ).scalar() is None
+
+    migration.upgrade()
+
+    assert (
+        conn.execute(
+            sa.text("SELECT timezone FROM courses WHERE id = :id"), {"id": null_course}
+        ).scalar()
+        == "UTC"
+    )
+    assert conn.execute(
+        sa.text(
+            "SELECT 1 FROM duedate_utc_tz_backfill WHERE course_id = :id"
+        ),
+        {"id": null_course},
+    ).scalar() == 1
+
+
+def test_upgrade_records_only_backfilled_courses(conn, migration, seeded):
+    _, course_ids = seeded
+    migration.upgrade()
+    recorded = {
+        r.course_id
+        for r in conn.execute(
+            sa.text("SELECT course_id FROM duedate_utc_tz_backfill")
+        )
+    }
+    assert course_ids[None] in recorded
+    # A course that already said 'UTC' must not be recorded, or the downgrade
+    # would wrongly set its timezone back to NULL.
+    assert course_ids["UTC"] not in recorded
+
+
+def test_downgrade_restores_duedates_and_timezones(conn, migration, seeded):
+    ids, course_ids = seeded
+    before = _duedates(conn, ids)
+
+    migration.upgrade()
+    migration.downgrade()
+
+    assert _duedates(conn, ids) == before
+    assert conn.execute(
+        sa.text("SELECT timezone FROM courses WHERE id = :id"),
+        {"id": course_ids[None]},
+    ).scalar() is None
+    assert conn.execute(
+        sa.text("SELECT timezone FROM courses WHERE id = :id"),
+        {"id": course_ids["America/Chicago"]},
+    ).scalar() == "America/Chicago"
+
+
+def test_downgrade_drops_the_backfill_table(conn, migration, seeded):
+    migration.upgrade()
+    assert conn.execute(
+        sa.text("SELECT to_regclass('duedate_utc_tz_backfill')")
+    ).scalar() is not None
+    migration.downgrade()
+    assert conn.execute(
+        sa.text("SELECT to_regclass('duedate_utc_tz_backfill')")
+    ).scalar() is None
+
+
+def test_unresolvable_timezone_on_a_course_with_assignments_is_rejected(
+    conn, migration, seeded
+):
+    _, course_ids = seeded
+    conn.execute(
+        sa.text("UPDATE courses SET timezone = 'Mars/Olympus' WHERE id = :id"),
+        {"id": course_ids["America/Chicago"]},
+    )
+    with pytest.raises(RuntimeError, match="Mars/Olympus"):
+        migration.upgrade()
+
+
+def test_unresolvable_timezone_on_a_course_without_assignments_does_not_block(
+    conn, migration, seeded
+):
+    conn.execute(
+        sa.text(
+            "INSERT INTO courses (course_name, base_course, timezone, "
+            "     term_start_date, login_required, allow_pairs, "
+            "     downloads_enabled, courselevel, institution) "
+            "VALUES ('duedate-utc-test-empty', 'duedate-utc-test-empty', "
+            "        'Mars/Olympus', '2026-01-01', 'F', 'F', 'F', '', '')"
+        )
+    )
+    migration.upgrade()  # must not raise

--- a/test/migrations/test_duedate_to_utc.py
+++ b/test/migrations/test_duedate_to_utc.py
@@ -73,6 +73,18 @@ def migration(conn):
 def seeded(conn):
     """Insert one course per timezone plus its assignments. Returns ids."""
     ids = {}
+    # The shared test database is seeded with courses that have no timezone and
+    # far-future deadlines, which the live-course guard rightly objects to.
+    # Give those a timezone so each test controls the precondition it is
+    # actually exercising. Rolled back with everything else.
+    conn.execute(
+        sa.text(
+            "UPDATE courses SET timezone = 'UTC' "
+            " WHERE timezone IS NULL "
+            "   AND id IN (SELECT course FROM assignments)"
+        )
+    )
+
     course_ids = {}
     for label, tz, local, _expected in CASES:
         if tz not in course_ids:
@@ -219,3 +231,96 @@ def test_unresolvable_timezone_on_a_course_without_assignments_does_not_block(
         )
     )
     migration.upgrade()  # must not raise
+
+
+# Live courses with no timezone
+# -----------------------------
+# A NULL timezone is left alone and backfilled to 'UTC'. That is harmless for a
+# finished course, but a course with deadlines still ahead of it would have its
+# typed wall clock silently start being read as UTC. Setting the timezone first
+# converts it correctly, so the migration blocks rather than let that ordering
+# be got wrong.
+
+
+def _add_course(conn, name, timezone, duedate):
+    course_id = conn.execute(
+        sa.text(
+            "INSERT INTO courses (course_name, base_course, timezone, "
+            "     term_start_date, login_required, allow_pairs, "
+            "     downloads_enabled, courselevel, institution) "
+            "VALUES (:n, :n, :tz, '2026-01-01', 'F', 'F', 'F', '', '') "
+            "RETURNING id"
+        ),
+        {"n": name, "tz": timezone},
+    ).scalar()
+    conn.execute(
+        sa.text(
+            "INSERT INTO assignments (course, name, duedate, visible, "
+            "     released, from_source, points) "
+            "VALUES (:c, :n, :d, 'F', 'F', 'F', 10)"
+        ),
+        {"c": course_id, "n": f"{name}-assignment", "d": duedate},
+    )
+    return course_id
+
+
+def _future():
+    return datetime.datetime.now(datetime.timezone.utc).replace(
+        tzinfo=None
+    ) + datetime.timedelta(days=30)
+
+
+def _past():
+    return datetime.datetime.now(datetime.timezone.utc).replace(
+        tzinfo=None
+    ) - datetime.timedelta(days=30)
+
+
+def test_live_course_without_a_timezone_blocks_the_upgrade(conn, migration, seeded):
+    _add_course(conn, "duedate-utc-test-live-null", None, _future())
+
+    with pytest.raises(RuntimeError, match="duedate-utc-test-live-null"):
+        migration.upgrade()
+
+
+def test_the_block_names_the_fix(conn, migration, seeded):
+    _add_course(conn, "duedate-utc-test-live-null-2", None, _future())
+
+    with pytest.raises(RuntimeError, match="Set courses.timezone"):
+        migration.upgrade()
+
+
+def test_a_finished_course_without_a_timezone_does_not_block(conn, migration, seeded):
+    # The seeded null-tz course is already in the past; add another for clarity.
+    _add_course(conn, "duedate-utc-test-done-null", None, _past())
+
+    migration.upgrade()  # must not raise
+
+
+def test_setting_the_timezone_lets_the_upgrade_proceed(conn, migration, seeded):
+    course_id = _add_course(conn, "duedate-utc-test-fixed", None, _future())
+
+    with pytest.raises(RuntimeError):
+        migration.upgrade()
+
+    conn.execute(
+        sa.text("UPDATE courses SET timezone = 'America/Chicago' WHERE id = :id"),
+        {"id": course_id},
+    )
+
+    migration.upgrade()  # must not raise
+
+
+def test_the_env_override_allows_the_upgrade(conn, migration, seeded, monkeypatch):
+    _add_course(conn, "duedate-utc-test-override", None, _future())
+    monkeypatch.setenv(migration.ALLOW_NULL_TIMEZONE_ENV, "1")
+
+    migration.upgrade()  # must not raise
+
+
+def test_the_env_override_only_accepts_exactly_one(conn, migration, seeded, monkeypatch):
+    _add_course(conn, "duedate-utc-test-override-2", None, _future())
+    monkeypatch.setenv(migration.ALLOW_NULL_TIMEZONE_ENV, "yes")
+
+    with pytest.raises(RuntimeError):
+        migration.upgrade()


### PR DESCRIPTION
`assignments.duedate` has always held a naive datetime in **course-local wall clock time**, while `visible_on`, `hidden_on` and every answer timestamp are naive **UTC**. Every grading path had to convert before comparing — and several didn't. This stores the due date in UTC and converts only for display.

Three commits: the storage change, the display change, then a migration guard.

## Why this is worth the churn

Three latent bugs fall out of the inconsistency, all fixed here:

| where | bug |
|---|---|
| `grading_helpers/regrade.py` | `_effective_deadline` compared a course-local due date directly against naive-UTC answer timestamps. **Batch regrades used a cutoff off by the course's UTC offset.** |
| `lti1p3/core.py` | pushed `duedate.isoformat()` to the LMS with no offset, so the LMS was free to read it as its own local time. |
| `admin_server_api/routers/instructor.py` | copy-assignment subtracted a timezone-less term-start midnight from the due date. Once `duedate` is UTC the operands are in different frames — a Chicago course copying a 23:59 assignment landed on **00:59 the next day**. |

There is also a standing `TODO: end this craziness by storing the deadline in UTC` in the web2py code that this resolves.

## Migration (`c4e8a1f7b2d9`)

Shifts `duedate` using `courses.timezone`, and backfills NULL timezones to `'UTC'`.

The `timezone` column was added in `8f857bdfef19` **without a backfill**, so most legacy courses are NULL and have no defensible source timezone — those rows are left byte-identical. On the dev database that was 27 of 35 courses.

- Courses that were backfilled are recorded in `duedate_utc_tz_backfill`, so `downgrade()` restores NULL for **exactly those** and not for courses that already said `'UTC'`.
- `downgrade()` **recomputes** local time from the stored UTC rather than restoring a snapshot, so assignments created or edited after the upgrade convert correctly instead of being clobbered.
- A pre-flight check rejects unrecognized `courses.timezone` values with a message naming the offending courses, instead of letting `AT TIME ZONE` abort mid-statement. Courses with a bad timezone but no assignments don't block.
- A second pre-flight **refuses to run while any NULL-timezone course still has a future due date** (see below). `DUEDATE_UTC_ALLOW_NULL_TIMEZONE=1` overrides.

## Display

Due dates render on the **reader's own clock**, so a travelling student never converts a deadline by hand. `course_datetime_tag()` emits

```html
<time datetime="2026-09-02T04:59:00Z" data-rs-localize="long"
      title="Sep 01, 2026 11:59 PM CDT course time">Sep 01, 2026 11:59 PM CDT</time>
```

and `staticAssets/js/localize-times.js` rewrites the text. Without JS the page still shows a correct, timezone-labelled time; course time stays in the tooltip. The zone abbreviation is always shown, so no displayed time is ambiguous.

Instructor analytics stay course-local — they show a date with no time, and a browser-local shift can move a late-evening deadline onto the neighbouring day in a report read against the course calendar.

An instructor authoring from a different timezone than the course gets a warning under the due date field showing the chosen instant in course time, so "11:59 PM" typed in Chicago for a Los Angeles course doesn't quietly become 9:59 PM for the students.

## Please look closely at

1. **The NULL-timezone decision.** Treating NULL as UTC means those courses' due dates don't move. The alternative — guessing a timezone — seemed worse, but it's the call with the widest blast radius.

   **In practice this is now a small, bounded set.** Every course created in the last year has a timezone, and instructors can set their own, so the NULL courses are overwhelmingly dormant ones whose deadlines are long past — where leaving the value alone has no effect at all. On the dev database only 6 of 27 NULL-timezone courses owned any assignments; the rest were irrelevant to the migration entirely. A production check turned up only a handful, which will be dealt with before deploy.

   The residual risk was a course created more than a year ago that is *still running* — long-running, self-paced or multi-term — since it would still be NULL and still have live deadlines. **The migration now blocks on exactly that case** rather than leaving it to the runbook:

   ```
   Cannot convert assignment due dates to UTC: these courses have deadlines in the
   future but no timezone set: course 24 ('PTXSB') latest due 2026-08-07 00:55:00.
   Set courses.timezone for them and re-run -- their due dates will then convert
   correctly. To proceed anyway and have their deadlines treated as UTC, set
   DUEDATE_UTC_ALLOW_NULL_TIMEZONE=1.
   ```

   This matters because **fixing such a course is much cheaper before the migration than after**: setting `courses.timezone` first converts it correctly along with everyone else, whereas afterwards its due dates are fixed instants and nothing records which zone they were meant to be in. Note also that setting a course timezone *after* the migration will not retroactively reinterpret existing due dates — it affects display and future deadlines only.
2. **`_term_start_utc`** in `admin_server_api/routers/instructor.py`. The copy-assignment date maths is the subtlest change here.
3. **The per-page localize include.** PreTeXt books ship their own `_base.html` and `get_jinja_templates()` searches the book directory first, so a base-template include silently vanished for exactly those courses. It's now included per page — **any new page using `course_datetime_tag()` must include `common/localize_times.html`.** That's the one part of the design that isn't self-enforcing.

## Deploying

Set `courses.timezone` on any still-running course that lacks one **first** — the migration will refuse to run otherwise and tell you which ones.

**The migration and the code must ship together.** A shifted `duedate` read by unconverted code (or the reverse) mis-grades. Single migration, single deploy, low-traffic window, and confirm no timed exams are in flight — one that starts before the cutover and ends after it straddles the shift.

Rollback is `alembic downgrade -1` plus rolling the code back in the same window.

**web2py is deliberately not converted** — it's being retired. Until then its pages subtract the browser `tz_offset` on the assumption the due date is course-local, so they'll show deadlines shifted by the course's UTC offset. `/runestone/dashboard/grades` is the one still-live surface (linked from `templates/author/logfiles.html:21`). Grades computed by the FastAPI path are unaffected.

## Testing

Python **181 → 235**, JS **2124 → 2130**. Green in UTC, America/Chicago, Asia/Tokyo, Pacific/Kiritimati (+14) and Pacific/Midway (−11).

New coverage includes the migration round trip run against a real database in a rolled-back transaction, the copy-between-terms regression, and the **first LTI 1.3 tests in the repo** (only `lti1p1` existed).

Verified in the running app after rebuilding `book`, `assignment`, `admin` and applying the migration to the dev database — 7 assignments shifted, 27 courses backfilled:

- every due date renders at its **original wall clock**
- the same assignment reads `Apr 24, 2026, 12:36 PM PDT` to a Los Angeles browser and `Apr 25, 2026, 04:36 AM GMT+9` to a Tokyo one
- the `is_assigned` scoring boundary, checked by moving a due date either side of now: due in 1h + `enforce_due` → assigned; due 1h ago + `enforce_due` → not assigned; due 1h ago without → assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xK9HD5NSi1EAWY3cSJPmC
