### PR TITLE
patch to avoid blocking initial dev setup when overview can't be built

### DIFF
--- a/bases/rsptx/book_server_api/routers/course.py
+++ b/bases/rsptx/book_server_api/routers/course.py
@@ -171,7 +171,7 @@ async def index(request: Request, user=Depends(auth_manager)):
             "student_page": True,
             "course_list": course_list,
             "is_instructor": "true" if user_is_instructor else "false",
-            "has_discussion_group": book.social_url,
+            "has_discussion_group": book.social_url if book else None,
             "lti1p1": is_lti1p1_course,
             "now": now,
             "visibility_map": visibility_map,


### PR DESCRIPTION
While it would probably be better to fix the underlying issue, that the database starts with testuser1 as enrolled in the "overview" book which can no longer easily be built, but this would move around that at least for now.  Plus would be safe in the future.