### PR TITLE
Remove chapter numbers from chapter titles

### DIFF
--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.module.css
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.module.css
@@ -2,6 +2,11 @@
   white-space: nowrap;
 }
 
+.chapterCell {
+  min-width: 0;
+  max-width: 16rem;
+}
+
 .sectionCell {
   min-width: 0;
   max-width: 24rem;

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.spec.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.spec.tsx
@@ -31,8 +31,12 @@ const READINGS: Exercise[] = [
     id: 1,
     name: "Welcome",
     title: "Welcome",
-    chapter: "Intro",
+    chapter: "intro",
+    chapter_name: "Intro",
+    chapter_num: 1,
     subchapter: "intro-welcome",
+    sub_chapter_name: "Welcome",
+    sub_chapter_num: 1,
     numQuestions: 10,
     activities_required: 6,
     points: 5,
@@ -42,8 +46,12 @@ const READINGS: Exercise[] = [
     id: 2,
     name: "Variables",
     title: "Variables",
-    chapter: "Basics",
+    chapter: "basics",
+    chapter_name: "Basics",
+    chapter_num: 2,
     subchapter: "basics-variables",
+    sub_chapter_name: "Variables",
+    sub_chapter_num: 3,
     numQuestions: 0,
     activities_required: 0,
     points: 3,
@@ -66,16 +74,21 @@ const baseProps = {
 describe("AssignmentReadingsTable", () => {
   it("renders one row per reading with chapter and section", () => {
     renderWithMantine(<AssignmentReadingsTable {...baseProps} />);
-    expect(screen.getByText("Intro")).toBeInTheDocument();
-    expect(screen.getByText("Welcome")).toBeInTheDocument();
-    expect(screen.getByText("Basics")).toBeInTheDocument();
-    expect(screen.getByText("Variables")).toBeInTheDocument();
+    expect(screen.getByText("1 Intro")).toBeInTheDocument();
+    expect(screen.getByText("intro")).toBeInTheDocument();
+    expect(screen.getByText("1.1 Welcome")).toBeInTheDocument();
+    expect(screen.getByText("intro-welcome")).toBeInTheDocument();
+    expect(screen.getByText("2 Basics")).toBeInTheDocument();
+    expect(screen.getByText("basics")).toBeInTheDocument();
+    expect(screen.getByText("2.3 Variables")).toBeInTheDocument();
+    expect(screen.getByText("basics-variables")).toBeInTheDocument();
   });
 
   it("filters readings by chapter or section text", () => {
     renderWithMantine(<AssignmentReadingsTable {...baseProps} globalFilter="basics" />);
-    expect(screen.queryByText("Welcome")).not.toBeInTheDocument();
-    expect(screen.getByText("Variables")).toBeInTheDocument();
+    expect(screen.queryByText("1.1 Welcome")).not.toBeInTheDocument();
+    expect(screen.getByText("2.3 Variables")).toBeInTheDocument();
+    expect(screen.getByText("basics-variables")).toBeInTheDocument();
   });
 
   it("defaults the activity count to at least one and required to 80 percent", () => {

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/AssignmentReadingsTable.tsx
@@ -35,13 +35,28 @@ interface AssignmentReadingsTableProps {
 const getNumQuestionsOrDefault = (numQuestions: Nullable<number>): number =>
   Math.max(numQuestions ?? 0, 1);
 
+const formatNumberedLabel = (label: string, numbers: Array<number | null | undefined>): string => {
+  const prefix = numbers
+    .filter((value): value is number => value !== null && value !== undefined)
+    .join(".");
+
+  return prefix ? [prefix, label].filter(Boolean).join(" ") : label;
+};
+
 const matchesFilter = (reading: Exercise, filter: string): boolean => {
   const query = filter.trim().toLowerCase();
 
   if (!query) {
     return true;
   }
-  return [reading.name, reading.title, reading.chapter, reading.subchapter]
+  return [
+    reading.name,
+    reading.title,
+    reading.chapter_name,
+    reading.sub_chapter_name,
+    reading.chapter,
+    reading.subchapter
+  ]
     .filter(Boolean)
     .some((field) => field!.toLowerCase().includes(query));
 };
@@ -75,8 +90,17 @@ export const AssignmentReadingsTable = ({
       {
         key: "chapter",
         header: "Chapter",
-        width: "12rem",
-        render: (row) => <div className={styles.nowrap}>{row.chapter}</div>
+        width: "16rem",
+        render: (row) => (
+          <div className={styles.chapterCell}>
+            <div className={styles.sectionTitle} title={row.chapter_name || row.chapter}>
+              {formatNumberedLabel(row.chapter_name || row.chapter, [row.chapter_num])}
+            </div>
+            <div className={styles.sectionPath} title={row.chapter || undefined}>
+              {row.chapter}
+            </div>
+          </div>
+        )
       },
       {
         key: "subchapter",
@@ -84,8 +108,14 @@ export const AssignmentReadingsTable = ({
         width: "20rem",
         render: (row) => (
           <div className={styles.sectionCell}>
-            <div className={styles.sectionTitle} title={row.name || row.title}>
-              {row.name || row.title}
+            <div
+              className={styles.sectionTitle}
+              title={row.sub_chapter_name || row.title || row.name || row.subchapter}
+            >
+              {formatNumberedLabel(
+                row.sub_chapter_name || row.title || row.name || row.subchapter,
+                [row.chapter_num, row.sub_chapter_num]
+              )}
             </div>
             <div className={styles.sectionPath} title={row.subchapter || undefined}>
               {row.subchapter}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/components/ChooseReadingsButton.spec.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/components/ChooseReadingsButton.spec.tsx
@@ -12,10 +12,10 @@ const { mockUpdate, mockReadingsSelector, updatingHolder, READINGS_TREE } = vi.h
   READINGS_TREE: [
     {
       key: "chapter-1",
-      data: { title: "Chapter 1" },
+      data: { title: "Chapter 1", chapter_num: 1 },
       children: [
-        { key: "sec-1", data: { title: "Section 1", id: 11 } },
-        { key: "sec-2", data: { title: "Section 2", id: 12 } }
+        { key: "sec-1", data: { title: "Section 1", id: 11, chapter_num: 1, sub_chapter_num: 1 } },
+        { key: "sec-2", data: { title: "Section 2", id: 12, chapter_num: 1, sub_chapter_num: 2 } }
       ]
     }
   ] as TreeNode[]
@@ -46,18 +46,18 @@ describe("ChooseReadingsButton", () => {
 
   it("reveals the readings tree when the button is clicked", async () => {
     renderWithMantine(<ChooseReadingsButton />);
-    expect(screen.queryByText("Chapter 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("1 Chapter 1")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Choose readings" }));
-    expect(screen.getByText("Chapter 1")).toBeInTheDocument();
+    expect(screen.getByText("1 Chapter 1")).toBeInTheDocument();
   });
 
   it("adds the selected leaf readings on select", async () => {
     renderWithMantine(<ChooseReadingsButton />);
     await userEvent.click(screen.getByRole("button", { name: "Choose readings" }));
-    await userEvent.click(screen.getByRole("button", { name: "Expand Chapter 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "Expand 1 Chapter 1" }));
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Select Section 1" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select 1.1 Section 1" }));
 
     expect(mockUpdate).toHaveBeenCalledWith({ idsToAdd: [11], isReading: true });
   });
@@ -70,9 +70,9 @@ describe("ChooseReadingsButton", () => {
 
     renderWithMantine(<ChooseReadingsButton />);
     await userEvent.click(screen.getByRole("button", { name: "Choose readings" }));
-    await userEvent.click(screen.getByRole("button", { name: "Expand Chapter 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "Expand 1 Chapter 1" }));
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Select Section 1" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select 1.1 Section 1" }));
 
     expect(mockUpdate).toHaveBeenCalledWith({ idsToRemove: [99], isReading: true });
   });
@@ -100,9 +100,9 @@ describe("ChooseReadingsButton", () => {
 
     renderWithMantine(<ChooseReadingsButton />);
     await userEvent.click(screen.getByRole("button", { name: "Choose readings" }));
-    await userEvent.click(screen.getByRole("button", { name: "Expand Chapter 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "Expand 1 Chapter 1" }));
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "Select Section 1" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select 1.1 Section 1" }));
 
     expect(mockUpdate).not.toHaveBeenCalled();
   });

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/components/ChooseReadingsButton.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/reading/components/ChooseReadingsButton.tsx
@@ -13,10 +13,29 @@ import { getLeafNodes } from "@/utils/exercise";
 
 import styles from "./ChooseReadingsButton.module.css";
 
+type NumberedNodeData = Partial<Exercise> & {
+  chapter_num?: number;
+  sub_chapter_num?: number;
+};
+
+const formatNumberedNodeLabel = (node: TreeNode): string => {
+  const data = node.data as NumberedNodeData | undefined;
+  const title = data?.title ?? String(node.key);
+  const numbers =
+    data?.sub_chapter_num !== null && data?.sub_chapter_num !== undefined
+      ? [data.chapter_num, data.sub_chapter_num]
+      : [data?.chapter_num ?? data?.num];
+  const prefix = numbers
+    .filter((value): value is number => value !== null && value !== undefined)
+    .join(".");
+
+  return prefix ? [prefix, title].filter(Boolean).join(" ") : title;
+};
+
 const READINGS_COLUMNS: TreeTableColumn[] = [
   {
     header: "Select readings",
-    render: (node) => <span>{(node.data as Exercise)?.title}</span>
+    render: (node) => <span>{formatNumberedNodeLabel(node)}</span>
   }
 ];
 
@@ -83,7 +102,7 @@ export const ChooseReadingsButton = () => {
             onSelect={onSelect}
             onUnselect={onUnselect}
             ariaLabel="Choose readings"
-            getNodeLabel={(node) => (node.data as Exercise)?.title ?? String(node.key)}
+            getNodeLabel={formatNumberedNodeLabel}
           />
         </div>
         <div className={styles.footer}>

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/types/exercises.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/types/exercises.ts
@@ -68,6 +68,10 @@ export type Exercise = {
   owner: string;
   tags: string;
   num: number;
+  chapter_num?: number;
+  sub_chapter_num?: number;
+  chapter_name?: string;
+  sub_chapter_name?: string;
   numQuestions: number;
   required: boolean;
   title: string;

--- a/bases/rsptx/assignment_server_api/routers/instructor.py
+++ b/bases/rsptx/assignment_server_api/routers/instructor.py
@@ -966,6 +966,10 @@ async def get_assignment_questions(
         # augment the assignment question with additional question data
         aq["name"] = q["name"]
         aq["subchapter"] = q["subchapter"]
+        aq["chapter_num"] = row.Chapter.chapter_num
+        aq["sub_chapter_num"] = row.SubChapter.sub_chapter_num
+        aq["chapter_name"] = row.Chapter.chapter_name
+        aq["sub_chapter_name"] = row.SubChapter.sub_chapter_name
         aq["chapter"] = q["chapter"]
         aq["base_course"] = q["base_course"]
         aq["htmlsrc"] = q["htmlsrc"]

--- a/components/rsptx/build_tools/core.py
+++ b/components/rsptx/build_tools/core.py
@@ -734,7 +734,7 @@ def _process_single_chapter(sess, db_context, chapter, chap_counter, course_name
         db_context["chapters"]
         .insert()
         .values(
-            chapter_name=f"{cnum} {chapter.find('./title').text}",
+            chapter_name=f"{chapter.find('./title').text}",
             course_id=course_name,
             chapter_label=chapter.find("./id").text,
             chapter_num=cnum,
@@ -808,7 +808,7 @@ def _process_single_subchapter(
         titletext = " ".join(
             [ET.tostring(y).decode("utf8") for y in subchapter.findall("./title/*")]
         )
-    titletext = f"{scnum} {titletext.strip()}"
+    titletext = f"{titletext.strip()}"
 
     # Insert subchapter
     ins = (

--- a/components/rsptx/db/crud/question.py
+++ b/components/rsptx/db/crud/question.py
@@ -823,6 +823,10 @@ async def fetch_questions_for_chapter_subchapter(
                             "num": chapters[chapter]["sub_chapters"][subchapter][
                                 "sub_chapter_num"
                             ],
+                            "chapter_num": chapters[chapter]["chapter_num"],
+                            "sub_chapter_num": chapters[chapter]["sub_chapters"][
+                                subchapter
+                            ]["sub_chapter_num"],
                             "chapter": chapter,
                             "subchapter": subchapter,
                             "id": find_page_id(chapter, subchapter),
@@ -835,7 +839,16 @@ async def fetch_questions_for_chapter_subchapter(
                             ),
                         },
                         "children": [
-                            {"key": q.name, "data": q.dict()}
+                            {
+                                "key": q.name,
+                                "data": {
+                                    **q.dict(),
+                                    "chapter_num": chapters[chapter]["chapter_num"],
+                                    "sub_chapter_num": chapters[chapter][
+                                        "sub_chapters"
+                                    ][subchapter]["sub_chapter_num"],
+                                },
+                            }
                             for q in questions[chapter][subchapter]
                         ],
                     }
@@ -846,6 +859,7 @@ async def fetch_questions_for_chapter_subchapter(
                     "data": {
                         "title": chapters[chapter]["chapter_name"],
                         "num": chapters[chapter]["chapter_num"],
+                        "chapter_num": chapters[chapter]["chapter_num"],
                     },
                     "children": subs,
                 }


### PR DESCRIPTION
Halts the inclusion of chapter/subchapter numbers into their titles.

Update the assignment builder to show explicit numbers.

(student facing doAssignment page was already updated to use explicit numbers)