### PR TITLE
Fix: course creation - prevent comparison error for books with None for shelf_section

### DIFF
--- a/bases/rsptx/admin_server_api/routers/instructor.py
+++ b/bases/rsptx/admin_server_api/routers/instructor.py
@@ -1320,7 +1320,7 @@ async def get_create_course_page(request: Request, user=Depends(auth_manager)):
     course_list = await fetch_library_books()
     # Convert LibraryValidator objects to dicts for template compatibility
     course_list = [c.dict() for c in course_list if c.for_classes]
-    sections = sorted({c["shelf_section"] for c in course_list})
+    sections = sorted({c["shelf_section"] or "Misc" for c in course_list})
     context = {
         "request": request,
         "course_list": course_list,
@@ -1447,7 +1447,7 @@ async def post_create_course_page(
         course_list = await fetch_library_books()
         # Convert LibraryValidator objects to dicts for template compatibility
         course_list = [c.dict() for c in course_list if c.for_classes]
-        sections = sorted({c["shelf_section"] for c in course_list})
+        sections = sorted({c["shelf_section"] or "Misc" for c in course_list})
 
         context = {
             "request": request,

--- a/components/rsptx/db/crud/library.py
+++ b/components/rsptx/db/crud/library.py
@@ -65,7 +65,9 @@ async def create_library_book(bookid: str, vals: Dict[str, Any]) -> None:
     :param vals: Dict[str, Any], the dictionary containing the properties of the book
     :return: None
     """
-    new_book = Library(**vals, basecourse=bookid)
+    book_vals = {"shelf_section": "Misc", **vals}
+    new_book = Library(**book_vals, basecourse=bookid)
+
     async with async_session.begin() as session:
         session.add(new_book)
 


### PR DESCRIPTION
I have a bunch of books in my dev library where shelf_section is None. That crashes the sort code when creating a new course. This fixes the course creation page to handle those.