### PR TITLE
Show source repository on book metadata page

### DIFF
--- a/bases/rsptx/author_server_api/main.py
+++ b/bases/rsptx/author_server_api/main.py
@@ -363,7 +363,13 @@ async def editlib(request: Request, book: str, user=Depends(auth_manager)):
         return RedirectResponse(url="/author/", status_code=status.HTTP_303_SEE_OTHER)
     return templates.TemplateResponse(
         "author/editlibrary.html",
-        context=dict(request=request, form=form, book=book, course=course),
+        context=dict(
+            request=request,
+            form=form,
+            book=book,
+            course=course,
+            github_url=book_data.github_url if book_data else None,
+        ),
     )
 
 

--- a/components/rsptx/templates/author/editlibrary.html
+++ b/components/rsptx/templates/author/editlibrary.html
@@ -19,6 +19,14 @@
 {% block content %}
 <div>
     <h2>Edit book metadata for {{book}}</h2>
+    <section aria-labelledby="source-repository-heading">
+        <h3 id="source-repository-heading">Source repository</h3>
+        {% if github_url %}
+        <p><strong>GitHub repository:</strong> <code id="github-repository">{{ github_url }}</code></p>
+        {% else %}
+        <p id="github-repository">No GitHub repository is recorded for this book.</p>
+        {% endif %}
+    </section>
     <form method="POST" action="/author/editlibrary/{{book}}">
         {% for field in form %}
             {{ with_errors(field)}}

--- a/test/components/rsptx/templates/test_core.py
+++ b/test/components/rsptx/templates/test_core.py
@@ -1,5 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+
 from rsptx.templates import core
 
 
 def test_sample():
     assert core is not None
+
+
+@pytest.mark.parametrize(
+    ("github_url", "expected"),
+    [
+        (
+            "https://github.com/RunestoneInteractive/thinkcspy",
+            "https://github.com/RunestoneInteractive/thinkcspy",
+        ),
+        (None, "No GitHub repository is recorded for this book."),
+    ],
+)
+def test_editlibrary_displays_source_repository(github_url, expected):
+    templates = core.get_jinja_templates("")
+    template = templates.env.get_template("author/editlibrary.html")
+
+    rendered = template.render(
+        form=[],
+        book="thinkcspy",
+        course=SimpleNamespace(course_name="thinkcspy"),
+        github_url=github_url,
+    )
+
+    assert expected in rendered


### PR DESCRIPTION
## Summary

- show the configured GitHub repository on the book metadata edit page
- keep the repository value read-only and show a clear fallback when none is recorded
- add rendering coverage for both cases

## Tests

- `pytest -q test/components/rsptx/templates/test_core.py` — 3 passed in an isolated environment matching the declared FastAPI 0.115 range
- `ruff check bases/rsptx/author_server_api/main.py test/components/rsptx/templates/test_core.py`
- `ruff format --check bases/rsptx/author_server_api/main.py test/components/rsptx/templates/test_core.py`

Closes #732

AI-assisted contribution prepared and tested by Avery Quinn, working with @vivid0o0.
