### PR TITLE
Improvements to developer documentation

### DIFF
--- a/docs/source/building_servers.rst
+++ b/docs/source/building_servers.rst
@@ -23,7 +23,8 @@ Now you are ready to install the required dependencies and build the servers:
    Future instructions will make it clear which commands need to be run inside the virtual environment by always including ``uv run ...`` at the start of the command. This is what you will need to type if you are **NOT** in the activated virtual environment. If you activate the virtual environment, you will be able to skip typing ``uv run``. For example, to check the environmental variables, you would type ``uv run rsmanage env`` if the virtual environment is not active; if the virtual environment is active, you would just type ``rsmanage env``.
 
 
-7.  Run the ``build`` script from the ``rs`` folder by doing ``uv run build full`` (or just ``build full`` if you are still in the virtual environment). The first step of this script will verify that you have all of your environment variables defined. It will then build the python wheels for all the runestone components and then build the docker servers. This will take a while.
+
+7.  Run the ``build`` script from the ``rs`` folder by doing ``uv run build full`` (or if still in the virtual environment, just ``build full``). The first step of this script will verify that you have all of your environment variables defined. It will then build the python wheels for all the runestone components and then build the docker servers. This will take a while (on the order of 30-90 minutes).  More details about the build server is given below.
 
 
 Starting the Servers

--- a/docs/source/building_servers.rst
+++ b/docs/source/building_servers.rst
@@ -23,7 +23,7 @@ Now you are ready to install the required dependencies and build the servers:
    Future instructions will make it clear which commands need to be run inside the virtual environment by always including ``uv run ...`` at the start of the command. This is what you will need to type if you are **NOT** in the activated virtual environment. If you activate the virtual environment, you will be able to skip typing ``uv run``. For example, to check the environmental variables, you would type ``uv run rsmanage env`` if the virtual environment is not active; if the virtual environment is active, you would just type ``rsmanage env``.
 
 
-7.  Run the ``build`` script from the ``rs`` folder by doing ``build full``. The first step of this script will verify that you have all of your environment variables defined. It will then build the python wheels for all the runestone components and then build the docker servers. This will take a while.
+7.  Run the ``build`` script from the ``rs`` folder by doing ``uv run build full`` (or just ``build full`` if you are still in the virtual environment). The first step of this script will verify that you have all of your environment variables defined. It will then build the python wheels for all the runestone components and then build the docker servers. This will take a while.
 
 
 Starting the Servers


### PR DESCRIPTION
While setting up my runestone dev environment, I got confused in section 13.  Step 6 says to leave the virtual environment.  There is then a note about how in the future commands that should happen inside the environment will include `uv run`.  But step 7 omits this.