### PR TITLE
Assignment import: any shared course

### DIFF
--- a/bases/rsptx/admin_server_api/routers/instructor.py
+++ b/bases/rsptx/admin_server_api/routers/instructor.py
@@ -16,15 +16,14 @@ from pydantic import BaseModel
 import csv
 import re
 from io import StringIO
-from typing import Optional
-from zoneinfo import ZoneInfo
 
 # Local application imports
 # -------------------------
 
 from rsptx.db.crud import (
-    create_assignment_question,
+    term_start_utc,
     create_assignment,
+    create_assignment_question,
     create_course_instructor,
     create_course,
     course_attr_is_true,
@@ -39,16 +38,13 @@ from rsptx.db.crud import (
     delete_lti_course,
     delete_user_course_entry,
     fetch_all_course_attributes,
-    fetch_lti1p1_config,
     fetch_assignment_questions,
-    fetch_assignments,
+    fetch_lti1p1_config,
     fetch_available_students_for_instructor_add,
     fetch_base_course,
-    fetch_course_by_id,
     fetch_course,
     fetch_courses_for_user,
     fetch_group,
-    fetch_instructor_courses,
     fetch_library_book,
     fetch_library_books,
     fetch_membership,
@@ -56,7 +52,11 @@ from rsptx.db.crud import (
     fetch_question,
     fetch_timed_assessments,
     fetch_users_for_course,
+    import_assignment,
+    import_course_assignments,
     reset_student_assessment,
+    search_assignments,
+    search_shareable_courses,
     update_course_settings,
     update_question,
     update_user,
@@ -65,18 +65,20 @@ from rsptx.auth.session import auth_manager
 from rsptx.auth.email import send_welcome_email
 from rsptx.templates import get_shared_templates
 from rsptx.validation.fields import clean_text, validate_text_field
+from rsptx.validation.schemas import AssignmentsSearchRequest
 from rsptx.configuration import settings
 from rsptx.endpoint_validators import with_course, instructor_role_required
 from rsptx.logging import rslogger
 from rsptx.db.crud.user import create_user, fetch_user
 from rsptx.db.models import (
-    AuthUserValidator,
-    AssignmentValidator,
     AssignmentQuestionValidator,
+    AssignmentValidator,
+    AuthUserValidator,
     CoursesValidator,
 )
 from rsptx.response_helpers.core import canonical_utcnow, make_json_response
 import datetime
+from typing import Optional
 
 # Routing
 # =======
@@ -170,6 +172,13 @@ async def get_manage_students(
     return templates.TemplateResponse("admin/instructor/manage_students.html", context)
 
 
+# A course with more assignments than this gets its list truncated rather than
+# paginated: picking one out of a list this long is not what the page is for,
+# and "copy all" does not care how many there are. Capped at the search
+# request's own ``limit`` ceiling, which rejects anything larger.
+MAX_SOURCE_ASSIGNMENTS = 100
+
+
 @router.get("/copy_assignments")
 @instructor_role_required()
 @with_course()
@@ -181,34 +190,69 @@ async def get_copy_assignments(
 ):
     """
     Display the copy assignments interface.
+
+    The source course is chosen through ``/shareable_courses`` rather than a
+    dropdown rendered here: the page can now copy from any course that shares
+    something, which is far too many to put in a ``<select>``. What is still
+    rendered server-side is the book's own course, so the official assignments
+    for this book are the first thing on screen instead of a search away.
     """
     templates = get_shared_templates()
 
-    # Get instructor's available courses for copying from
-    instructor_course_relationships = await fetch_instructor_courses(user.id)
-    instructor_course_list = []
-
     base_course = await fetch_base_course(course.base_course)
-    instructor_course_list.append(base_course)
-    # For each course where the user is an instructor, get the full course information
-    for course_relation in instructor_course_relationships:
-        temp_course = await fetch_course_by_id(course_relation.course)
-        # Make sure the course exists and has the same base course
-        if temp_course and temp_course.base_course == base_course.course_name:
-            instructor_course_list.append(temp_course)
 
-    instructor_course_list.sort(key=lambda x: x.course_name)
     context = {
         "course": course,
         "user": user,
         "request": request,
         "is_instructor": True,
         "student_page": False,
-        "instructor_course_list": instructor_course_list,
+        "base_course": base_course,
         "settings": settings,
     }
 
     return templates.TemplateResponse("admin/instructor/copy_assignments.html", context)
+
+
+@router.get("/shareable_courses")
+@instructor_role_required()
+@with_course()
+async def get_shareable_courses(
+    request: Request,
+    search: str = "",
+    only_my_courses: bool = False,
+    use_base_course: bool = False,
+    page: int = 0,
+    limit: int = 20,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    Courses holding assignments this instructor may copy.
+
+    Backs the source-course picker on the Copy Assignments page. Shares one
+    implementation with the assignment server's endpoint of the same name, so
+    the two surfaces cannot drift on what counts as shareable.
+    """
+    try:
+        result = await search_shareable_courses(
+            user_id=user.id,
+            search=search,
+            base_course=course.base_course if use_base_course else None,
+            prefer_base_course=course.base_course,
+            only_my_courses=only_my_courses,
+            exclude_course_id=course.id,
+            page=page,
+            limit=min(max(limit, 1), 100),
+        )
+    except Exception as e:
+        rslogger.error(f"Error listing shareable courses: {e}")
+        return JSONResponse(
+            status_code=500,
+            content={"message": "Could not load courses"},
+        )
+
+    return JSONResponse(content=result)
 
 
 @router.get("/source_assignments")
@@ -223,9 +267,14 @@ async def get_source_assignments(
     """
     List the assignments for a course the instructor may copy from.
 
-    Used by the Copy Assignments page to populate the assignment dropdown once the
-    instructor picks a source course. Verifies the instructor is associated with the
-    source course (base courses are allowed) before returning its assignments.
+    Used by the Copy Assignments page once a source course is picked. Runs the
+    same visibility rules as the assignment browser rather than its own, so a
+    course cannot expose more through this page than through that one: an
+    assignment shows up when its owner shared it, when it belongs to a book, or
+    when the caller already instructs the course.
+
+    Each row says whether it is already in the caller's course, so bulk copying
+    can report what it will pass over before the instructor commits to it.
     """
     source_course = await fetch_course(course_name)
     if not source_course:
@@ -234,23 +283,47 @@ async def get_source_assignments(
             content={"message": "Source course not found"},
         )
 
-    # Allow copying from a base course; otherwise require instructor access.
-    copy_base_course = source_course.course_name == source_course.base_course
-    if not copy_base_course:
-        instructor_courses = await fetch_instructor_courses(user.id)
-        has_access = any(ic.course == source_course.id for ic in instructor_courses)
-        if not has_access:
-            return JSONResponse(
-                status_code=403,
-                content={"message": "Not authorized to view this course"},
-            )
+    if source_course.id == course.id:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "That is the course you are copying into"},
+        )
 
-    assignments = await fetch_assignments(course_name, fetch_all=True)
-    res = sorted(
-        ({"id": a.id, "name": a.name} for a in assignments),
-        key=lambda a: a["name"],
+    criteria = AssignmentsSearchRequest(
+        page=0,
+        limit=MAX_SOURCE_ASSIGNMENTS,
+        sorting={"field": "name", "order": 1},
+        filters={"course_name": {"value": course_name, "matchMode": "equals"}},
     )
-    return JSONResponse(content={"assignments": res})
+    result = await search_assignments(
+        criteria,
+        user_id=user.id,
+        exclude_course_id=course.id,
+        target_course_id=course.id,
+    )
+
+    # The book build regenerates these from the book's own markup, so a copy
+    # starts drifting the moment the book does. Bulk import leaves them out for
+    # the same reason; listing them here would offer something it will not take.
+    assignments = [
+        {
+            "id": a["id"],
+            "name": a["name"],
+            "question_count": a["question_count"],
+            "is_official": a["is_official"],
+            "already_imported": a["already_imported"],
+            "imported_as": a["imported_as"],
+        }
+        for a in result["assignments"]
+    ]
+
+    return JSONResponse(
+        content={
+            "assignments": assignments,
+            "is_official": source_course.course_name == source_course.base_course,
+            "truncated": result["pagination"]["total"] > len(assignments),
+        }
+    )
 
 
 # TA Management endpoints
@@ -437,6 +510,8 @@ async def get_course_settings(
         "use_pretext_student_pages": str(
             course_attr_is_true(course_attrs, "use_pretext_student_pages", default=True)
         ).lower(),
+        "sharing_description": course_attrs.get("sharing_description", ""),
+        "share_assignments": course_attrs.get("share_assignments", "false"),
     }
 
     return templates.TemplateResponse("admin/instructor/course_settings.html", context)
@@ -1086,8 +1161,10 @@ async def enroll_students(
 
 # Assignment Copy Models
 class CopyAssignmentRequest(BaseModel):
-    course: str
-    oldassignment: str  # assignment id or "-1" for all assignments
+    source_course_id: int
+    # None copies everything importable from the source course, which is what
+    # this page is mostly used for.
+    assignment_id: Optional[int] = None
 
 
 @router.post("/copy_assignment")
@@ -1100,76 +1177,72 @@ async def copy_assignment(
     course=None,
 ):
     """
-    Copy assignment(s) from another course to the current course.
-    Can copy a single assignment or all assignments from the source course.
+    Copy one assignment, or a whole course's worth, into the caller's course.
+
+    Delegates to the same ``import_assignment`` the assignment browser uses
+    rather than copying rows here. That is what lets this page copy from any
+    course that shares something instead of only the instructor's own, and it
+    picks up name de-duplication, cross-book reading handling and the record of
+    where each copy came from -- none of which the old local copy had.
     """
     try:
-        # Check if the source course is a base course
-        rslogger.debug(f"Copying assignments from course: {copy_data.course}")
-        source_course = await fetch_course(copy_data.course)
-        if not source_course:
+        if copy_data.assignment_id is not None:
+            result = await import_assignment(
+                source_assignment_id=copy_data.assignment_id,
+                target_course=course,
+                importing_user=user,
+            )
             return JSONResponse(
-                status_code=404,
-                content={"success": False, "message": "Source course not found"},
+                content={
+                    "success": True,
+                    "message": f'Copied as "{result.name}". It is hidden until you '
+                    f"make it visible.",
+                    "imported": [result.name],
+                    "skipped_existing": [],
+                    "skipped_readings": result.skipped_readings,
+                    "failed": [],
+                }
             )
 
-        copy_base_course = source_course.course_name == source_course.base_course
+        bulk = await import_course_assignments(
+            source_course_id=copy_data.source_course_id,
+            target_course=course,
+            importing_user=user,
+        )
 
-        # Verify instructor has access to source course (unless it's a base course)
-        if not copy_base_course:
-            instructor_courses = await fetch_instructor_courses(user.id)
-            has_access = any(ic.course == source_course.id for ic in instructor_courses)
-            if not has_access:
-                return JSONResponse(
-                    status_code=403,
-                    content={
-                        "success": False,
-                        "message": "Not authorized to copy from this course",
-                    },
-                )
-
-        res = None
-        if copy_data.oldassignment == "-1":
-            # Copy all assignments
-            assignments = await fetch_assignments(copy_data.course, fetch_all=True)
-            source_assignments = [a for a in assignments if not a.from_source]
-
-            if not source_assignments:
-                return JSONResponse(
-                    status_code=404,
-                    content={"success": False, "message": "No assignments to copy"},
-                )
-
-            for assignment in source_assignments:
-                res = await _copy_one_assignment(
-                    copy_data.course, assignment.id, course
-                )
-                if res != "success":
-                    break
-        else:
-            # Copy single assignment
-            res = await _copy_one_assignment(
-                copy_data.course, int(copy_data.oldassignment), course
-            )
-
-        if res is None:
+        if not bulk.imported and not bulk.skipped_existing and not bulk.failed:
             return JSONResponse(
                 status_code=404,
                 content={"success": False, "message": "No assignments to copy"},
             )
-        elif res == "success":
-            return JSONResponse(
-                content={
-                    "success": True,
-                    "message": "Assignment(s) copied successfully",
-                },
-            )
-        else:
-            return JSONResponse(
-                status_code=500,
-                content={"success": False, "message": f"Copy failed: {res}"},
-            )
 
+        parts = [f"Copied {len(bulk.imported)}"]
+        if bulk.skipped_existing:
+            parts.append(f"{len(bulk.skipped_existing)} already in your course")
+        if bulk.failed:
+            parts.append(f"{len(bulk.failed)} could not be copied")
+        if bulk.skipped_readings:
+            parts.append(f"{bulk.skipped_readings} readings left behind")
+
+        return JSONResponse(
+            content={
+                "success": True,
+                "message": ", ".join(parts)
+                + ". Copies are hidden until you make them visible.",
+                "imported": bulk.imported,
+                "skipped_existing": bulk.skipped_existing,
+                "skipped_readings": bulk.skipped_readings,
+                "failed": bulk.failed,
+            }
+        )
+
+    except HTTPException as e:
+        # import_assignment answers 404 for anything the caller may not see, so
+        # a private foreign assignment does not confirm it exists.
+        return JSONResponse(
+            status_code=e.status_code,
+            content={"success": False, "message": str(e.detail)},
+        )
     except Exception as e:
         rslogger.error(f"Error copying assignment: {e}")
         return JSONResponse(
@@ -1178,22 +1251,10 @@ async def copy_assignment(
         )
 
 
-def _term_start_utc(term_start_date, timezone: Optional[str]) -> datetime.datetime:
-    """Midnight local time on the first day of term, expressed as naive UTC.
-
-    ``term_start_date`` is a bare date, so on its own it has no timezone. Due
-    dates are stored as naive UTC, so the term start has to be anchored in the
-    course timezone before the two can be subtracted -- otherwise the offset
-    from the start of term is wrong by the course's UTC offset. A course with
-    no timezone is treated as UTC, matching the ``duedate`` migration.
-    """
-    midnight = datetime.datetime.combine(term_start_date, datetime.time())
-    tz = ZoneInfo(timezone) if timezone else datetime.timezone.utc
-    return (
-        midnight.replace(tzinfo=tz)
-        .astimezone(datetime.timezone.utc)
-        .replace(tzinfo=None)
-    )
+# The due-date arithmetic now lives beside the assignment CRUD so this page and
+# the cross-course import share one implementation. Kept under the original
+# private name because this module and its tests already refer to it that way.
+_term_start_utc = term_start_utc
 
 
 def _shift_between_terms(

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/AssignmentBuilder.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/AssignmentBuilder.tsx
@@ -16,7 +16,7 @@ import {
 } from "@store/dataset/dataset.logic.api";
 import { useGetAvailableReadingsQuery } from "@store/readings/readings.logic.api";
 import sortBy from "lodash/sortBy";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
 import { useSelectedAssignment } from "@/hooks/useSelectedAssignment";
@@ -25,6 +25,7 @@ import { Assignment, CreateAssignmentPayload } from "@/types/assignment";
 import { saveEnforceDue, saveVisibility } from "./assignmentMutationHandlers";
 import { ErrorState } from "./components/ErrorState/ErrorState";
 import { AssignmentEdit } from "./components/edit/AssignmentEdit";
+import { ImportAssignmentModal } from "./components/importAssignment/ImportAssignmentModal";
 import { AssignmentList } from "./components/list/AssignmentList";
 import { AssignmentWizard } from "./components/wizard/AssignmentWizard";
 import { defaultAssignment } from "./defaultAssignment";
@@ -37,6 +38,7 @@ import styles from "./AssignmentBuilder.module.css";
 
 export const AssignmentBuilder = () => {
   const dispatch = useDispatch();
+  const [importModalVisible, setImportModalVisible] = useState(false);
   const { isLoading, isError, data: assignments = [] } = useGetAssignmentsQuery();
   const [createAssignment, { isLoading: isCreating }] = useCreateAssignmentMutation();
   const [updateAssignment] = useUpdateAssignmentMutation();
@@ -193,10 +195,15 @@ export const AssignmentBuilder = () => {
           onEdit={handleEdit}
           onDuplicate={handleDuplicate}
           onEnforceDueChange={handleEnforceDueChange}
+          onImport={() => setImportModalVisible(true)}
           onVisibilityChange={handleVisibilityChange}
           onRemove={onRemove}
         />
       )}
+      <ImportAssignmentModal
+        visible={importModalVisible}
+        onHide={() => setImportModalVisible(false)}
+      />
       {mode === "create" && (
         <AssignmentWizard
           control={control}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/assignmentMutationHandlers.spec.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/assignmentMutationHandlers.spec.ts
@@ -141,3 +141,4 @@ describe("getVisibilityToastCopy", () => {
     ).toBe("Assignment visibility is scheduled");
   });
 });
+

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportAssignmentModal.module.css
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportAssignmentModal.module.css
@@ -1,0 +1,45 @@
+.search {
+  flex: 1;
+  min-width: 16rem;
+}
+
+.nameButton {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-weight: var(--rs-font-weight-medium);
+  color: var(--rs-text-strong);
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--rs-transition-fast);
+}
+
+.nameButton:hover {
+  color: var(--rs-brand-600);
+}
+
+.questionList {
+  max-height: 22rem;
+  overflow-y: auto;
+  border: 1px solid var(--mantine-color-default-border);
+  border-radius: var(--mantine-radius-sm);
+}
+
+.questionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.questionRow + .questionRow {
+  border-top: 1px solid var(--mantine-color-default-border);
+}
+
+/* A reading that stays behind on a cross-book import. Struck through rather
+   than hidden: the row is what tells the instructor it is being left out. */
+.skippedName {
+  text-decoration: line-through;
+}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportAssignmentModal.spec.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportAssignmentModal.spec.tsx
@@ -1,0 +1,326 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithMantine, screen, waitFor } from "@/test/renderWithMantine";
+import { ShareableTreeCourse } from "@/types/assignmentSharing";
+
+import {
+  ImportAssignmentModal,
+  buildSelectionKeys,
+  buildTree
+} from "./ImportAssignmentModal";
+
+const {
+  treeHolder,
+  previewHolder,
+  importMock,
+  importCourseMock,
+  treeSkipSpy,
+  treeParamsSpy
+} = vi.hoisted(
+  () => ({
+    treeHolder: {
+      value: {
+        courses: [
+          {
+            id: 7,
+            course_name: "cs101-fall",
+            institution: "State University",
+            base_course: "thinkcspy",
+            book_title: "How to Think Like a Computer Scientist",
+            shareable_count: 2,
+            is_official: false,
+            is_mine: false,
+            assignments: [
+              {
+                id: 1,
+                name: "Loops Homework",
+                description: "Week 3",
+                points: 40,
+                kind: "Regular",
+                question_count: 10,
+                is_official: false,
+                already_imported: false,
+                imported_as: null
+              },
+              {
+                id: 2,
+                name: "Recursion Set",
+                description: null,
+                points: 20,
+                kind: "Regular",
+                question_count: 4,
+                is_official: false,
+                already_imported: false,
+                imported_as: null
+              }
+            ]
+          },
+          {
+            id: 8,
+            course_name: "thinkcspy",
+            institution: null,
+            base_course: "thinkcspy",
+            book_title: "How to Think Like a Computer Scientist",
+            shareable_count: 1,
+            is_official: true,
+            is_mine: false,
+            assignments: [
+              {
+                id: 3,
+                name: "Chapter 1 Exercises",
+                description: null,
+                points: 10,
+                kind: "Regular",
+                question_count: 5,
+                is_official: true,
+                already_imported: true,
+                imported_as: "Chapter 1 Exercises"
+              }
+            ]
+          }
+        ] as ShareableTreeCourse[],
+        pagination: { total: 2, page: 0, limit: 25, pages: 1 }
+      }
+    },
+    previewHolder: {
+      value: {
+        id: 1,
+        name: "Loops Homework",
+        description: "Week 3",
+        points: 40,
+        kind: "Regular",
+        duedate: "2099-01-01T00:00:00",
+        question_count: 2,
+        course_name: "cs101-fall",
+        base_course: "thinkcspy",
+        book_title: "How to Think Like a Computer Scientist",
+        institution: "State University",
+        is_official: false,
+        sharing_description: "",
+        is_cross_book: false,
+        already_imported: false,
+        imported_as: null,
+        skipped_readings: 0,
+        questions: [
+          {
+            id: 11,
+            name: "q_loop_1",
+            question_type: "mchoice",
+            points: 5,
+            chapter: "ch1",
+            subchapter: "sub1",
+            reading_assignment: false,
+            will_import: true
+          }
+        ]
+      }
+    },
+    importMock: vi.fn(),
+    importCourseMock: vi.fn(),
+    treeSkipSpy: vi.fn(),
+    treeParamsSpy: vi.fn()
+  })
+);
+
+vi.mock("@store/assignment/assignment.logic.api", () => ({
+  useShareableTreeQuery: (params: unknown, options: { skip: boolean }) => {
+    treeSkipSpy(options.skip);
+    treeParamsSpy(params);
+    return { data: treeHolder.value, isFetching: false };
+  },
+  useImportAssignmentMutation: () => [importMock, { isLoading: false }],
+  useImportCourseAssignmentsMutation: () => [importCourseMock, { isLoading: false }],
+  usePreviewSharedAssignmentQuery: () => ({
+    data: previewHolder.value,
+    isFetching: false
+  })
+}));
+
+const onHide = vi.fn();
+
+const resolved = (value: unknown) => ({ unwrap: () => Promise.resolve(value) });
+
+describe("buildTree", () => {
+  it("namespaces keys so a course and an assignment can share an id", () => {
+    // Course 7 and assignment 1 would collide on a bare id, and TreeTable keys
+    // its whole selection map by node key.
+    const tree = buildTree(treeHolder.value.courses);
+
+    expect(tree[0].key).toBe("course:7");
+    expect(tree[0].children?.[0].key).toBe("assignment:1");
+  });
+});
+
+describe("buildSelectionKeys", () => {
+  const courses = () => treeHolder.value.courses;
+
+  it("marks a course checked only when all of its assignments are", () => {
+    const keys = buildSelectionKeys(courses(), new Set([1, 2]));
+
+    expect(keys["course:7"]).toEqual({ checked: true, partialChecked: false });
+  });
+
+  it("marks a course partially checked when only some are", () => {
+    const keys = buildSelectionKeys(courses(), new Set([1]));
+
+    expect(keys["course:7"]).toEqual({ checked: false, partialChecked: true });
+    expect(keys["assignment:1"].checked).toBe(true);
+    expect(keys["assignment:2"].checked).toBe(false);
+  });
+
+  it("leaves a course unchecked when nothing under it is selected", () => {
+    const keys = buildSelectionKeys(courses(), new Set());
+
+    expect(keys["course:7"]).toEqual({ checked: false, partialChecked: false });
+  });
+});
+
+describe("ImportAssignmentModal", () => {
+  beforeEach(() => {
+    onHide.mockReset();
+    importMock.mockReset();
+    importCourseMock.mockReset();
+    importMock.mockReturnValue(resolved({ detail: { id: 5, name: "Loops Homework" } }));
+    importCourseMock.mockReturnValue(resolved({ detail: { imported: ["a"] } }));
+    treeSkipSpy.mockReset();
+    treeParamsSpy.mockReset();
+  });
+
+  it("lists the courses that have assignments to offer", () => {
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+
+    expect(screen.getByText("cs101-fall")).toBeInTheDocument();
+    expect(screen.getByText("thinkcspy")).toBeInTheDocument();
+    expect(screen.getByText("2 assignments")).toBeInTheDocument();
+  });
+
+  it("keeps a course's assignments collapsed until it is expanded", async () => {
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+
+    expect(screen.queryByText("Loops Homework")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand cs101-fall" }));
+
+    expect(screen.getByText("Loops Homework")).toBeInTheDocument();
+    expect(screen.getByText("Recursion Set")).toBeInTheDocument();
+  });
+
+  it("narrows the list to the caller's own book", async () => {
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByLabelText("Only for this book"));
+
+    expect(treeParamsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ use_base_course: true, only_my_courses: false })
+    );
+  });
+
+  it("narrows the list to courses the instructor teaches", async () => {
+    // Independent of the book filter, so the two apply together.
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByLabelText("Only courses I teach"));
+
+    expect(treeParamsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ use_base_course: false, only_my_courses: true })
+    );
+  });
+
+  it("marks the book's own course as official", () => {
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+
+    expect(screen.getByText("Official")).toBeInTheDocument();
+  });
+
+  it("does not load the tree until the modal is opened", () => {
+    // The modal stays mounted so it can animate, so a naive implementation
+    // would query every course on the platform on every render.
+    renderWithMantine(<ImportAssignmentModal visible={false} onHide={onHide} />);
+
+    expect(treeSkipSpy).toHaveBeenCalledWith(true);
+  });
+
+  it("imports a whole course through the bulk endpoint when it is checked", async () => {
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByRole("checkbox", { name: "Select cs101-fall" }));
+
+    expect(
+      screen.getByRole("button", { name: "Import 2 assignments" })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Import 2 assignments" }));
+
+    // One request rather than two, so anything added to that course since the
+    // tree loaded comes across too.
+    expect(importCourseMock).toHaveBeenCalledWith(7);
+    expect(importMock).not.toHaveBeenCalled();
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it("imports one at a time when only part of a course is checked", async () => {
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByRole("button", { name: "Expand cs101-fall" }));
+    await user.click(screen.getByRole("checkbox", { name: "Select Loops Homework" }));
+    await user.click(screen.getByRole("button", { name: "Import 1 assignment" }));
+
+    expect(importMock).toHaveBeenCalledWith(1);
+    expect(importCourseMock).not.toHaveBeenCalled();
+  });
+
+  it("does not select an assignment already in this course", async () => {
+    // Selecting one would promise something the import then skips, so the count
+    // on the button would contradict what happens.
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByRole("checkbox", { name: "Select thinkcspy" }));
+
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
+  it("marks an assignment already in this course", async () => {
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByRole("button", { name: "Expand thinkcspy" }));
+
+    expect(screen.getByText("Imported")).toBeInTheDocument();
+  });
+
+  it("disables import until something is selected", () => {
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
+  it("stays open when an import fails", async () => {
+    const user = userEvent.setup();
+
+    importCourseMock.mockReturnValue({ unwrap: () => Promise.reject(new Error("nope")) });
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByRole("checkbox", { name: "Select cs101-fall" }));
+    await user.click(screen.getByRole("button", { name: "Import 2 assignments" }));
+
+    await waitFor(() => expect(importCourseMock).toHaveBeenCalled());
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("opens the question list from an assignment's preview button", async () => {
+    const user = userEvent.setup();
+
+    renderWithMantine(<ImportAssignmentModal visible onHide={onHide} />);
+    await user.click(screen.getByRole("button", { name: "Expand cs101-fall" }));
+    await user.click(screen.getAllByRole("button", { name: "Preview" })[0]);
+
+    expect(await screen.findByText("q_loop_1")).toBeInTheDocument();
+  });
+});

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportAssignmentModal.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportAssignmentModal.tsx
@@ -1,0 +1,445 @@
+import { SearchInput } from "@components/ui/SearchInput";
+import { TreeTable, TreeTableColumn } from "@components/ui/TreeTable";
+import { Badge, Button, Group, Modal, Stack, Switch, Text, Tooltip } from "@mantine/core";
+import {
+  useImportAssignmentMutation,
+  useImportCourseAssignmentsMutation,
+  useShareableTreeQuery
+} from "@store/assignment/assignment.logic.api";
+import debounce from "lodash/debounce";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  ShareableTreeAssignment,
+  ShareableTreeCourse
+} from "@/types/assignmentSharing";
+import { SelectedKey, TreeNode } from "@/types/treeNode";
+
+import { ImportPreviewPanel } from "./ImportPreviewPanel";
+
+import styles from "./ImportAssignmentModal.module.css";
+
+const SEARCH_DEBOUNCE_MS = 300;
+const PAGE_SIZE = 25;
+
+interface ImportAssignmentModalProps {
+  visible: boolean;
+  onHide: () => void;
+}
+
+/** Node keys are namespaced so a course and an assignment can share an id. */
+const courseKey = (course: ShareableTreeCourse) => `course:${course.id}`;
+const assignmentKey = (assignment: ShareableTreeAssignment) => `assignment:${assignment.id}`;
+
+export const buildTree = (courses: ShareableTreeCourse[]): TreeNode[] =>
+  courses.map((course) => ({
+    key: courseKey(course),
+    label: course.course_name,
+    data: course,
+    children: course.assignments.map((assignment) => ({
+      key: assignmentKey(assignment),
+      label: assignment.name,
+      data: assignment
+    }))
+  }));
+
+/**
+ * Roll a set of checked assignment ids up into TreeTable's selection map.
+ *
+ * A course is checked when every assignment under it is, and partially checked
+ * when only some are -- the same contract `getSelectedKeys` provides for the
+ * exercise picker, which is what makes the two trees behave alike.
+ */
+export const buildSelectionKeys = (
+  courses: ShareableTreeCourse[],
+  selectedIds: Set<number>
+): Record<string, SelectedKey> => {
+  const keys: Record<string, SelectedKey> = {};
+
+  for (const course of courses) {
+    let checkedCount = 0;
+
+    for (const assignment of course.assignments) {
+      const checked = selectedIds.has(assignment.id);
+
+      keys[assignmentKey(assignment)] = { checked, partialChecked: false };
+      if (checked) {
+        checkedCount += 1;
+      }
+    }
+
+    const total = course.assignments.length;
+
+    keys[courseKey(course)] = {
+      checked: total > 0 && checkedCount === total,
+      partialChecked: checkedCount > 0 && checkedCount < total
+    };
+  }
+  return keys;
+};
+
+const isCourseNode = (node: TreeNode) => String(node.key).startsWith("course:");
+
+const assignmentsUnder = (node: TreeNode): ShareableTreeAssignment[] =>
+  isCourseNode(node)
+    ? (node.data as ShareableTreeCourse).assignments
+    : [node.data as ShareableTreeAssignment];
+
+/**
+ * Browse and import assignments other courses share.
+ *
+ * A tree of courses rather than a flat list of assignments: the question an
+ * instructor arrives with is "what does that course use", and taking a whole
+ * course at once is the common case. Checking a course takes all of it;
+ * expanding one lets you take part. The shape deliberately matches the exercise
+ * picker, down to the shared TreeTable.
+ */
+export const ImportAssignmentModal = ({ visible, onHide }: ImportAssignmentModalProps) => {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [useBaseCourse, setUseBaseCourse] = useState(false);
+  const [onlyMyCourses, setOnlyMyCourses] = useState(false);
+  const [page, setPage] = useState(0);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [previewId, setPreviewId] = useState<number | null>(null);
+
+  const { data, isFetching } = useShareableTreeQuery(
+    {
+      search: debouncedSearch,
+      use_base_course: useBaseCourse,
+      only_my_courses: onlyMyCourses,
+      page,
+      limit: PAGE_SIZE
+    },
+    // The modal stays mounted so it can animate; don't search until it opens.
+    { skip: !visible }
+  );
+
+  const [importAssignment, { isLoading: isImportingOne }] = useImportAssignmentMutation();
+  const [importCourse, { isLoading: isImportingCourse }] = useImportCourseAssignmentsMutation();
+
+  const courses = useMemo(() => data?.courses ?? [], [data]);
+  const tree = useMemo(() => buildTree(courses), [courses]);
+  const selectionKeys = useMemo(
+    () => buildSelectionKeys(courses, selectedIds),
+    [courses, selectedIds]
+  );
+
+  const debouncedSetSearch = useRef(
+    debounce((value: string) => {
+      setDebouncedSearch(value);
+      setPage(0);
+    }, SEARCH_DEBOUNCE_MS)
+  ).current;
+
+  useEffect(() => () => debouncedSetSearch.cancel(), [debouncedSetSearch]);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearch(value);
+      debouncedSetSearch(value);
+    },
+    [debouncedSetSearch]
+  );
+
+  const handleClose = useCallback(() => {
+    setSelectedIds(new Set());
+    setPreviewId(null);
+    onHide();
+  }, [onHide]);
+
+  // Only ever selects what can actually be taken. An assignment already in the
+  // course would be skipped by the import anyway, so checking it would promise
+  // something the count then contradicts.
+  const selectableUnder = useCallback(
+    (node: TreeNode) => assignmentsUnder(node).filter((a) => !a.already_imported),
+    []
+  );
+
+  const handleSelect = useCallback(
+    (node: TreeNode) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+
+        for (const assignment of selectableUnder(node)) {
+          next.add(assignment.id);
+        }
+        return next;
+      });
+    },
+    [selectableUnder]
+  );
+
+  const handleUnselect = useCallback(
+    (node: TreeNode) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+
+        for (const assignment of assignmentsUnder(node)) {
+          next.delete(assignment.id);
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  /**
+   * Import the selection, one course at a time where a whole course is checked.
+   *
+   * A fully checked course goes through the bulk endpoint rather than N single
+   * imports: it is one request, and it picks up anything added to that course
+   * since the tree was loaded.
+   */
+  const handleImport = useCallback(async () => {
+    const wholeCourses = courses.filter(
+      (course) =>
+        course.assignments.length > 0 &&
+        course.assignments.every(
+          (a) => a.already_imported || selectedIds.has(a.id)
+        ) &&
+        course.assignments.some((a) => selectedIds.has(a.id))
+    );
+    const wholeCourseIds = new Set(wholeCourses.map((c) => c.id));
+    const individual = courses
+      .filter((course) => !wholeCourseIds.has(course.id))
+      .flatMap((course) => course.assignments)
+      .filter((a) => selectedIds.has(a.id));
+
+    let failed = false;
+
+    for (const course of wholeCourses) {
+      const result = await importCourse(course.id)
+        .unwrap()
+        .catch(() => null);
+
+      failed = failed || !result;
+    }
+    for (const assignment of individual) {
+      const result = await importAssignment(assignment.id)
+        .unwrap()
+        .catch(() => null);
+
+      failed = failed || !result;
+    }
+
+    if (!failed) {
+      handleClose();
+    } else {
+      // Something landed even if something else did not, so drop the selection
+      // rather than inviting a retry that would duplicate the successful half.
+      setSelectedIds(new Set());
+    }
+  }, [courses, selectedIds, importCourse, importAssignment, handleClose]);
+
+  const columns = useMemo<TreeTableColumn[]>(
+    () => [
+      {
+        header: "Course / assignment",
+        render: (node) => {
+          if (isCourseNode(node)) {
+            const course = node.data as ShareableTreeCourse;
+
+            return (
+              <Group gap="xs" wrap="nowrap">
+                <Text size="sm" fw={500}>
+                  {course.course_name}
+                </Text>
+                {course.is_official ? (
+                  <Tooltip label={`Comes with ${course.book_title}`} position="top">
+                    <Badge size="sm" variant="filled">
+                      Official
+                    </Badge>
+                  </Tooltip>
+                ) : null}
+                {course.is_mine ? (
+                  <Badge size="sm" variant="light" color="gray">
+                    Yours
+                  </Badge>
+                ) : null}
+              </Group>
+            );
+          }
+
+          const assignment = node.data as ShareableTreeAssignment;
+
+          return (
+            <Group gap="xs" wrap="nowrap">
+              <Text size="sm" c={assignment.already_imported ? "dimmed" : undefined}>
+                {assignment.name}
+              </Text>
+              {assignment.already_imported ? (
+                <Tooltip
+                  label={
+                    assignment.imported_as
+                      ? `Already in this course as “${assignment.imported_as}”`
+                      : "Already in this course"
+                  }
+                  position="top"
+                >
+                  <Badge size="sm" variant="light" color="green">
+                    Imported
+                  </Badge>
+                </Tooltip>
+              ) : null}
+            </Group>
+          );
+        }
+      },
+      {
+        header: "Book",
+        width: "18rem",
+        render: (node) =>
+          isCourseNode(node) ? (
+            <Stack gap={0}>
+              <Text size="xs" c="dimmed">
+                {(node.data as ShareableTreeCourse).book_title}
+              </Text>
+              {(node.data as ShareableTreeCourse).institution ? (
+                <Text size="xs" c="dimmed">
+                  {(node.data as ShareableTreeCourse).institution}
+                </Text>
+              ) : null}
+            </Stack>
+          ) : null
+      },
+      {
+        header: "Questions",
+        width: "7rem",
+        render: (node) => (
+          <Text size="xs" c="dimmed">
+            {isCourseNode(node)
+              ? `${(node.data as ShareableTreeCourse).shareable_count} assignment${
+                  (node.data as ShareableTreeCourse).shareable_count === 1 ? "" : "s"
+                }`
+              : `${(node.data as ShareableTreeAssignment).question_count} question${
+                  (node.data as ShareableTreeAssignment).question_count === 1 ? "" : "s"
+                }`}
+          </Text>
+        )
+      },
+      {
+        header: "",
+        width: "6rem",
+        // A real button so the question list stays reachable from the keyboard;
+        // the row itself has no click handler in this tree.
+        render: (node) =>
+          isCourseNode(node) ? null : (
+            <button
+              type="button"
+              className={styles.nameButton}
+              onClick={() => setPreviewId((node.data as ShareableTreeAssignment).id)}
+            >
+              Preview
+            </button>
+          )
+      }
+    ],
+    []
+  );
+
+  const selectedCount = selectedIds.size;
+  const isImporting = isImportingOne || isImportingCourse;
+  const totalPages = data?.pagination.pages ?? 0;
+
+  return (
+    <Modal
+      opened={visible}
+      onClose={handleClose}
+      title="Import assignments"
+      size="72rem"
+    >
+      <Stack gap="md">
+        <Group justify="space-between" align="center">
+          <SearchInput
+            value={search}
+            onChange={handleSearchChange}
+            placeholder="Search courses, institutions and books"
+            ariaLabel="Search courses"
+            className={styles.search}
+          />
+          <Group gap="lg" wrap="nowrap">
+            <Switch
+              label="Only for this book"
+              checked={useBaseCourse}
+              onChange={(e) => {
+                setUseBaseCourse(e.currentTarget.checked);
+                setPage(0);
+              }}
+            />
+            <Switch
+              label="Only courses I teach"
+              checked={onlyMyCourses}
+              onChange={(e) => {
+                setOnlyMyCourses(e.currentTarget.checked);
+                setPage(0);
+              }}
+            />
+          </Group>
+        </Group>
+
+        {isFetching && !courses.length ? (
+          <Text size="sm" c="dimmed">
+            Loading courses…
+          </Text>
+        ) : courses.length ? (
+          <TreeTable
+            value={tree}
+            columns={columns}
+            selectionKeys={selectionKeys}
+            onSelect={handleSelect}
+            onUnselect={handleUnselect}
+            ariaLabel="Courses sharing assignments"
+          />
+        ) : (
+          <Text size="sm" c="dimmed">
+            No courses match your search.
+          </Text>
+        )}
+
+        {totalPages > 1 ? (
+          <Group justify="center" gap="sm">
+            <Button
+              variant="default"
+              size="xs"
+              disabled={page === 0}
+              onClick={() => setPage((p) => Math.max(p - 1, 0))}
+            >
+              Previous
+            </Button>
+            <Text size="xs" c="dimmed">
+              Page {page + 1} of {totalPages}
+            </Text>
+            <Button
+              variant="default"
+              size="xs"
+              disabled={page >= totalPages - 1}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </Group>
+        ) : null}
+
+        <Text size="xs" c="dimmed">
+          Checking a course takes everything it offers. Imports start hidden, exercises are used
+          where they live rather than copied into your book, and anything you already have is
+          skipped.
+        </Text>
+
+        <Group justify="flex-end">
+          <Button variant="default" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleImport} loading={isImporting} disabled={selectedCount === 0}>
+            {selectedCount === 0
+              ? "Import"
+              : `Import ${selectedCount} assignment${selectedCount === 1 ? "" : "s"}`}
+          </Button>
+        </Group>
+      </Stack>
+
+      <ImportPreviewPanel assignmentId={previewId} onClose={() => setPreviewId(null)} />
+    </Modal>
+  );
+};

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportPreviewPanel.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/importAssignment/ImportPreviewPanel.tsx
@@ -1,0 +1,127 @@
+import { Alert, Badge, Button, Group, Modal, Stack, Text } from "@mantine/core";
+import { usePreviewSharedAssignmentQuery } from "@store/assignment/assignment.logic.api";
+
+import { formatUTCDateForDisplay } from "@/utils/date";
+
+import styles from "./ImportAssignmentModal.module.css";
+
+const DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric"
+};
+
+interface ImportPreviewPanelProps {
+  /** Assignment to summarize, or null when nothing is being previewed. */
+  assignmentId: number | null;
+  onClose: () => void;
+}
+
+/**
+ * Answer "is this the one" for a single assignment, without leaving the tree.
+ *
+ * Read-only on purpose. Importing is driven by the tree's checkboxes, so a
+ * second import button here would give the same action two homes and let an
+ * instructor import something that is not part of what they have selected.
+ */
+export const ImportPreviewPanel = ({ assignmentId, onClose }: ImportPreviewPanelProps) => {
+  const { data: preview, isFetching } = usePreviewSharedAssignmentQuery(assignmentId ?? 0, {
+    skip: assignmentId === null
+  });
+
+  return (
+    <Modal
+      opened={assignmentId !== null}
+      onClose={onClose}
+      title={preview ? preview.name : "Loading assignment…"}
+      size="42rem"
+    >
+      {isFetching || !preview ? (
+        <Text size="sm" c="dimmed">
+          Loading assignment…
+        </Text>
+      ) : (
+        <Stack gap="md">
+          <Stack gap={4}>
+            <Text size="sm">
+              From <strong>{preview.course_name}</strong> · {preview.book_title}
+            </Text>
+            <Text size="sm" c="dimmed">
+              {preview.question_count} question{preview.question_count === 1 ? "" : "s"} ·{" "}
+              {preview.points} points · due{" "}
+              {formatUTCDateForDisplay(preview.duedate, DATE_FORMAT)} in your term
+            </Text>
+          </Stack>
+
+          {preview.already_imported ? (
+            <Alert variant="light" color="yellow" title="You already imported this">
+              {preview.imported_as
+                ? `It is in this course as “${preview.imported_as}”. `
+                : "It is already in this course. "}
+              Importing the course again skips it.
+            </Alert>
+          ) : null}
+
+          {preview.sharing_description ? (
+            <Alert variant="light" color="gray" title="Note from this course">
+              {preview.sharing_description}
+            </Alert>
+          ) : null}
+
+          {preview.skipped_readings > 0 ? (
+            <Alert
+              variant="light"
+              color="yellow"
+              title={`${preview.skipped_readings} reading${
+                preview.skipped_readings === 1 ? "" : "s"
+              } won't come across`}
+            >
+              A reading points at a page of {preview.book_title}, which your students are not
+              reading. The exercises import normally.
+            </Alert>
+          ) : null}
+
+          <div className={styles.questionList}>
+            {preview.questions.map((question) => (
+              <div key={question.id} className={styles.questionRow}>
+                <Text
+                  size="sm"
+                  c={question.will_import ? undefined : "dimmed"}
+                  className={question.will_import ? undefined : styles.skippedName}
+                >
+                  {question.name}
+                </Text>
+                <Group gap="xs">
+                  {question.will_import ? null : (
+                    <Badge size="sm" variant="outline" color="gray">
+                      not imported
+                    </Badge>
+                  )}
+                  {question.question_type ? (
+                    <Badge size="sm" variant="light">
+                      {question.question_type}
+                    </Badge>
+                  ) : null}
+                  <Text size="xs" c="dimmed">
+                    {question.points} pt
+                  </Text>
+                </Group>
+              </div>
+            ))}
+            {preview.questions.length === 0 ? (
+              <Text size="sm" c="dimmed">
+                This assignment has no questions yet.
+              </Text>
+            ) : null}
+          </div>
+
+          <Group justify="flex-end">
+            <Button variant="default" onClick={onClose}>
+              Close
+            </Button>
+          </Group>
+        </Stack>
+      )}
+    </Modal>
+  );
+};

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/AssignmentList.spec.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/AssignmentList.spec.tsx
@@ -17,6 +17,7 @@ const makeAssignment = (overrides: Partial<Assignment>): Assignment =>
     visible_on: null,
     hidden_on: null,
     enforce_due: false,
+    is_private: true,
     ...overrides
   }) as Assignment;
 
@@ -34,6 +35,7 @@ const baseProps = () => ({
   onEdit: vi.fn(),
   onDuplicate: vi.fn(),
   onEnforceDueChange: vi.fn(),
+  onImport: vi.fn(),
   onVisibilityChange: vi.fn(),
   onRemove: vi.fn()
 });
@@ -117,10 +119,15 @@ describe("AssignmentList", () => {
     renderWithMantine(<AssignmentList {...props} />);
 
     const bravoRow = screen.getByRole("button", { name: "Bravo" }).closest("tr")!;
-    const cells = bravoRow.querySelectorAll("td");
+    const cells = Array.from(bravoRow.querySelectorAll("td"));
+    // Found by content rather than index: a column added or removed anywhere to
+    // the left used to silently retarget this at a different cell.
+    const pointsCell = cells.find(
+      (cell) => cell.textContent?.trim() === String(ASSIGNMENTS[1].points)
+    )!;
 
-    fireEvent.click(cells[5]);
-    fireEvent.click(cells[7]);
+    fireEvent.click(pointsCell);
+    fireEvent.click(cells[cells.length - 1]);
 
     expect(props.onEdit).not.toHaveBeenCalled();
   });
@@ -131,6 +138,16 @@ describe("AssignmentList", () => {
     expect(
       screen.getByRole("switch", { name: "Allow late submissions for Bravo" })
     ).toBeInTheDocument();
+  });
+
+  it("invokes onImport when the import button is clicked", () => {
+    const props = baseProps();
+
+    renderWithMantine(<AssignmentList {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(props.onImport).toHaveBeenCalledTimes(1);
   });
 
   it("confirms deletion with the assignment name before calling onRemove", async () => {

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/AssignmentList.tsx
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/AssignmentBuilder/components/list/AssignmentList.tsx
@@ -24,6 +24,7 @@ interface AssignmentListProps {
   onEdit: (assignment: Assignment) => void;
   onDuplicate: (assignment: Assignment) => void;
   onEnforceDueChange: (assignment: Assignment, enforce_due: boolean) => void;
+  onImport: () => void;
   onVisibilityChange: (
     assignment: Assignment,
     data: { visible: boolean; visible_on: string | null; hidden_on: string | null }
@@ -70,8 +71,9 @@ export const AssignmentList = ({
   onEdit,
   onDuplicate,
   onEnforceDueChange,
-  onVisibilityChange,
-  onRemove
+  onImport,
+  onRemove,
+  onVisibilityChange
 }: AssignmentListProps) => {
   const [sortField, setSortField] = useState<string>(
     () => localStorage.getItem(SORT_STORAGE_KEY) || "name"
@@ -281,7 +283,13 @@ export const AssignmentList = ({
         )
       }
     ],
-    [confirmRemove, onDuplicate, onEdit, onEnforceDueChange, onVisibilityChange]
+    [
+      confirmRemove,
+      onDuplicate,
+      onEdit,
+      onEnforceDueChange,
+      onVisibilityChange
+    ]
   );
 
   const showEmptyState = !loading && assignments.length === 0;
@@ -300,6 +308,9 @@ export const AssignmentList = ({
             placeholder="Search assignments"
             className={styles.search}
           />
+          <Button variant="default" leftSection={<Icon name="download" />} onClick={onImport}>
+            Import
+          </Button>
           <Button
             className={styles.primaryCta}
             leftSection={<Icon name="plus" />}

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/Grader/tour/graderDemoData.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/components/routes/Grader/tour/graderDemoData.ts
@@ -102,7 +102,8 @@ const baseAssignment = {
   allow_self_autograde: null,
   from_source: false,
   current_index: 0,
-  enforce_due: false
+  enforce_due: false,
+  is_private: true
 };
 
 export const DEMO_ASSIGNMENTS: Assignment[] = [

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/store/assignment/assignment.logic.api.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/store/assignment/assignment.logic.api.ts
@@ -12,6 +12,13 @@ import {
   GetAssignmentResponse,
   GetAssignmentsResponse
 } from "@/types/assignment";
+import {
+  ImportAssignmentResult,
+  ImportCourseResult,
+  ShareableTreeRequest,
+  ShareableTreeResponse,
+  SharedAssignmentPreview
+} from "@/types/assignmentSharing";
 
 export const ASSIGNMENT_TOAST_COPY = {
   loadAssignmentsError: "Couldn't load assignments. Refresh the page.",
@@ -23,14 +30,44 @@ export const ASSIGNMENT_TOAST_COPY = {
   deleted: "Assignment deleted",
   deleteError: "Couldn't delete assignment. Try again.",
   duplicated: (name: string) => `Assignment duplicated as "${name}"`,
-  duplicateError: "Couldn't duplicate assignment. Try again."
+  duplicateError: "Couldn't duplicate assignment. Try again.",
+  previewSharedError: "Couldn't load that assignment. It may no longer be shared.",
+  imported: (name: string, skippedReadings: number) =>
+    skippedReadings > 0
+      ? `Imported as "${name}", without ${skippedReadings} reading${
+          skippedReadings === 1 ? "" : "s"
+        } that belong to the other book. It is hidden until you make it visible.`
+      : `Imported as "${name}". It is hidden until you make it visible.`,
+  importError: "Couldn't import assignment. It may no longer be shared.",
+  loadTreeError: "Couldn't load shared assignments. Try again.",
+  // Partial success is a normal outcome for a multi-import, so the toast counts
+  // rather than claiming everything worked.
+  importedMany: (result: {
+    imported: string[];
+    skipped_existing: string[];
+    skipped_readings: number;
+    failed: string[];
+  }) => {
+    const parts = [`Imported ${result.imported.length}`];
+
+    if (result.skipped_existing.length) {
+      parts.push(`${result.skipped_existing.length} already in your course`);
+    }
+    if (result.failed.length) {
+      parts.push(`${result.failed.length} couldn't be imported`);
+    }
+    if (result.skipped_readings) {
+      parts.push(`${result.skipped_readings} readings left behind`);
+    }
+    return `${parts.join(", ")}. Imports are hidden until you make them visible.`;
+  }
 } as const;
 
 export const assignmentApi = createApi({
   reducerPath: "assignmentAPI",
   keepUnusedDataFor: 60, //change to 0 for tests,
   baseQuery: baseQuery,
-  tagTypes: ["Assignments", "Exercises", "Assignment"],
+  tagTypes: ["Assignments", "Exercises", "Assignment", "ShareableTree"],
   endpoints: (build) => ({
     getAssignments: build.query<Assignment[], void>({
       query: () => ({
@@ -183,6 +220,70 @@ export const assignmentApi = createApi({
             notify.error(ASSIGNMENT_TOAST_COPY.duplicateError);
           });
       }
+    }),
+    previewSharedAssignment: build.query<SharedAssignmentPreview, number>({
+      query: (assignmentId) => ({
+        method: "GET",
+        url: `/assignment/instructor/assignments/${assignmentId}/preview`
+      }),
+      keepUnusedDataFor: 0.1,
+      transformResponse: (response: DetailResponse<SharedAssignmentPreview>) => response.detail,
+      onQueryStarted: (_, { queryFulfilled }) => {
+        queryFulfilled.catch(() => {
+          notify.error(ASSIGNMENT_TOAST_COPY.previewSharedError);
+        });
+      }
+    }),
+    shareableTree: build.query<ShareableTreeResponse, ShareableTreeRequest>({
+      query: ({ search, use_base_course, only_my_courses, page, limit }) => ({
+        method: "GET",
+        url: "/assignment/instructor/shareable_tree",
+        params: { search, use_base_course, only_my_courses, page, limit }
+      }),
+      providesTags: ["ShareableTree"],
+      transformResponse: (response: DetailResponse<ShareableTreeResponse>) => response.detail,
+      onQueryStarted: (_, { queryFulfilled }) => {
+        queryFulfilled.catch(() => {
+          notify.error(ASSIGNMENT_TOAST_COPY.loadTreeError);
+        });
+      }
+    }),
+    importCourseAssignments: build.mutation<DetailResponse<ImportCourseResult>, number>({
+      query: (sourceCourseId) => ({
+        method: "POST",
+        url: "/assignment/instructor/assignments/import_course",
+        body: { source_course_id: sourceCourseId }
+      }),
+      invalidatesTags: (_, error) =>
+        error ? [] : [{ type: "Assignments" as const }, { type: "ShareableTree" as const }],
+      onQueryStarted: (_, { queryFulfilled }) => {
+        queryFulfilled
+          .then(({ data }) => {
+            notify.success(ASSIGNMENT_TOAST_COPY.importedMany(data.detail));
+          })
+          .catch(() => {
+            notify.error(ASSIGNMENT_TOAST_COPY.importError);
+          });
+      }
+    }),
+    importAssignment: build.mutation<DetailResponse<ImportAssignmentResult>, number>({
+      query: (assignmentId) => ({
+        method: "POST",
+        url: `/assignment/instructor/assignments/${assignmentId}/import`
+      }),
+      invalidatesTags: (_, error) =>
+        error ? [] : [{ type: "Assignments" as const }, { type: "ShareableTree" as const }],
+      onQueryStarted: (_, { queryFulfilled }) => {
+        queryFulfilled
+          .then(({ data }) => {
+            notify.success(
+              ASSIGNMENT_TOAST_COPY.imported(data.detail.name, data.detail.skipped_readings)
+            );
+          })
+          .catch(() => {
+            notify.error(ASSIGNMENT_TOAST_COPY.importError);
+          });
+      }
     })
   })
 });
@@ -193,5 +294,9 @@ export const {
   useUpdateAssignmentMutation,
   useCreateAssignmentMutation,
   useRemoveAssignmentMutation,
-  useDuplicateAssignmentMutation
+  useDuplicateAssignmentMutation,
+  useShareableTreeQuery,
+  usePreviewSharedAssignmentQuery,
+  useImportAssignmentMutation,
+  useImportCourseAssignmentsMutation
 } = assignmentApi;

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/types/assignment.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/types/assignment.ts
@@ -32,6 +32,8 @@ export type Assignment = {
   from_source: boolean;
   current_index: number;
   enforce_due: boolean;
+  /** False makes this assignment importable by instructors in other courses. */
+  is_private: boolean;
 };
 
 export type CreateAssignmentPayload = {

--- a/bases/rsptx/assignment_server_api/assignment_builder/src/types/assignmentSharing.ts
+++ b/bases/rsptx/assignment_server_api/assignment_builder/src/types/assignmentSharing.ts
@@ -1,0 +1,106 @@
+/** Types for browsing and importing assignments shared by other courses. */
+
+export type SharedAssignmentQuestion = {
+  id: number;
+  name: string;
+  question_type: string | null;
+  points: number;
+  chapter: string | null;
+  subchapter: string | null;
+  reading_assignment: boolean | null;
+  /** False for a reading that cannot follow the assignment into your book. */
+  will_import: boolean;
+};
+
+export type SharedAssignmentPreview = {
+  id: number;
+  name: string;
+  description: string | null;
+  points: number;
+  kind: string | null;
+  /** Already shifted to the importing course's term. */
+  duedate: string;
+  question_count: number;
+  course_name: string;
+  base_course: string;
+  book_title: string;
+  institution: string | null;
+  /** True for an assignment the book itself ships, on its base course row. */
+  is_official: boolean;
+  sharing_description: string;
+  /** True when this assignment belongs to a different book than your course. */
+  is_cross_book: boolean;
+  /** True when a copy is already in your course. */
+  already_imported: boolean;
+  /** Name that copy goes by, which may have been renamed since. */
+  imported_as: string | null;
+  /** How many readings will be left behind, which only happens cross-book. */
+  skipped_readings: number;
+  questions: SharedAssignmentQuestion[];
+};
+
+export type ImportAssignmentResult = {
+  status: string;
+  id: number;
+  name: string;
+  skipped_readings: number;
+};
+
+/** One assignment under a course in the import tree. */
+export type ShareableTreeAssignment = {
+  id: number;
+  name: string;
+  description: string | null;
+  points: number;
+  kind: string | null;
+  question_count: number;
+  /** True for an assignment the book itself ships. */
+  is_official: boolean;
+  /** True when a copy is already in the requester's course. */
+  already_imported: boolean;
+  /** Name that copy goes by, which may have been renamed since. */
+  imported_as: string | null;
+};
+
+/** A course in the import tree, with everything it offers. */
+export type ShareableTreeCourse = {
+  id: number;
+  course_name: string;
+  institution: string | null;
+  base_course: string;
+  book_title: string;
+  /** How many assignments this course offers, before any are expanded. */
+  shareable_count: number;
+  /** True when this course is a book's own course. */
+  is_official: boolean;
+  /** True when the requester instructs this course. */
+  is_mine: boolean;
+  assignments: ShareableTreeAssignment[];
+};
+
+export type ShareableTreeResponse = {
+  courses: ShareableTreeCourse[];
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    pages: number;
+  };
+};
+
+export type ShareableTreeRequest = {
+  search: string;
+  /** When true, only courses on the caller's own book. */
+  use_base_course: boolean;
+  only_my_courses: boolean;
+  page: number;
+  limit: number;
+};
+
+export type ImportCourseResult = {
+  status: string;
+  imported: string[];
+  skipped_existing: string[];
+  skipped_readings: number;
+  failed: string[];
+};

--- a/bases/rsptx/assignment_server_api/routers/instructor.py
+++ b/bases/rsptx/assignment_server_api/routers/instructor.py
@@ -11,6 +11,7 @@ from fastapi import (
     APIRouter,
     Cookie,
     Depends,
+    HTTPException,
     Request,
     status,
     Form,
@@ -67,6 +68,12 @@ from rsptx.db.crud import (
     user_in_course,
     get_peer_votes,
     search_exercises,
+    fetch_shareable_assignment_tree,
+    search_assignments,
+    search_shareable_courses,
+    import_assignment,
+    import_course_assignments,
+    fetch_assignment_for_preview,
     create_api_token,
     delete_api_token,
     fetch_all_api_tokens,
@@ -109,6 +116,7 @@ from rsptx.validation.schemas import (
     UpdateAssignmentExercisesPayload,
     AssignmentQuestionUpdateDict,
     ExercisesSearchRequest,
+    AssignmentsSearchRequest,
     CreateExercisesPayload,
     ValidateQuestionNameRequest,
     CopyQuestionRequest,
@@ -692,6 +700,8 @@ async def new_assignment(
         from_source=False,
         current_index=0,
         updated_date=canonical_utcnow(),
+        # Sharing is opt-in; the instructor turns it on later if they want to.
+        is_private=True,
     )
     try:
         res = await create_assignment(new_assignment)
@@ -1832,7 +1842,16 @@ async def delete_single_token(
 
 @router.delete("/assignments/{assignment_id}")
 @instructor_role_required()
-async def remove_assignment(assignment_id: int, request: Request):
+@with_course()
+async def remove_assignment(assignment_id: int, request: Request, course=None):
+    # delete_assignment keys off the id alone, so without this check any
+    # instructor could delete any assignment on the platform by guessing an id.
+    existing = await fetch_one_assignment(assignment_id)
+    if not existing or existing.course != course.id:
+        return make_json_response(
+            status=status.HTTP_404_NOT_FOUND, detail="Assignment not found"
+        )
+
     rslogger.debug(f"Attempting to delete assignment {assignment_id}")
     try:
         await delete_assignment(assignment_id=assignment_id)
@@ -2064,7 +2083,17 @@ async def duplicate_assignment_endpoint(
 ):
     """
     Duplicate an assignment with all its exercises and readings.
+
+    Duplicating is a within-course operation. Copying in from somewhere else
+    goes through the import endpoint, which enforces the sharing rules -- so
+    this has to refuse a foreign id or it would be a way around them.
     """
+    source = await fetch_one_assignment(assignment_id)
+    if not source or source.course != course.id:
+        return make_json_response(
+            status=status.HTTP_404_NOT_FOUND, detail="Assignment not found"
+        )
+
     try:
         assignments = await fetch_assignments(course.course_name, fetch_all=True)
         existing_names = {assignment.name for assignment in assignments}
@@ -2086,6 +2115,267 @@ async def duplicate_assignment_endpoint(
             status=status.HTTP_400_BAD_REQUEST,
             detail=f"Error duplicating assignment: {str(e)}",
         )
+
+
+@router.post("/assignments/search")
+@instructor_role_required()
+@with_course()
+async def search_assignments_endpoint(
+    request: Request,
+    search_request: AssignmentsSearchRequest,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    Browse assignments other instructors have marked as shareable.
+
+    Results span every course on the platform, so an instructor can pick up a
+    problem set from a course they have no connection to. ``use_base_course``
+    narrows this to the caller's own book and ``only_my_courses`` to courses
+    they instruct; the two are independent and apply together. The caller's
+    current course is left out -- importing an assignment into the course it
+    already lives in is not a thing anyone wants.
+
+    Rows carry ``already_imported`` for anything the caller has previously
+    imported into this course, which is what keeps a second import from
+    happening by accident.
+    """
+    if search_request.use_base_course:
+        search_request.base_course = course.base_course
+    else:
+        search_request.base_course = None
+
+    try:
+        result = await search_assignments(
+            search_request,
+            user_id=user.id,
+            exclude_course_id=course.id,
+            target_course_id=course.id,
+            prefer_base_course=course.base_course,
+        )
+    except Exception as e:
+        rslogger.error(f"Error searching assignments: {e}")
+        return make_json_response(
+            status=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error searching assignments: {str(e)}",
+        )
+
+    return make_json_response(status=status.HTTP_200_OK, detail=result)
+
+
+@router.get("/assignments/{assignment_id}/preview")
+@instructor_role_required()
+@with_course()
+async def preview_assignment_endpoint(
+    request: Request,
+    assignment_id: int,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    Summarize an assignment from another course before importing it.
+
+    Deliberately separate from ``GET /assignments/{assignment_id}``, which is
+    scoped to the caller's own course. Widening that endpoint to cover this case
+    would put the "is it mine" and "is it shared" rules in one place where a
+    later edit could blur them; this one answers only the sharing question.
+    """
+    try:
+        preview = await fetch_assignment_for_preview(
+            assignment_id, user_id=user.id, target_course=course
+        )
+    except HTTPException as e:
+        return make_json_response(status=e.status_code, detail=e.detail)
+    except Exception as e:
+        rslogger.error(f"Error previewing assignment {assignment_id}: {e}")
+        return make_json_response(
+            status=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error previewing assignment: {str(e)}",
+        )
+
+    return make_json_response(status=status.HTTP_200_OK, detail=preview)
+
+
+@router.post("/assignments/{assignment_id}/import")
+@instructor_role_required()
+@with_course()
+async def import_assignment_endpoint(
+    request: Request,
+    assignment_id: int,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    Copy a shareable assignment from another course into the caller's course.
+
+    The exercises are linked, not copied -- the same thing adding an exercise
+    from another course already does. Readings are left behind when the books
+    differ, since they name a subchapter of a book the caller's students are
+    not reading; ``skipped_readings`` says how many.
+    """
+    try:
+        result = await import_assignment(
+            source_assignment_id=assignment_id,
+            target_course=course,
+            importing_user=user,
+        )
+    except HTTPException as e:
+        return make_json_response(status=e.status_code, detail=e.detail)
+    except Exception as e:
+        rslogger.error(f"Error importing assignment {assignment_id}: {e}")
+        return make_json_response(
+            status=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error importing assignment: {str(e)}",
+        )
+
+    return make_json_response(
+        status=status.HTTP_201_CREATED,
+        detail={
+            "status": "success",
+            "id": result.assignment.id,
+            "name": result.name,
+            "skipped_readings": result.skipped_readings,
+        },
+    )
+
+
+# Not under /assignments/: `GET /assignments/{assignment_id}` is registered far
+# earlier in this file, and Starlette matches in registration order, so a path
+# like /assignments/shareable_tree binds "shareable_tree" to assignment_id and
+# dies in int coercion. A sibling of /shareable_courses cannot collide.
+@router.get("/shareable_tree")
+@instructor_role_required()
+@with_course()
+async def shareable_assignment_tree_endpoint(
+    request: Request,
+    search: str = "",
+    use_base_course: bool = False,
+    only_my_courses: bool = False,
+    page: int = 0,
+    limit: int = 20,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    Courses with the assignments each offers, for the import browser's tree.
+
+    Both levels in one response: the page is bounded by courses, so expanding
+    one is instant rather than another round trip. The caller's own book sorts
+    first, and every assignment says whether it is already in their course.
+    """
+    try:
+        result = await fetch_shareable_assignment_tree(
+            user_id=user.id,
+            target_course=course,
+            search=search,
+            use_base_course=use_base_course,
+            only_my_courses=only_my_courses,
+            page=page,
+            limit=min(max(limit, 1), 100),
+        )
+    except Exception as e:
+        rslogger.error(f"Error building the shareable assignment tree: {e}")
+        return make_json_response(
+            status=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error loading shared assignments: {str(e)}",
+        )
+
+    return make_json_response(status=status.HTTP_200_OK, detail=result)
+
+
+@router.get("/shareable_courses")
+@instructor_role_required()
+@with_course()
+async def shareable_courses_endpoint(
+    request: Request,
+    search: str = "",
+    use_base_course: bool = False,
+    only_my_courses: bool = False,
+    page: int = 0,
+    limit: int = 20,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    List courses with assignments the caller could import.
+
+    The course-first half of importing: "give me what that course uses" rather
+    than "find me one problem set". The book's own course sorts first, since an
+    instructor looking for material for their book should not have to search
+    for the book itself.
+    """
+    try:
+        result = await search_shareable_courses(
+            user_id=user.id,
+            search=search,
+            base_course=course.base_course if use_base_course else None,
+            prefer_base_course=course.base_course,
+            only_my_courses=only_my_courses,
+            exclude_course_id=course.id,
+            page=page,
+            limit=min(max(limit, 1), 100),
+        )
+    except Exception as e:
+        rslogger.error(f"Error listing shareable courses: {e}")
+        return make_json_response(
+            status=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error listing shareable courses: {str(e)}",
+        )
+
+    return make_json_response(status=status.HTTP_200_OK, detail=result)
+
+
+class ImportCoursePayload(BaseModel):
+    source_course_id: int
+    # Off only when the instructor deliberately wants a second set. Defaulting
+    # to skipping is what makes re-running this after the source course adds an
+    # assignment useful rather than duplicating everything already taken.
+    skip_existing: bool = True
+
+
+@router.post("/assignments/import_course")
+@instructor_role_required()
+@with_course()
+async def import_course_assignments_endpoint(
+    request: Request,
+    payload: ImportCoursePayload,
+    user=Depends(auth_manager),
+    course=None,
+):
+    """
+    Import every importable assignment from one course into the caller's.
+
+    Each assignment goes through the same path as a single import, so the
+    sharing rules, name de-duplication and cross-book reading handling are
+    identical. Partial success is a normal outcome and is reported as one:
+    the response says what came across, what was already here and what failed.
+    """
+    try:
+        result = await import_course_assignments(
+            source_course_id=payload.source_course_id,
+            target_course=course,
+            importing_user=user,
+            skip_existing=payload.skip_existing,
+        )
+    except HTTPException as e:
+        return make_json_response(status=e.status_code, detail=e.detail)
+    except Exception as e:
+        rslogger.error(f"Error importing course {payload.source_course_id}: {e}")
+        return make_json_response(
+            status=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error importing course assignments: {str(e)}",
+        )
+
+    return make_json_response(
+        status=status.HTTP_201_CREATED,
+        detail={
+            "status": "success",
+            "imported": result.imported,
+            "skipped_existing": result.skipped_existing,
+            "skipped_readings": result.skipped_readings,
+            "failed": result.failed,
+        },
+    )
 
 
 class CreateDatafilePayload(BaseModel):

--- a/bases/rsptx/interactives/package-lock.json
+++ b/bases/rsptx/interactives/package-lock.json
@@ -2150,6 +2150,40 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@exodus/bytes": {
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -2276,6 +2310,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+            "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+                "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2326,6 +2382,23 @@
             "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
             "dev": true
         },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/@rolldown/binding-darwin-arm64": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
@@ -2337,6 +2410,247 @@
             "optional": true,
             "os": [
                 "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -2361,6 +2675,17 @@
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@types/chai": {
@@ -5718,6 +6043,27 @@
                 "lightningcss-win32-x64-msvc": "1.32.0"
             }
         },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/lightningcss-darwin-arm64": {
             "version": "1.32.0",
             "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
@@ -5729,6 +6075,207 @@
             "optional": true,
             "os": [
                 "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">= 12.0.0"
@@ -9251,23 +9798,6 @@
                 "yaml": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vitest/node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/w3c-xmlserializer": {

--- a/bases/rsptx/interactives/package.json
+++ b/bases/rsptx/interactives/package.json
@@ -58,5 +58,12 @@
     },
     "optionalDependencies": {
         "canvas": "^3.2.3"
+    },
+    "allowScripts": {
+        "canvas@3.2.3": true,
+        "canvas@1.6.13": true,
+        "canvas-prebuilt@1.6.11": true,
+        "core-js@3.25.1": true,
+        "handsontable@7.2.2": true
     }
 }

--- a/components/rsptx/db/crud/__init__.py
+++ b/components/rsptx/db/crud/__init__.py
@@ -23,6 +23,14 @@ from .user import (
 
 from .assignment import (
     create_assignment,
+    fetch_assignment_for_preview,
+    fetch_shareable_assignment_tree,
+    import_assignment,
+    import_course_assignments,
+    search_assignments,
+    search_shareable_courses,
+    shift_duedate_between_courses,
+    term_start_utc,
     create_assignment_question,
     create_deadline_exception,
     delete_deadline_exception,
@@ -275,6 +283,14 @@ __all__ = []
 # from .assignment
 __all__ += [
     "create_assignment",
+    "fetch_assignment_for_preview",
+    "fetch_shareable_assignment_tree",
+    "import_assignment",
+    "import_course_assignments",
+    "search_assignments",
+    "search_shareable_courses",
+    "shift_duedate_between_courses",
+    "term_start_utc",
     "create_assignment_question",
     "create_deadline_exception",
     "delete_deadline_exception",

--- a/components/rsptx/db/crud/assignment.py
+++ b/components/rsptx/db/crud/assignment.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import Optional, List
+from typing import NamedTuple, Optional, List
+from zoneinfo import ZoneInfo
 from fastapi import HTTPException, status
 from asyncpg.exceptions import UniqueViolationError
 from rsptx.validation import schemas
@@ -12,7 +13,7 @@ from rsptx.data_types.autograde import AutogradeOptions
 from rsptx.response_helpers.core import canonical_utcnow
 
 import logging
-from sqlalchemy import select, update, delete, and_, or_, func
+from sqlalchemy import select, update, delete, and_, or_, func, asc, desc, case
 from sqlalchemy.exc import IntegrityError
 from .question import fetch_question_count_per_subchapter
 
@@ -23,6 +24,7 @@ from ..models import (
     AssignmentQuestion,
     AssignmentQuestionValidator,
     AuthUser,
+    CourseAttribute,
     CourseInstructor,
     Courses,
     DeadlineException,
@@ -1477,3 +1479,1078 @@ async def duplicate_assignment(
         )
 
         return AssignmentValidator.from_orm(new_assignment), new_name
+
+
+def term_start_utc(
+    term_start_date: datetime.date, timezone: Optional[str]
+) -> datetime.datetime:
+    """Midnight local time on the first day of term, expressed as naive UTC.
+
+    ``term_start_date`` is a bare date, so on its own it has no timezone. Due
+    dates are stored as naive UTC, so the term start has to be anchored in the
+    course timezone before the two can be subtracted -- otherwise the offset
+    from the start of term is wrong by the course's UTC offset. A course with
+    no timezone is treated as UTC, matching the ``duedate`` migration.
+    """
+    midnight = datetime.datetime.combine(term_start_date, datetime.time())
+    tz = ZoneInfo(timezone) if timezone else datetime.timezone.utc
+    return (
+        midnight.replace(tzinfo=tz)
+        .astimezone(datetime.timezone.utc)
+        .replace(tzinfo=None)
+    )
+
+
+def shift_duedate_between_courses(
+    duedate: datetime.datetime, source_course, target_course
+) -> datetime.datetime:
+    """Re-date ``duedate`` so it keeps its offset from the start of term.
+
+    Both term starts are anchored in their own course timezone, so the offset
+    is preserved as local wall clock time even when the two terms fall on
+    opposite sides of a DST change. If either course is missing a term start
+    there is nothing to shift against, so the original date is kept.
+    """
+    if not (source_course.term_start_date and target_course.term_start_date):
+        return duedate
+
+    due_delta = duedate - term_start_utc(
+        source_course.term_start_date, source_course.timezone
+    )
+    return (
+        term_start_utc(target_course.term_start_date, target_course.timezone)
+        + due_delta
+    )
+
+
+def _normalize_assignment_kind(kind: str, is_timed: bool, is_peer: bool):
+    """Reconcile the ``is_timed``/``is_peer`` flags with ``kind``.
+
+    Older assignments predate ``kind`` and can carry flag combinations it
+    disallows. Copying one forward is a good moment to make the two agree,
+    rather than propagating the inconsistency into a new course.
+    """
+    if kind == "Regular":
+        return False, False
+    if kind == "Timed":
+        return True, False
+    if kind == "Peer":
+        return False, True
+    return is_timed, is_peer
+
+
+def unique_assignment_name(base_name: str, existing_names) -> str:
+    """Pick a name for a copied assignment that is free within the course.
+
+    The ``(name, course)`` index on ``assignments`` is unique, so a copy landing
+    in a course that already has that name has to be renamed. Matches the
+    ``X (Copy)`` / ``X (Copy 2)`` scheme ``duplicate_assignment`` uses.
+    """
+    if base_name not in existing_names:
+        return base_name
+
+    stem = base_name.split(" (Copy")[0] if " (Copy" in base_name else base_name
+    candidate = f"{stem} (Copy)"
+    counter = 1
+    while candidate in existing_names:
+        counter += 1
+        candidate = f"{stem} (Copy {counter})"
+    return candidate
+
+
+def _is_book_bound(assignment_question, question) -> bool:
+    """True when a row only makes sense inside the book it came from.
+
+    A reading is an instruction to read a subchapter, and it is graded by
+    counting activity in that subchapter of the course's own book -- neither of
+    which survives the trip to a different book. Exercises carry their own
+    content and travel freely. ``question_type == "page"`` is checked alongside
+    the flag because a page question is a reading whether or not the flag on
+    the row happens to say so.
+    """
+    return (
+        bool(assignment_question.reading_assignment) or question.question_type == "page"
+    )
+
+
+class ImportedAssignment(NamedTuple):
+    """What :func:`import_assignment` produced.
+
+    ``skipped_readings`` is how many rows were left behind by the cross-book
+    rule above, so the caller can say so rather than letting the instructor
+    discover the gap themselves.
+    """
+
+    assignment: AssignmentValidator
+    name: str
+    skipped_readings: int
+
+
+def _searchable_column(field: str, joined_columns: dict):
+    """Resolve a client-supplied field name to a column, or None.
+
+    Checked against the table's columns rather than ``hasattr``: a declarative
+    class also answers to ``metadata``, ``registry`` and the ``questions``
+    relationship, none of which can be filtered or sorted on.
+    """
+    if field in joined_columns:
+        return joined_columns[field]
+    if field in Assignment.__table__.columns:
+        return getattr(Assignment, field)
+    return None
+
+
+# How much of a course's sharing blurb to carry in a page of search results.
+SHARING_DESCRIPTION_PREVIEW_CHARS = 1000
+
+
+# An assignment the book itself ships: it lives on the base course row, which is
+# the course whose ``base_course`` points at its own name.
+#
+# Two things follow from that. It needs no sharing flag -- a book has always been
+# copyable by anyone, which is what ``_fetch_source_for_import`` already allows,
+# and requiring an opt-in would hide every official assignment until some author
+# went looking for a toggle that has no UI. And ``from_source`` rows are excluded:
+# those are generated from the book's own markup on every build, so a copy starts
+# drifting from the book the moment the book changes.
+_IS_OFFICIAL = (Courses.course_name == Courses.base_course) & (
+    Assignment.from_source == False  # noqa: E712
+)
+
+
+def _is_official(assignment, course) -> bool:
+    """The Python-side reading of :data:`_IS_OFFICIAL`, for a fetched row."""
+    return course.course_name == course.base_course and not assignment.from_source
+
+
+# The course attribute an instructor sets on the Course Settings page to offer
+# their assignments to other courses.
+COURSE_SHARING_ATTR = "share_assignments"
+
+
+# Sharing is a decision about a course, not about each assignment in it. It used
+# to live on ``Assignment.is_private``, one switch per row in the assignment
+# list, which put a column in front of every instructor to answer a question
+# most of them never think about -- and which did nothing at all on a base
+# course, whose assignments are public regardless.
+#
+# ``is_private`` still exists and is still set on an imported copy, so importing
+# something never signs the importer up for sharing it onward. It just no longer
+# decides who can see what.
+_COURSE_SHARES_ASSIGNMENTS = (
+    select(CourseAttribute.id)
+    .where(
+        (CourseAttribute.course_id == Courses.id)
+        & (CourseAttribute.attr == COURSE_SHARING_ATTR)
+        & (func.lower(CourseAttribute.value) == "true")
+    )
+    .exists()
+)
+
+
+async def course_shares_assignments(course_id: int) -> bool:
+    """Has this course opted in to offering its assignments to other courses?
+
+    The row-at-a-time counterpart to :data:`_COURSE_SHARES_ASSIGNMENTS`, for the
+    authorization check on a single assignment.
+    """
+    async with async_session() as session:
+        value = (
+            await session.execute(
+                select(CourseAttribute.value).where(
+                    (CourseAttribute.course_id == course_id)
+                    & (CourseAttribute.attr == COURSE_SHARING_ATTR)
+                )
+            )
+        ).scalar()
+    return (value or "").lower() == "true"
+
+
+def _visibility(my_course_ids: List[int]):
+    """Which assignments this instructor may see in the import browser.
+
+    Three ways in, and they are the same three the import endpoint enforces:
+    the owning course offers its assignments, the assignment belongs to a book,
+    or the caller already instructs the course it lives in.
+    """
+    visibility = or_(_COURSE_SHARES_ASSIGNMENTS, _IS_OFFICIAL)
+    if my_course_ids:
+        visibility = or_(visibility, Courses.id.in_(my_course_ids))
+    return visibility
+
+
+async def _existing_imports(
+    session, source_assignment_ids: List[int], target_course_id: Optional[int]
+) -> dict:
+    """Map source assignment id -> name of the copy already in ``target_course``.
+
+    Answers "have I imported this before" for a page of search results in one
+    query. Keyed off ``imported_from_assignment_id`` rather than the name or the
+    linked question set, both of which stop matching the moment the instructor
+    edits their copy -- which is the normal thing to do after importing.
+    """
+    if not source_assignment_ids or target_course_id is None:
+        return {}
+
+    rows = await session.execute(
+        select(Assignment.imported_from_assignment_id, Assignment.name)
+        .where(
+            (Assignment.course == target_course_id)
+            & (Assignment.imported_from_assignment_id.in_(source_assignment_ids))
+        )
+        .order_by(Assignment.id)
+    )
+
+    # Oldest copy wins when a source was imported more than once: it is the one
+    # the instructor has had longest and the one they are likeliest to know by
+    # name. Later copies are still covered -- the flag is per source, not per
+    # copy -- so nothing goes unmarked.
+    existing = {}
+    for source_id, name in rows.all():
+        existing.setdefault(source_id, name)
+    return existing
+
+
+async def search_assignments(
+    criteria: schemas.AssignmentsSearchRequest,
+    user_id: int,
+    exclude_course_id: Optional[int] = None,
+    target_course_id: Optional[int] = None,
+    prefer_base_course: Optional[str] = None,
+) -> dict:
+    """Find assignments an instructor is allowed to see, for the import browser.
+
+    An assignment is visible when its owning course offers its assignments, when
+    it belongs to a book, or when the requester already instructs the course that
+    owns it. That last case mirrors ``search_exercises``: your own material never
+    disappears from your own search results.
+
+    :param criteria: search parameters (filters, sorting, pagination)
+    :param user_id: id of the requesting instructor
+    :param exclude_course_id: course to leave out, normally the requester's own
+    :param target_course_id: course the results would be imported into; each row
+        is marked with whether it is already there. Normally the same course as
+        ``exclude_course_id``, but kept separate so neither implies the other.
+    :param prefer_base_course: sort this book's own assignments first, normally
+        the caller's book
+    :return: dict with ``assignments`` and ``pagination`` keys
+    """
+    from .course import fetch_instructor_courses
+
+    my_course_ids = [ci.course for ci in await fetch_instructor_courses(user_id)]
+
+    visibility = _visibility(my_course_ids)
+
+    query = (
+        select(Assignment, Courses, Library)
+        .join(Courses, Assignment.course == Courses.id)
+        .outerjoin(Library, Courses.base_course == Library.basecourse)
+        .where(visibility)
+    )
+
+    # Never browsable, wherever they live. The book build regenerates a
+    # ``from_source`` assignment from the book's own markup every time it runs,
+    # so a copy is a snapshot that starts drifting immediately. Importing one
+    # directly by id still works -- this governs what gets advertised, not what
+    # an instructor who knows the id may do.
+    query = query.where(Assignment.from_source == False)  # noqa: E712
+
+    if exclude_course_id is not None:
+        query = query.where(Courses.id != exclude_course_id)
+
+    # Restrict to a single book when the caller asked for "my book only".
+    if criteria.base_course:
+        query = query.where(Courses.base_course == criteria.base_course)
+
+    # "Only from my courses": material the caller has taught with, as opposed to
+    # everything on the platform. An empty ``my_course_ids`` renders as a false
+    # predicate, which is the honest answer -- there is nothing of theirs to show.
+    if criteria.only_my_courses:
+        query = query.where(Courses.id.in_(my_course_ids))
+
+    # Columns a filter may name, beyond the plain Assignment columns. "Course"
+    # and "book" are the same join here -- a book is just a course whose
+    # base_course points at itself.
+    joined_columns = {
+        "course_name": Courses.course_name,
+        "institution": Courses.institution,
+        "base_course": Courses.base_course,
+        "book_title": Library.title,
+    }
+
+    for field, filter_data in (criteria.filters or {}).items():
+        # ``filters`` is loosely typed, so a caller can hand us a bare value
+        # where the nested {"value": ..., "matchMode": ...} shape is expected.
+        if not isinstance(filter_data, dict):
+            continue
+        filter_value = filter_data.get("value")
+        filter_mode = filter_data.get("matchMode", "contains")
+        if filter_value is None or filter_value == "":
+            continue
+
+        if field == "global":
+            # Every whitespace-separated term must appear somewhere, so extra
+            # words narrow the result set instead of widening it.
+            search_columns = [
+                Assignment.name,
+                Assignment.description,
+                Courses.course_name,
+                Library.title,
+            ]
+            terms = str(filter_value).strip().split()
+            for term in terms:
+                query = query.where(
+                    or_(*[col.ilike(f"%{term}%") for col in search_columns])
+                )
+            continue
+
+        column = _searchable_column(field, joined_columns)
+        if column is None:
+            continue
+
+        # Only "in" takes a list; interpolating one into a LIKE pattern would
+        # match on its repr and quietly return nothing.
+        if isinstance(filter_value, list) and filter_mode != "in":
+            continue
+
+        if filter_mode == "contains":
+            query = query.where(column.ilike(f"%{filter_value}%"))
+        elif filter_mode == "equals":
+            query = query.where(column == filter_value)
+        elif filter_mode == "startsWith":
+            query = query.where(column.ilike(f"{filter_value}%"))
+        elif filter_mode == "endsWith":
+            query = query.where(column.ilike(f"%{filter_value}"))
+        elif filter_mode == "notContains":
+            query = query.where(~column.ilike(f"%{filter_value}%"))
+        elif filter_mode == "notEquals":
+            query = query.where(column != filter_value)
+        elif filter_mode == "in" and isinstance(filter_value, list) and filter_value:
+            query = query.where(column.in_(filter_value))
+
+    # The caller's *own* book leads, and their chosen column orders within each
+    # group. Only their own book: elevating every book's official assignments
+    # would put nineteen other books' material ahead of what an instructor
+    # actually shares, which is the opposite of not losing things.
+    if prefer_base_course:
+        query = query.order_by(
+            case(
+                (_IS_OFFICIAL & (Courses.base_course == prefer_base_course), 0), else_=1
+            )
+        )
+
+    if criteria.sorting and criteria.sorting.get("field"):
+        field = criteria.sorting["field"]
+        order = criteria.sorting.get("order", 1)
+        column = _searchable_column(field, joined_columns)
+        if column is not None:
+            query = query.order_by(asc(column) if order == 1 else desc(column))
+
+    # Order by id last so paging is stable when the sort column ties.
+    query = query.order_by(Assignment.id)
+
+    count_query = select(func.count()).select_from(query.subquery())
+    page_query = query.offset(criteria.page * criteria.limit).limit(criteria.limit)
+
+    async with async_session() as session:
+        total_count = (await session.execute(count_query)).scalar() or 0
+        rows = (await session.execute(page_query)).all()
+
+        assignment_ids = [row.Assignment.id for row in rows]
+        course_ids = {row.Courses.id for row in rows}
+
+        # One extra query each for question counts and sharing blurbs, rather
+        # than joins that would complicate the count query above.
+        question_counts = {}
+        if assignment_ids:
+            count_rows = await session.execute(
+                select(
+                    AssignmentQuestion.assignment_id,
+                    func.count(AssignmentQuestion.id),
+                )
+                .where(AssignmentQuestion.assignment_id.in_(assignment_ids))
+                .group_by(AssignmentQuestion.assignment_id)
+            )
+            question_counts = {aid: count for aid, count in count_rows.all()}
+
+        sharing_descriptions = {}
+        if course_ids:
+            attr_rows = await session.execute(
+                select(CourseAttribute.course_id, CourseAttribute.value).where(
+                    (CourseAttribute.course_id.in_(course_ids))
+                    & (CourseAttribute.attr == "sharing_description")
+                )
+            )
+            # Truncated because a page of results carries one of these per
+            # course and the value is instructor-entered free text; the form's
+            # maxlength is only advisory.
+            sharing_descriptions = {
+                cid: (value or "")[:SHARING_DESCRIPTION_PREVIEW_CHARS]
+                for cid, value in attr_rows.all()
+            }
+
+        existing_imports = await _existing_imports(
+            session, assignment_ids, target_course_id
+        )
+
+        assignments = []
+        for row in rows:
+            assignment, course, library = row.Assignment, row.Courses, row.Library
+            assignments.append(
+                {
+                    "id": assignment.id,
+                    "name": assignment.name,
+                    "description": assignment.description,
+                    "duedate": assignment.duedate,
+                    "points": assignment.points,
+                    "kind": assignment.kind,
+                    "is_private": assignment.is_private,
+                    "question_count": question_counts.get(assignment.id, 0),
+                    "course_id": course.id,
+                    "course_name": course.course_name,
+                    "institution": course.institution,
+                    "base_course": course.base_course,
+                    "book_title": library.title if library else course.base_course,
+                    "sharing_description": sharing_descriptions.get(course.id, ""),
+                    "is_mine": course.id in my_course_ids,
+                    "is_official": _is_official(assignment, course),
+                    # Left in the results rather than filtered out: a row that
+                    # silently vanishes after an import looks like a bug, and
+                    # seeing it marked is what tells the instructor why they
+                    # cannot find it.
+                    "already_imported": assignment.id in existing_imports,
+                    "imported_as": existing_imports.get(assignment.id),
+                }
+            )
+
+        return {
+            "assignments": assignments,
+            "pagination": {
+                "total": total_count,
+                "page": criteria.page,
+                "limit": criteria.limit,
+                "pages": (total_count + criteria.limit - 1) // criteria.limit,
+            },
+        }
+
+
+async def _fetch_source_for_import(source_assignment_id: int, user_id: int):
+    """Load an assignment and its course, enforcing the sharing rules.
+
+    Import and preview both need the same answer to "may this person look at
+    this assignment", so they share this. Raises rather than returning a flag so
+    a caller cannot forget to check.
+    """
+    from .course import fetch_instructor_courses
+
+    async with async_session() as session:
+        row = (
+            await session.execute(
+                select(Assignment, Courses)
+                .join(Courses, Assignment.course == Courses.id)
+                .where(Assignment.id == source_assignment_id)
+            )
+        ).first()
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assignment {source_assignment_id} not found",
+        )
+
+    assignment, source_course = row.Assignment, row.Courses
+
+    # The same three ways in that ``_visibility`` allows, asked of one row: the
+    # owning course offers its assignments, it belongs to a book (which has
+    # always been copyable), or the caller already instructs that course.
+    allowed = (
+        await course_shares_assignments(source_course.id)
+        or source_course.course_name == source_course.base_course
+        or bool(await fetch_instructor_courses(user_id, source_course.id))
+    )
+    if not allowed:
+        # 404 rather than 403: a private assignment should not confirm it exists.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assignment {source_assignment_id} not found",
+        )
+
+    return assignment, source_course
+
+
+async def fetch_assignment_for_preview(
+    source_assignment_id: int, user_id: int, target_course=None
+) -> dict:
+    """Summarize a shareable assignment without exposing question content.
+
+    Deliberately separate from ``GET /assignments/{id}``, which is scoped to the
+    caller's own course and should stay that way.
+    """
+    assignment, source_course = await _fetch_source_for_import(
+        source_assignment_id, user_id
+    )
+
+    async with async_session() as session:
+        rows = (
+            await session.execute(
+                select(AssignmentQuestion, Question)
+                .join(Question, AssignmentQuestion.question_id == Question.id)
+                .where(AssignmentQuestion.assignment_id == source_assignment_id)
+                .order_by(AssignmentQuestion.sorting_priority)
+            )
+        ).all()
+
+        library = (
+            (
+                await session.execute(
+                    select(Library).where(
+                        Library.basecourse == source_course.base_course
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+        sharing_description = (
+            await session.execute(
+                select(CourseAttribute.value).where(
+                    (CourseAttribute.course_id == source_course.id)
+                    & (CourseAttribute.attr == "sharing_description")
+                )
+            )
+        ).scalar()
+
+        existing_imports = await _existing_imports(
+            session,
+            [source_assignment_id],
+            target_course.id if target_course is not None else None,
+        )
+
+    duedate = assignment.duedate
+    if target_course is not None:
+        duedate = shift_duedate_between_courses(duedate, source_course, target_course)
+
+    cross_book = (
+        target_course is not None
+        and target_course.base_course != source_course.base_course
+    )
+    # Which rows import tells the instructor what they are getting before they
+    # commit to it, and is worked out the same way import_assignment does.
+    will_import = [
+        not (cross_book and _is_book_bound(row.AssignmentQuestion, row.Question))
+        for row in rows
+    ]
+
+    return {
+        "id": assignment.id,
+        "name": assignment.name,
+        "description": assignment.description,
+        "points": assignment.points,
+        "kind": assignment.kind,
+        "duedate": duedate,
+        "question_count": len(rows),
+        "course_name": source_course.course_name,
+        "base_course": source_course.base_course,
+        "book_title": library.title if library else source_course.base_course,
+        "institution": source_course.institution,
+        "is_official": _is_official(assignment, source_course),
+        "sharing_description": sharing_description or "",
+        # True when the source belongs to a different book than the target.
+        # Exercises still link across, but readings do not travel.
+        "is_cross_book": cross_book,
+        # A copy of this source already sits in the target course. Reported, not
+        # enforced -- re-importing to get a clean copy back is a real thing to
+        # want, so the decision belongs to the instructor looking at the warning.
+        "already_imported": source_assignment_id in existing_imports,
+        "imported_as": existing_imports.get(source_assignment_id),
+        "skipped_readings": will_import.count(False),
+        "questions": [
+            {
+                "id": row.Question.id,
+                "name": row.Question.name,
+                "question_type": row.Question.question_type,
+                "points": row.AssignmentQuestion.points,
+                "chapter": row.Question.chapter,
+                "subchapter": row.Question.subchapter,
+                "reading_assignment": row.AssignmentQuestion.reading_assignment,
+                "will_import": imported,
+            }
+            for row, imported in zip(rows, will_import)
+        ],
+    }
+
+
+async def import_assignment(
+    source_assignment_id: int,
+    target_course,
+    importing_user,
+) -> ImportedAssignment:
+    """Copy a shareable assignment from any course into ``target_course``.
+
+    Questions are linked, never copied, exactly as adding an exercise from
+    another course does. An exercise renders from its own stored HTML and is
+    identified everywhere -- in the DOM, in ``useinfo``, in grading -- by the
+    div id baked into that HTML, so a copy would have to rewrite the HTML to
+    stay coherent; a link needs nothing rewritten and leaves no duplicate
+    behind in the book when the imported assignment is deleted.
+
+    Readings are the exception when the books differ: a reading points at a
+    chapter and subchapter of its own book, which the importer's students are
+    not reading, so those rows are left behind rather than imported broken.
+
+    :param source_assignment_id: assignment being imported
+    :param target_course: course to import into, as a Courses row or validator
+    :param importing_user: the instructor performing the import
+    :return: the new assignment, its name, and how many readings were skipped
+    """
+    assignment, source_course = await _fetch_source_for_import(
+        source_assignment_id, importing_user.id
+    )
+
+    duedate = shift_duedate_between_courses(
+        assignment.duedate, source_course, target_course
+    )
+    is_timed, is_peer = _normalize_assignment_kind(
+        assignment.kind, assignment.is_timed, assignment.is_peer
+    )
+    cross_book = source_course.base_course != target_course.base_course
+
+    async with async_session.begin() as session:
+        existing_names = set(
+            (
+                await session.execute(
+                    select(Assignment.name).where(Assignment.course == target_course.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        new_name = unique_assignment_name(assignment.name, existing_names)
+
+        source_rows = (
+            await session.execute(
+                select(AssignmentQuestion, Question)
+                .join(Question, AssignmentQuestion.question_id == Question.id)
+                .where(AssignmentQuestion.assignment_id == source_assignment_id)
+                .order_by(AssignmentQuestion.sorting_priority)
+            )
+        ).all()
+
+        rows_to_import = [
+            row
+            for row in source_rows
+            if not (cross_book and _is_book_bound(row.AssignmentQuestion, row.Question))
+        ]
+        skipped_readings = len(source_rows) - len(rows_to_import)
+
+        new_assignment = Assignment(
+            course=target_course.id,
+            name=new_name,
+            duedate=duedate,
+            updated_date=canonical_utcnow(),
+            description=assignment.description,
+            # Recomputed rather than copied: skipping a reading changes the
+            # total, and fetch_one_assignment overwrites this with the sum of
+            # the question points anyway.
+            points=sum(row.AssignmentQuestion.points or 0 for row in rows_to_import),
+            threshold_pct=assignment.threshold_pct,
+            is_timed=is_timed,
+            is_peer=is_peer,
+            time_limit=assignment.time_limit,
+            from_source=False,
+            nofeedback=assignment.nofeedback,
+            nopause=assignment.nopause,
+            released=assignment.released,
+            # Hidden until the importer has looked it over, and not re-shared on
+            # their behalf -- sharing is a decision each owner makes themselves.
+            visible=False,
+            is_private=True,
+            allow_self_autograde=assignment.allow_self_autograde,
+            current_index=0,
+            enforce_due=assignment.enforce_due,
+            peer_async_visible=assignment.peer_async_visible,
+            kind=assignment.kind,
+            # The breadcrumb the import browser reads back to warn about a
+            # second import. Records the immediate source, so a copy of a copy
+            # points at the copy rather than at the original.
+            imported_from_assignment_id=source_assignment_id,
+        )
+        session.add(new_assignment)
+        await session.flush()
+
+        for row in rows_to_import:
+            source_aq = row.AssignmentQuestion
+
+            # Field by field rather than through copy_question, whose linking
+            # path looks the source row up under the *new* assignment id and so
+            # always falls back to its defaults. Here the points and grading
+            # settings the source author chose ride along with the exercise.
+            session.add(
+                AssignmentQuestion(
+                    assignment_id=new_assignment.id,
+                    question_id=source_aq.question_id,
+                    points=source_aq.points,
+                    timed=source_aq.timed,
+                    autograde=source_aq.autograde,
+                    which_to_grade=source_aq.which_to_grade,
+                    reading_assignment=source_aq.reading_assignment,
+                    sorting_priority=source_aq.sorting_priority,
+                    activities_required=source_aq.activities_required,
+                )
+            )
+
+        await session.flush()
+        result = AssignmentValidator.from_orm(new_assignment)
+
+    rslogger.info(
+        f"Imported assignment {source_assignment_id} from {source_course.course_name} "
+        f"into {target_course.course_name} as {result.id} ({new_name}) with "
+        f"{len(rows_to_import)} questions, {skipped_readings} readings skipped"
+    )
+    return ImportedAssignment(result, new_name, skipped_readings)
+
+
+class BulkImportResult(NamedTuple):
+    """What :func:`import_course_assignments` did, item by item.
+
+    Names rather than counts so a caller can show either. ``skipped_existing``
+    holds the source names that were passed over, which is the difference
+    between "that course only had two new ones" and "nothing happened".
+    """
+
+    imported: List[str]
+    skipped_existing: List[str]
+    skipped_readings: int
+    failed: List[str]
+
+
+async def import_course_assignments(
+    source_course_id: int,
+    target_course,
+    importing_user,
+    skip_existing: bool = True,
+) -> BulkImportResult:
+    """Import every importable assignment from one course into another.
+
+    The case the assignment-at-a-time browser serves badly: an instructor
+    picking up a colleague's whole semester, or starting from the book's
+    official set. Each assignment goes through :func:`import_assignment`, so
+    the sharing rules, name de-duplication, due-date shifting and cross-book
+    reading handling are the same as importing one by hand.
+
+    ``from_source`` assignments are left out. The book build regenerates those
+    from the book's own markup every time it runs, so a copy is a snapshot that
+    starts drifting immediately -- the older Copy Assignments page excluded them
+    from its "all assignments" option for the same reason.
+
+    Not one transaction. Each import commits on its own, so a failure partway
+    through leaves the ones that already worked in place and reports the rest;
+    for a bulk copy that beats rolling back thirty successful imports because
+    the thirty-first had a bad row.
+
+    :param source_course_id: course to take assignments from
+    :param target_course: course to import into, as a Courses row or validator
+    :param importing_user: the instructor performing the import
+    :param skip_existing: pass over assignments already imported into the target
+    :return: what was imported, skipped and failed
+    """
+    from .course import fetch_instructor_courses
+
+    if source_course_id == target_course.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot import a course's assignments into itself",
+        )
+
+    my_course_ids = [
+        ci.course for ci in await fetch_instructor_courses(importing_user.id)
+    ]
+
+    visibility = _visibility(my_course_ids)
+
+    async with async_session() as session:
+        source_course = (
+            (
+                await session.execute(
+                    select(Courses).where(Courses.id == source_course_id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+        if source_course is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Course {source_course_id} not found",
+            )
+
+        rows = (
+            (
+                await session.execute(
+                    select(Assignment)
+                    .join(Courses, Assignment.course == Courses.id)
+                    .where(
+                        (Courses.id == source_course_id)
+                        & visibility
+                        & (Assignment.from_source == False)  # noqa: E712
+                    )
+                    .order_by(Assignment.name)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        already_imported = await _existing_imports(
+            session, [row.id for row in rows], target_course.id
+        )
+
+    imported: List[str] = []
+    skipped_existing: List[str] = []
+    failed: List[str] = []
+    skipped_readings = 0
+
+    for source in rows:
+        if skip_existing and source.id in already_imported:
+            skipped_existing.append(source.name)
+            continue
+        try:
+            result = await import_assignment(
+                source_assignment_id=source.id,
+                target_course=target_course,
+                importing_user=importing_user,
+            )
+        except Exception as e:
+            # One bad assignment should not cost the instructor the other
+            # twenty-nine, so this records the failure and carries on.
+            rslogger.error(f"Bulk import skipped assignment {source.id}: {e}")
+            failed.append(source.name)
+            continue
+        imported.append(result.name)
+        skipped_readings += result.skipped_readings
+
+    rslogger.info(
+        f"Bulk imported {len(imported)} assignments from {source_course.course_name} "
+        f"into {target_course.course_name}; {len(skipped_existing)} already present, "
+        f"{len(failed)} failed, {skipped_readings} readings skipped"
+    )
+    return BulkImportResult(imported, skipped_existing, skipped_readings, failed)
+
+
+async def search_shareable_courses(
+    user_id: int,
+    search: str = "",
+    base_course: Optional[str] = None,
+    prefer_base_course: Optional[str] = None,
+    only_my_courses: bool = False,
+    exclude_course_id: Optional[int] = None,
+    page: int = 0,
+    limit: int = 20,
+) -> dict:
+    """List courses that have something an instructor could import.
+
+    Course-first browsing, for the case the assignment grid handles badly:
+    "give me what that course uses" rather than "find me one problem set". A
+    course only appears if at least one of its assignments passes the same
+    visibility rules :func:`search_assignments` applies, so nothing shows up
+    here that would turn out to be empty when opened.
+
+    :param user_id: id of the requesting instructor
+    :param search: matched against course name, institution and book title
+    :param base_course: restrict to one book
+    :param prefer_base_course: sort this book's own course to the very top,
+        normally the caller's book -- its official assignments are the answer
+        often enough to be worth not making anyone search for them
+    :param only_my_courses: restrict to courses the caller instructs
+    :param exclude_course_id: course to leave out, normally the caller's own
+    :return: dict with ``courses`` and ``pagination`` keys
+    """
+    from .course import fetch_instructor_courses
+
+    my_course_ids = [ci.course for ci in await fetch_instructor_courses(user_id)]
+
+    visibility = _visibility(my_course_ids)
+
+    query = (
+        select(
+            Courses.id,
+            Courses.course_name,
+            Courses.institution,
+            Courses.base_course,
+            Library.title,
+            func.count(Assignment.id).label("shareable_count"),
+        )
+        .join(Assignment, Assignment.course == Courses.id)
+        .outerjoin(Library, Courses.base_course == Library.basecourse)
+        # Same exclusion the assignment search and the bulk import apply, so
+        # the count here is what opening the course actually offers.
+        .where(visibility & (Assignment.from_source == False))  # noqa: E712
+        .group_by(
+            Courses.id,
+            Courses.course_name,
+            Courses.institution,
+            Courses.base_course,
+            Library.title,
+        )
+    )
+
+    if exclude_course_id is not None:
+        query = query.where(Courses.id != exclude_course_id)
+    if base_course:
+        query = query.where(Courses.base_course == base_course)
+    if only_my_courses:
+        query = query.where(Courses.id.in_(my_course_ids))
+
+    if search and search.strip():
+        # Every term must appear somewhere, so extra words narrow rather than
+        # widen -- the same rule the assignment search uses.
+        columns = [Courses.course_name, Courses.institution, Library.title]
+        for term in search.strip().split():
+            query = query.where(or_(*[col.ilike(f"%{term}%") for col in columns]))
+
+    # The caller's own book first; everything else alphabetically. Other books
+    # get no boost -- another book's official set is no more relevant to this
+    # instructor than a colleague's course, and putting every book on top buries
+    # the courses that actually share.
+    if prefer_base_course:
+        query = query.order_by(
+            case((Courses.course_name == prefer_base_course, 0), else_=1)
+        )
+    query = query.order_by(Courses.course_name)
+
+    count_query = select(func.count()).select_from(query.subquery())
+    page_query = query.offset(page * limit).limit(limit)
+
+    async with async_session() as session:
+        total_count = (await session.execute(count_query)).scalar() or 0
+        rows = (await session.execute(page_query)).all()
+
+    courses = [
+        {
+            "id": row.id,
+            "course_name": row.course_name,
+            "institution": row.institution,
+            "base_course": row.base_course,
+            "book_title": row.title or row.base_course,
+            "shareable_count": row.shareable_count,
+            "is_official": row.course_name == row.base_course,
+            "is_mine": row.id in my_course_ids,
+        }
+        for row in rows
+    ]
+
+    return {
+        "courses": courses,
+        "pagination": {
+            "total": total_count,
+            "page": page,
+            "limit": limit,
+            "pages": (total_count + limit - 1) // limit,
+        },
+    }
+
+
+async def fetch_shareable_assignment_tree(
+    user_id: int,
+    target_course=None,
+    search: str = "",
+    use_base_course: bool = False,
+    only_my_courses: bool = False,
+    page: int = 0,
+    limit: int = 20,
+) -> dict:
+    """Courses with the assignments each one offers, for the import tree.
+
+    The browser shows courses and expands them, so both levels arrive together
+    rather than a request per expansion. That is affordable because the page is
+    bounded by *courses*, not assignments: one extra query fetches the children
+    of every course on the page at once.
+
+    :param user_id: id of the requesting instructor
+    :param target_course: course being imported into; rows are marked with
+        whether they are already there and its book sorts first
+    :param search: matched against course name, institution and book title
+    :param use_base_course: restrict to courses on the target course's book
+    :param only_my_courses: restrict to courses the caller instructs
+    :return: dict with ``courses`` (each carrying ``assignments``) and
+        ``pagination`` keys
+    """
+    from .course import fetch_instructor_courses
+
+    result = await search_shareable_courses(
+        user_id=user_id,
+        search=search,
+        base_course=(
+            target_course.base_course if use_base_course and target_course else None
+        ),
+        prefer_base_course=target_course.base_course if target_course else None,
+        only_my_courses=only_my_courses,
+        exclude_course_id=target_course.id if target_course else None,
+        page=page,
+        limit=limit,
+    )
+
+    course_ids = [c["id"] for c in result["courses"]]
+    if not course_ids:
+        return result
+
+    my_course_ids = [ci.course for ci in await fetch_instructor_courses(user_id)]
+
+    async with async_session() as session:
+        rows = (
+            await session.execute(
+                select(Assignment, Courses)
+                .join(Courses, Assignment.course == Courses.id)
+                .where(
+                    Courses.id.in_(course_ids)
+                    & _visibility(my_course_ids)
+                    & (Assignment.from_source == False)  # noqa: E712
+                )
+                .order_by(Assignment.name)
+            )
+        ).all()
+
+        counts = {}
+        if rows:
+            count_rows = await session.execute(
+                select(
+                    AssignmentQuestion.assignment_id, func.count(AssignmentQuestion.id)
+                )
+                .where(
+                    AssignmentQuestion.assignment_id.in_(
+                        [r.Assignment.id for r in rows]
+                    )
+                )
+                .group_by(AssignmentQuestion.assignment_id)
+            )
+            counts = {aid: count for aid, count in count_rows.all()}
+
+        existing_imports = await _existing_imports(
+            session,
+            [r.Assignment.id for r in rows],
+            target_course.id if target_course else None,
+        )
+
+    by_course = {course_id: [] for course_id in course_ids}
+    for row in rows:
+        assignment, course = row.Assignment, row.Courses
+        by_course[course.id].append(
+            {
+                "id": assignment.id,
+                "name": assignment.name,
+                "description": assignment.description,
+                "points": assignment.points,
+                "kind": assignment.kind,
+                "question_count": counts.get(assignment.id, 0),
+                "is_official": _is_official(assignment, course),
+                "already_imported": assignment.id in existing_imports,
+                "imported_as": existing_imports.get(assignment.id),
+            }
+        )
+
+    for course in result["courses"]:
+        course["assignments"] = by_course.get(course["id"], [])
+
+    return result

--- a/components/rsptx/db/crud/assignment.py
+++ b/components/rsptx/db/crud/assignment.py
@@ -2286,6 +2286,18 @@ async def import_course_assignments(
                 detail=f"Course {source_course_id} not found",
             )
 
+        allowed = (
+            await session.execute(
+                select(visibility).where(Courses.id == source_course_id)
+            )
+        ).scalar()
+        if not allowed:
+            # 404 rather than 403: a private course should not confirm it exists.
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Course {source_course_id} not found",
+            )
+
         rows = (
             (
                 await session.execute(

--- a/components/rsptx/db/models.py
+++ b/components/rsptx/db/models.py
@@ -639,6 +639,9 @@ class Assignment(Base, IdMixin):
     __tablename__ = "assignments"
     __table_args__ = (
         Index("assignments_name_course_idx", "name", "course", unique=True),
+        # The import browser always asks "which rows in *this* course came from
+        # one of these source assignments", so the course leads the index.
+        Index("assignments_imported_from_idx", "course", "imported_from_assignment_id"),
     )
 
     course = Column(ForeignKey("courses.id", ondelete="CASCADE"), index=True)
@@ -663,6 +666,20 @@ class Assignment(Base, IdMixin):
     enforce_due = Column(Web2PyBoolean)
     peer_async_visible = Column(Web2PyBoolean, default=False)
     kind = Column(String(128))
+    # When False this assignment is discoverable and importable by instructors
+    # in other courses. Nullable with no Python-side default, matching
+    # ``Question.is_private``: the sharing predicate tests ``== False``, which
+    # in SQL does not match NULL, so an unset value stays private. Sharing is
+    # only ever an explicit act.
+    is_private = Column(Web2PyBoolean)
+    # The assignment this one was imported from, or NULL when it was authored
+    # here. Only a breadcrumb -- the import browser reads it to say "you already
+    # have this" -- so it is nullable and ON DELETE SET NULL. Deleting a source
+    # must not reach into the importer's course, and an import chain (A imported
+    # from B, C imported from A's copy) records only the immediate source.
+    imported_from_assignment_id = Column(
+        ForeignKey("assignments.id", ondelete="SET NULL"), nullable=True
+    )
 
     questions = relationship("AssignmentQuestion", cascade="all, delete-orphan")
 

--- a/components/rsptx/templates/admin/instructor/copy_assignments.html
+++ b/components/rsptx/templates/admin/instructor/copy_assignments.html
@@ -8,38 +8,53 @@
 
     <div class="page-header">
         <h1>Copy Assignments</h1>
-        <p>Copy assignments from other courses to your current course.</p>
+        <p>Copy assignments into your course from the book, from your other courses, or from any course whose instructor has shared them.</p>
     </div>
 
     <div class="row">
         <div class="col-md-8">
             <div class="card">
                 <div class="card-header">
-                    <h4 class="card-title">Select Source Course and Assignment</h4>
+                    <h4 class="card-title">1. Choose a course to copy from</h4>
                 </div>
                 <div class="card-body">
-                    <form id="copyAssignmentForm">
-                        <div class="form-group">
-                            <label for="courseSelection">Select the course you want to copy assignments from:</label>
-                            <select id="courseSelection" class="form-control" onchange="getAssignList(this)">
-                                <option value="">Select a Course</option>
-                                {% for course in instructor_course_list %}
-                                <option value="{{ course.course_name }}">{{ course.course_name }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
+                    <div class="form-group">
+                        <label for="courseSearch">Search courses:</label>
+                        <input type="text" id="courseSearch" class="form-control" autocomplete="off"
+                            placeholder="Course name, institution or book" aria-describedby="courseSearchHelp">
+                        <small id="courseSearchHelp" class="form-text text-muted">
+                            Official assignments for {{ base_course.course_name }} are listed first.
+                        </small>
+                    </div>
 
-                        <div class="form-group">
-                            <div id="assignSelection"></div>
-                        </div>
+                    <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="useBaseCourse">
+                        <label class="form-check-label" for="useBaseCourse">Only for this book</label>
+                    </div>
 
-                        <div class="form-group">
-                            <button type="button" onclick="copyAssignments()" class="btn btn-primary" id="copyButton"
-                                disabled>
-                                <i class="fas fa-copy"></i> Copy Assignment
-                            </button>
-                        </div>
-                    </form>
+                    <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="onlyMyCourses">
+                        <label class="form-check-label" for="onlyMyCourses">Only courses I teach</label>
+                    </div>
+
+                    <div id="courseResults" class="course-results" role="listbox"
+                        aria-label="Courses you can copy from"></div>
+                </div>
+            </div>
+
+            <div class="card" id="assignmentCard" hidden>
+                <div class="card-header">
+                    <h4 class="card-title">2. Choose what to copy</h4>
+                </div>
+                <div class="card-body">
+                    <div id="assignSelection" class="assignment-picker"></div>
+
+                    <div class="form-group">
+                        <button type="button" onclick="copyAssignments()" class="btn btn-primary" id="copyButton"
+                            disabled>
+                            <i class="fas fa-copy"></i> Copy
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -53,18 +68,18 @@
                     <div class="alert alert-info">
                         <h5><i class="fas fa-info-circle"></i> How to Copy Assignments</h5>
                         <ol>
-                            <li>Select a source course from the dropdown</li>
-                            <li>Choose which assignment to copy (or "All" for all assignments)</li>
-                            <li>Click "Copy Assignment" to copy to your current course</li>
+                            <li>Find the course you want to copy from</li>
+                            <li>Choose one assignment, or all of them</li>
+                            <li>Click "Copy"</li>
                         </ol>
                     </div>
 
                     <div class="alert alert-warning">
                         <h5><i class="fas fa-exclamation-triangle"></i> Important Notes</h5>
                         <ul>
-                            <li>Due dates will be adjusted based on your course term dates</li>
-                            <li>Assignment names must be unique in your course</li>
-                            <li>This action cannot be undone</li>
+                            <li>Copies start hidden, and are not shared onward until you say so</li>
+                            <li>Due dates shift to match your term</li>
+                            <li>Anything you have already copied is skipped, and marked below</li>
                         </ul>
                     </div>
                 </div>

--- a/components/rsptx/templates/admin/instructor/course_settings.html
+++ b/components/rsptx/templates/admin/instructor/course_settings.html
@@ -93,6 +93,30 @@ Course Settings
             </div>
 
             <div class="settingsbox">
+                <div class="checkbox-container">
+                    <input type="checkbox" id="share_assignments" {% if share_assignments=="true" %}checked{% endif %}
+                        onchange="updateCourse(this,'share_assignments')">
+                    <label for="share_assignments">Share This Course's Assignments</label>
+                </div>
+                <div class="setting-description">
+                    Let instructors in other courses find and import your assignments. This covers
+                    <strong>every</strong> assignment in the course, exams included, so leave it off if any
+                    of them should stay private. Importing never copies student work or grades, and the
+                    instructor who imports gets their own hidden copy.
+                </div>
+            </div>
+
+            <div class="settingsbox">
+                <label for="sharing_description">Note for Instructors Importing Your Assignments</label>
+                <textarea id="sharing_description" rows="4" maxlength="1000"
+                    onchange="updateCourse(this, 'sharing_description')">{{ sharing_description }}</textarea>
+                <div class="setting-description">
+                    Shown to instructors browsing your assignments. Use it to describe your problem sets
+                    &mdash; what they cover, how hard they are, anything worth knowing before importing one.
+                </div>
+            </div>
+
+            <div class="settingsbox">
                 <label for="timezone_select">Course Time Zone</label>
                 <select id="timezone_select" onchange="updateCourse(this,'timezone')"></select>
                 <div class="setting-description">

--- a/components/rsptx/templates/admin/instructor/menu.html
+++ b/components/rsptx/templates/admin/instructor/menu.html
@@ -40,7 +40,7 @@ Instructor Dashboard
                 </a>
                 <a href="/admin/instructor/copy_assignments" class="menu-item">
                     <h4>Copy Assignments</h4>
-                    <p>Copy assignments from previous courses</p>
+                    <p>Copy assignments from shared courses</p>
                 </a>
                 <a href="/runestone/admin/practice" class="menu-item">
                     <h4>Configure Practice</h4>

--- a/components/rsptx/templates/staticAssets/css/admin.css
+++ b/components/rsptx/templates/staticAssets/css/admin.css
@@ -755,6 +755,89 @@ tr.duplicate {
     color: #333;
 }
 
+/* Step 2's assignment picker is injected by JS, so the gap that keeps the Copy
+   button off the dropdown belongs on the container rather than on whichever
+   element the script happened to render last. Its label sits outside a
+   .form-group, so it needs the same treatment those labels get. */
+.copy-assignments .assignment-picker {
+    margin-bottom: 20px;
+}
+
+.copy-assignments .assignment-picker label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 500;
+    color: #333;
+}
+
+/* The source-course picker. Scrolls rather than paginates: it is a shortlist to
+   choose from, and searching is the way through a long one. */
+.copy-assignments .course-results {
+    margin-top: 15px;
+    max-height: 22rem;
+    overflow-y: auto;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+}
+
+.copy-assignments .course-row {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 14px;
+    background: none;
+    border: none;
+    border-bottom: 1px solid #eee;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+}
+
+.copy-assignments .course-row:last-child {
+    border-bottom: none;
+}
+
+.copy-assignments .course-row:hover,
+.copy-assignments .course-row:focus-visible {
+    background: #f4f8ff;
+}
+
+.copy-assignments .course-row.selected {
+    background: #e8f0fe;
+    box-shadow: inset 3px 0 0 #1a73e8;
+}
+
+.copy-assignments .course-row-title {
+    font-weight: 600;
+    color: #333;
+}
+
+/* Pushed to its own line so the course name and its badges stay together. */
+.copy-assignments .course-row-meta {
+    flex-basis: 100%;
+    font-size: 13px;
+    color: #666;
+}
+
+.copy-assignments .course-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 10px;
+}
+
+.copy-assignments .badge-primary {
+    background: #1a73e8;
+    color: #fff;
+}
+
+.copy-assignments .badge-secondary {
+    background: #e0e0e0;
+    color: #444;
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 768px) {
     .admin-page {

--- a/components/rsptx/templates/staticAssets/js/admin/copy_assignments.js
+++ b/components/rsptx/templates/staticAssets/js/admin/copy_assignments.js
@@ -1,98 +1,227 @@
-/* Copy assignments (admin/instructor/copy_assignments.html) */
+/* Copy assignments (admin/instructor/copy_assignments.html)
+ *
+ * Two steps: pick a source course, then pick one assignment or all of them.
+ * The course list is fetched rather than rendered into a <select> because it
+ * now spans every course that shares something, not just the instructor's own.
+ */
 
-// Populate the assignment dropdown when a source course is selected
-async function getAssignList(sel) {
-    const container = document.getElementById("assignSelection");
-    const copyButton = document.getElementById("copyButton");
-    container.innerHTML = ""; // Clear the entire container
-    copyButton.disabled = true;
+const SEARCH_DEBOUNCE_MS = 300;
 
-    if (!sel.value) {
-        return;
-    }
+let selectedCourse = null;
+let searchTimer = null;
+
+function debounce(fn, ms) {
+    return function (...args) {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(() => fn(...args), ms);
+    };
+}
+
+function badge(text, kind) {
+    const span = document.createElement("span");
+    span.className = `badge badge-${kind} course-badge`;
+    span.textContent = text;
+    return span;
+}
+
+// --- Step 1: courses -------------------------------------------------------
+
+async function loadCourses() {
+    const results = document.getElementById("courseResults");
+    const params = new URLSearchParams({
+        search: document.getElementById("courseSearch").value,
+        use_base_course: document.getElementById("useBaseCourse").checked,
+        only_my_courses: document.getElementById("onlyMyCourses").checked,
+        limit: 25,
+    });
+
+    results.setAttribute("aria-busy", "true");
 
     let data;
     try {
-        const params = new URLSearchParams({ course_name: sel.value });
-        const response = await fetch(
-            `/admin/instructor/source_assignments?${params}`
-        );
+        const response = await fetch(`/admin/instructor/shareable_courses?${params}`);
         if (!response.ok) {
             throw new Error(response.statusText);
         }
         data = await response.json();
     } catch (error) {
-        showMessage("Failed to load assignments for selected course", "error");
+        results.removeAttribute("aria-busy");
+        showMessage("Could not load the list of courses", "error");
+        return;
+    }
+
+    results.removeAttribute("aria-busy");
+    results.innerHTML = "";
+
+    if (!data.courses.length) {
+        const empty = document.createElement("p");
+        empty.className = "text-muted";
+        empty.textContent = "No courses match that search.";
+        results.appendChild(empty);
+        return;
+    }
+
+    for (const course of data.courses) {
+        results.appendChild(courseRow(course));
+    }
+}
+
+function courseRow(course) {
+    // A real button so the list is reachable from the keyboard; the rows are a
+    // listbox, not a set of links.
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "course-row";
+    row.setAttribute("role", "option");
+    row.setAttribute("aria-selected", "false");
+    row.onclick = () => selectCourse(course, row);
+
+    const title = document.createElement("span");
+    title.className = "course-row-title";
+    title.textContent = course.course_name;
+    row.appendChild(title);
+
+    if (course.is_official) {
+        row.appendChild(badge("Official", "primary"));
+    }
+    if (course.is_mine) {
+        row.appendChild(badge("Yours", "secondary"));
+    }
+
+    const meta = document.createElement("span");
+    meta.className = "course-row-meta";
+    const where = course.is_official
+        ? course.book_title
+        : [course.institution, course.book_title].filter(Boolean).join(" · ");
+    const count = course.shareable_count;
+    meta.textContent = `${where} — ${count} assignment${count === 1 ? "" : "s"}`;
+    row.appendChild(meta);
+
+    return row;
+}
+
+function selectCourse(course, row) {
+    selectedCourse = course;
+
+    for (const other of document.querySelectorAll(".course-row")) {
+        other.classList.toggle("selected", other === row);
+        other.setAttribute("aria-selected", String(other === row));
+    }
+
+    loadAssignments(course);
+}
+
+// --- Step 2: assignments ---------------------------------------------------
+
+async function loadAssignments(course) {
+    const card = document.getElementById("assignmentCard");
+    const container = document.getElementById("assignSelection");
+    const copyButton = document.getElementById("copyButton");
+
+    card.hidden = false;
+    container.innerHTML = "";
+    copyButton.disabled = true;
+
+    let data;
+    try {
+        const params = new URLSearchParams({ course_name: course.course_name });
+        const response = await fetch(`/admin/instructor/source_assignments?${params}`);
+        if (!response.ok) {
+            throw new Error(response.statusText);
+        }
+        data = await response.json();
+    } catch (error) {
+        showMessage("Failed to load assignments for that course", "error");
+        return;
+    }
+
+    if (!data.assignments.length) {
+        const empty = document.createElement("p");
+        empty.className = "text-muted";
+        empty.textContent = "That course has nothing you can copy.";
+        container.appendChild(empty);
         return;
     }
 
     const label = document.createElement("label");
-    label.textContent = "Select assignment to copy:";
+    label.textContent = "Select what to copy:";
     label.setAttribute("for", "assignmentsDropdown");
     container.appendChild(label);
 
     const dropdown = document.createElement("select");
     dropdown.classList.add("form-control");
     dropdown.id = "assignmentsDropdown";
-    dropdown.onchange = function () {
-        copyButton.disabled = false;
-    };
 
-    // Add "All" option, selected by default
+    // Bulk is the common case and the reason to use this page rather than the
+    // assignment browser, so it leads and is selected by default.
+    const newCount = data.assignments.filter((a) => !a.already_imported).length;
     const allOpt = document.createElement("option");
-    allOpt.value = -1;
-    allOpt.text = "All Assignments";
+
+    allOpt.value = "";
+    allOpt.text =
+        newCount === data.assignments.length
+            ? `All assignments (${newCount})`
+            : `All assignments (${newCount} new, ${
+                  data.assignments.length - newCount
+              } already copied)`;
     allOpt.selected = true;
     dropdown.appendChild(allOpt);
 
     for (const assign of data.assignments) {
         const opt = document.createElement("option");
         opt.value = assign.id;
-        opt.text = assign.name;
+        opt.text = assign.already_imported
+            ? `${assign.name} — already copied as "${assign.imported_as}"`
+            : assign.name;
         dropdown.appendChild(opt);
     }
 
     container.appendChild(dropdown);
 
-    // Enable the copy button since "All Assignments" is selected by default
+    if (data.truncated) {
+        const note = document.createElement("small");
+        note.className = "form-text text-muted";
+        note.textContent =
+            "This course has more assignments than are listed. \"All assignments\" still copies every one of them.";
+        container.appendChild(note);
+    }
+
     copyButton.disabled = false;
 }
 
 async function copyAssignments() {
-    const selectedCourse = document.getElementById("courseSelection").value;
-    let selectedAssignment = document.getElementById("assignmentsDropdown");
+    const dropdown = document.getElementById("assignmentsDropdown");
 
-    if (!selectedCourse || !selectedAssignment) {
-        showMessage("Please select both a course and an assignment", "error");
+    if (!selectedCourse || !dropdown) {
+        showMessage("Pick a course and an assignment first", "error");
         return;
     }
 
-    selectedAssignment =
-        selectedAssignment.options[selectedAssignment.selectedIndex].value;
-
-    // Show loading state
+    const chosen = dropdown.options[dropdown.selectedIndex].value;
     const copyButton = document.getElementById("copyButton");
+
     copyButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Copying...';
     copyButton.disabled = true;
 
     try {
         const data = await postJSON("/admin/instructor/copy_assignment", {
-            oldassignment: selectedAssignment,
-            course: selectedCourse,
+            source_course_id: selectedCourse.id,
+            // "" is the All option; the endpoint reads a missing id as "all".
+            assignment_id: chosen === "" ? null : Number(chosen),
         });
         if (data.success) {
-            showMessage("Assignment(s) copied successfully!", "success");
-            // Reset form
-            document.getElementById("courseSelection").value = "";
-            document.getElementById("assignSelection").innerHTML = "";
+            showMessage(data.message, "success");
+            // Reload the list so what just came across shows as already copied
+            // rather than inviting a second pass.
+            await loadAssignments(selectedCourse);
         } else {
-            showMessage(`Copy Failed: ${data.message}`, "error");
+            showMessage(`Copy failed: ${data.message}`, "error");
         }
     } catch (error) {
         showMessage("Copy failed due to server error", "error");
     } finally {
-        copyButton.innerHTML = '<i class="fas fa-copy"></i> Copy Assignment';
-        copyButton.disabled = true;
+        copyButton.innerHTML = '<i class="fas fa-copy"></i> Copy';
+        copyButton.disabled = false;
     }
 }
 
@@ -103,17 +232,43 @@ function showMessage(message, type) {
         type === "success" ? "fas fa-check-circle" : "fas fa-exclamation-circle";
 
     const container = document.getElementById("messageContainer");
-    container.innerHTML = `
-        <div class="alert ${alertClass} alert-dismissible" role="alert">
-            <i class="${icon}"></i> ${message}
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-    `;
+    const alert = document.createElement("div");
 
-    // Auto-dismiss after 5 seconds
+    alert.className = `alert ${alertClass} alert-dismissible`;
+    alert.setAttribute("role", "alert");
+
+    const iconEl = document.createElement("i");
+    iconEl.className = icon;
+    alert.appendChild(iconEl);
+    // Text node rather than innerHTML: the message carries assignment names
+    // that came from another instructor's course.
+    alert.appendChild(document.createTextNode(` ${message}`));
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "close";
+    close.setAttribute("data-dismiss", "alert");
+    close.setAttribute("aria-label", "Close");
+    close.innerHTML = '<span aria-hidden="true">&times;</span>';
+    alert.appendChild(close);
+
+    container.innerHTML = "";
+    container.appendChild(alert);
+
     setTimeout(function () {
         container.innerHTML = "";
-    }, 5000);
+    }, 8000);
 }
+
+document.addEventListener("DOMContentLoaded", function () {
+    document
+        .getElementById("courseSearch")
+        .addEventListener("input", debounce(loadCourses, SEARCH_DEBOUNCE_MS));
+    document
+        .getElementById("useBaseCourse")
+        .addEventListener("change", loadCourses);
+    document
+        .getElementById("onlyMyCourses")
+        .addEventListener("change", loadCourses);
+    loadCourses();
+});

--- a/components/rsptx/validation/schemas.py
+++ b/components/rsptx/validation/schemas.py
@@ -305,6 +305,37 @@ class ExercisesSearchRequest(BaseModel):
     filters: Dict[str, Any] = Field(default_factory=dict)
 
 
+class AssignmentsSearchRequest(BaseModel):
+    """Request model for browsing shareable assignments from other courses"""
+
+    # When true the search is limited to the caller's own book; when false it
+    # spans every book on the platform.
+    use_base_course: bool = False
+    base_course: Optional[str] = None
+
+    # When true, only assignments from courses the caller instructs. Independent
+    # of the book filter -- an instructor may teach several courses on different
+    # books -- so the two narrow the results together.
+    only_my_courses: bool = False
+
+    # Pagination. ``limit`` is bounded on both ends: zero would make the page
+    # count divide by zero, and an unbounded value invites a huge scan.
+    page: int = Field(default=0, ge=0)
+    limit: int = Field(default=20, ge=1, le=100)
+
+    # Sorting
+    sorting: Dict[str, Any] = Field(
+        default_factory=lambda: {"field": "name", "order": 1}
+    )
+
+    # Filters keyed by column name. Each value is a dict of the shape
+    # {"value": <term>, "matchMode": "contains"}; the key "global" searches
+    # assignment name/description, course name and book title at once.
+    # Recognized keys beyond the Assignment columns: course_name, institution,
+    # base_course, book_title.
+    filters: Dict[str, Any] = Field(default_factory=dict)
+
+
 class ScoringSpecification(BaseModel):
     assigned: bool = False
     score: Optional[Union[int, float]] = None

--- a/migrations/versions/e7a3c9d1f4b2_add_is_private_to_assignments.py
+++ b/migrations/versions/e7a3c9d1f4b2_add_is_private_to_assignments.py
@@ -1,0 +1,42 @@
+"""add is_private to assignments
+
+Marks whether an assignment may be discovered and imported by instructors
+outside the course that owns it. Existing assignments were authored with no
+expectation of being visible elsewhere, so they all become private and sharing
+is only ever an explicit act.
+
+Revision ID: e7a3c9d1f4b2
+Revises: c4e8a1f7b2d9
+Create Date: 2026-08-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e7a3c9d1f4b2'
+down_revision: Union[str, None] = 'c4e8a1f7b2d9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'assignments',
+        sa.Column(
+            'is_private',
+            sa.CHAR(length=1),
+            nullable=True,
+            server_default=sa.text("'T'"),
+        ),
+    )
+    # Backfill rather than constrain: the column stays nullable to match
+    # questions.is_private, and the sharing predicate tests `is_private = 'F'`,
+    # which no NULL row satisfies. An unset value is therefore private.
+    op.execute("UPDATE assignments SET is_private = 'T' WHERE is_private IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column('assignments', 'is_private')

--- a/migrations/versions/f3b8d5c2a710_add_imported_from_to_assignments.py
+++ b/migrations/versions/f3b8d5c2a710_add_imported_from_to_assignments.py
@@ -1,0 +1,59 @@
+"""add imported_from_assignment_id to assignments
+
+Records which assignment an imported copy came from, so the import browser can
+tell an instructor they already have a copy rather than letting them import the
+same thing twice without noticing. Assignments that predate this column were
+authored in place or copied by the old admin page, neither of which left a
+trail, so they stay NULL.
+
+Revision ID: f3b8d5c2a710
+Revises: e7a3c9d1f4b2
+Create Date: 2026-08-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'f3b8d5c2a710'
+down_revision: Union[str, None] = 'e7a3c9d1f4b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'assignments',
+        sa.Column('imported_from_assignment_id', sa.Integer(), nullable=True),
+    )
+    # ON DELETE SET NULL, not CASCADE: this is a breadcrumb, and deleting the
+    # source assignment must never reach into another instructor's course and
+    # delete their copy. Losing the breadcrumb is the correct fallout -- a
+    # source that no longer exists cannot be offered for import again anyway.
+    op.create_foreign_key(
+        'assignments_imported_from_assignment_id_fkey',
+        'assignments',
+        'assignments',
+        ['imported_from_assignment_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+    # The lookup is always "which rows in *this* course came from one of these
+    # source ids", so the index carries the course alongside the source.
+    op.create_index(
+        'assignments_imported_from_idx',
+        'assignments',
+        ['course', 'imported_from_assignment_id'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('assignments_imported_from_idx', table_name='assignments')
+    op.drop_constraint(
+        'assignments_imported_from_assignment_id_fkey',
+        'assignments',
+        type_='foreignkey',
+    )
+    op.drop_column('assignments', 'imported_from_assignment_id')

--- a/test/bases/rsptx/admin_server_api/conftest.py
+++ b/test/bases/rsptx/admin_server_api/conftest.py
@@ -5,6 +5,9 @@ Admin-server-specific test fixtures.
                            ``overview`` base course.
 ``auth_editor_client``   — auth_manager patched to return that editor.
 ``auth_noneditor_client``— authenticated as testuser1, who is not an editor.
+``admin_instructor_user``— an instructor of a course of their own, for the
+                           instructor pages (Copy Assignments and friends).
+``auth_admin_instructor_client`` — auth_manager patched to return them.
 
 Routes decorated with @editor_role_required() call auth_manager() directly
 inside the decorator -- not via FastAPI's Depends() -- so the clients patch
@@ -62,6 +65,78 @@ async def editor_user(init_test_db):
     await create_membership(group.id, user.id)
     await create_editor_for_basecourse(user.id, "overview")
     return user
+
+
+@pytest_asyncio.fixture(scope="session")
+async def admin_instructor_user(init_test_db):
+    """An instructor with a course of their own to copy assignments into.
+
+    Its own course rather than a shared one: the copy endpoints leave the
+    caller's current course out of every list, so a course another test is also
+    writing assignments into would make those lists depend on test order.
+    """
+    from rsptx.db.crud import (
+        create_course,
+        create_course_instructor,
+        create_user,
+        fetch_course,
+        fetch_user,
+    )
+    from rsptx.db.models import AuthUserValidator, CoursesValidator
+
+    existing = await fetch_user("test_admin_instructor")
+    if existing:
+        return existing
+
+    if not await fetch_course("admin_copy_target"):
+        await create_course(
+            CoursesValidator(
+                course_name="admin_copy_target",
+                base_course="overview",
+                term_start_date=datetime.date(2026, 8, 24),
+                login_required=False,
+                allow_pairs=False,
+                downloads_enabled=False,
+                courselevel="",
+                institution="Copy Test University",
+                new_server=True,
+            )
+        )
+    course = await fetch_course("admin_copy_target")
+
+    user = await create_user(
+        AuthUserValidator(
+            username="test_admin_instructor",
+            first_name="Test",
+            last_name="Instructor",
+            password="xxx",
+            email="test_admin_instructor@example.com",
+            course_name="admin_copy_target",
+            course_id=course.id,
+            donated=True,
+            active=True,
+            accept_tcp=True,
+            created_on=datetime.datetime(2020, 1, 1),
+            modified_on=datetime.datetime(2020, 1, 1),
+            registration_key="",
+            registration_id="",
+            reset_password_key="",
+        )
+    )
+    await create_course_instructor(course.id, user.id)
+    return user
+
+
+@pytest_asyncio.fixture
+async def auth_admin_instructor_client(admin_instructor_user):
+    """Async HTTP client for the admin server authenticated as an instructor."""
+    app, auth_manager, mock_auth, transport = _client_for(admin_instructor_user)
+    with patch("rsptx.endpoint_validators.core.auth_manager", mock_auth):
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            yield client
+    app.dependency_overrides.pop(auth_manager, None)
 
 
 def _client_for(user):

--- a/test/bases/rsptx/admin_server_api/test_copy_assignments_routes.py
+++ b/test/bases/rsptx/admin_server_api/test_copy_assignments_routes.py
@@ -1,0 +1,259 @@
+"""
+Routes behind the Copy Assignments page.
+
+The page used to copy rows itself, from a dropdown limited to the instructor's
+own courses on the same book. It now delegates to the shared ``import_assignment``
+and can take from any course that shares something, so these cover the two
+things that changed: which courses are on offer, and what copying actually does.
+"""
+
+import datetime
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+from rsptx.db.crud import (  # noqa: E402
+    create_assignment,
+    create_course,
+    create_course_attribute,
+    create_course_instructor,
+    fetch_course,
+)
+from rsptx.db.models import AssignmentValidator, CoursesValidator  # noqa: E402
+
+SOURCE_COURSE = "admin_copy_source"
+
+
+async def _assignment(course_id, name, is_private=False, from_source=False):
+    return await create_assignment(
+        AssignmentValidator(
+            course=course_id,
+            name=name,
+            points=10,
+            released=False,
+            description="copy route test assignment",
+            duedate=datetime.datetime(2099, 1, 1),
+            visible=True,
+            from_source=from_source,
+            is_peer=False,
+            is_timed=False,
+            current_index=0,
+            peer_async_visible=False,
+            kind="Regular",
+            is_private=is_private,
+        )
+    )
+
+
+@pytest.fixture(scope="session")
+async def copy_source_course(admin_instructor_user):
+    """A course the caller does not instruct, which has opted in to sharing."""
+    existing = await fetch_course(SOURCE_COURSE)
+    if existing:
+        return existing
+
+    await create_course(
+        CoursesValidator(
+            course_name=SOURCE_COURSE,
+            base_course="overview",
+            term_start_date=datetime.date(2026, 1, 12),
+            login_required=False,
+            allow_pairs=False,
+            downloads_enabled=False,
+            courselevel="",
+            institution="Sharing University",
+            new_server=True,
+        )
+    )
+    course = await fetch_course(SOURCE_COURSE)
+    await create_course_attribute(course.id, "share_assignments", "true")
+    await _assignment(course.id, "copy_shared_one")
+    await _assignment(course.id, "copy_shared_two")
+    return course
+
+
+@pytest.fixture(scope="session")
+async def closed_source_course(admin_instructor_user):
+    """A course that never opted in. Opting in covers a whole course, so the
+    unshared case needs a course of its own."""
+    existing = await fetch_course("admin_copy_closed")
+    if existing:
+        return existing
+
+    await create_course(
+        CoursesValidator(
+            course_name="admin_copy_closed",
+            base_course="overview",
+            term_start_date=datetime.date(2026, 1, 12),
+            login_required=False,
+            allow_pairs=False,
+            downloads_enabled=False,
+            courselevel="",
+            institution="Private University",
+            new_server=True,
+        )
+    )
+    course = await fetch_course("admin_copy_closed")
+    await _assignment(course.id, "copy_secret", is_private=True)
+    return course
+
+
+@pytest.fixture(scope="session")
+async def other_instructor_course(admin_instructor_user):
+    """A second course the caller does instruct, for the "only mine" filter."""
+    existing = await fetch_course("admin_copy_mine")
+    if existing:
+        return existing
+
+    await create_course(
+        CoursesValidator(
+            course_name="admin_copy_mine",
+            base_course="overview",
+            term_start_date=datetime.date(2026, 1, 12),
+            login_required=False,
+            allow_pairs=False,
+            downloads_enabled=False,
+            courselevel="",
+            institution="Copy Test University",
+            new_server=True,
+        )
+    )
+    course = await fetch_course("admin_copy_mine")
+    await create_course_instructor(course.id, admin_instructor_user.id)
+    await _assignment(course.id, "copy_my_own_hw", is_private=True)
+    return course
+
+
+# The source-course picker
+# ------------------------
+
+
+async def test_shareable_courses_lists_a_course_the_caller_does_not_teach(
+    auth_admin_instructor_client, copy_source_course
+):
+    """The change that makes this page more than a re-run of last term.
+
+    The old dropdown only offered the base course and the instructor's own
+    courses on the same book.
+    """
+    resp = await auth_admin_instructor_client.get("/instructor/shareable_courses")
+    assert resp.status_code == 200
+    names = [c["course_name"] for c in resp.json()["courses"]]
+    assert SOURCE_COURSE in names
+
+
+async def test_shareable_courses_counts_only_shared_assignments(
+    auth_admin_instructor_client, copy_source_course
+):
+    resp = await auth_admin_instructor_client.get("/instructor/shareable_courses")
+    row = next(
+        c for c in resp.json()["courses"] if c["course_name"] == SOURCE_COURSE
+    )
+    assert row["shareable_count"] == 2
+    assert row["is_mine"] is False
+
+
+async def test_shareable_courses_can_be_limited_to_my_own(
+    auth_admin_instructor_client, copy_source_course, other_instructor_course
+):
+    resp = await auth_admin_instructor_client.get(
+        "/instructor/shareable_courses", params={"only_my_courses": True}
+    )
+    assert resp.status_code == 200
+    names = [c["course_name"] for c in resp.json()["courses"]]
+    assert "admin_copy_mine" in names
+    assert SOURCE_COURSE not in names
+
+
+async def test_source_assignments_hides_a_course_that_has_not_opted_in(
+    auth_admin_instructor_client, copy_source_course, closed_source_course
+):
+    """Same visibility rules as the assignment browser, so this page cannot be
+    the softer way in."""
+    resp = await auth_admin_instructor_client.get(
+        "/instructor/source_assignments",
+        params={"course_name": SOURCE_COURSE},
+    )
+    assert resp.status_code == 200
+    names = [a["name"] for a in resp.json()["assignments"]]
+    assert sorted(names) == ["copy_shared_one", "copy_shared_two"]
+
+    closed = await auth_admin_instructor_client.get(
+        "/instructor/source_assignments",
+        params={"course_name": "admin_copy_closed"},
+    )
+    assert closed.json()["assignments"] == []
+
+
+async def test_source_assignments_refuses_the_callers_own_course(
+    auth_admin_instructor_client,
+):
+    resp = await auth_admin_instructor_client.get(
+        "/instructor/source_assignments",
+        params={"course_name": "admin_copy_target"},
+    )
+    assert resp.status_code == 400
+
+
+# Copying
+# -------
+
+
+async def test_copy_all_takes_every_shared_assignment(
+    auth_admin_instructor_client, copy_source_course
+):
+    resp = await auth_admin_instructor_client.post(
+        "/instructor/copy_assignment",
+        json={"source_course_id": copy_source_course.id},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    assert sorted(body["imported"]) == ["copy_shared_one", "copy_shared_two"]
+    assert body["failed"] == []
+
+
+async def test_copying_again_skips_what_is_already_there(
+    auth_admin_instructor_client, copy_source_course
+):
+    """Runs after the bulk copy above, which is the point: a second pass over
+    the same course should be a no-op rather than a duplicate set."""
+    resp = await auth_admin_instructor_client.post(
+        "/instructor/copy_assignment",
+        json={"source_course_id": copy_source_course.id},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["imported"] == []
+    assert sorted(body["skipped_existing"]) == ["copy_shared_one", "copy_shared_two"]
+
+
+async def test_source_assignments_marks_what_was_already_copied(
+    auth_admin_instructor_client, copy_source_course
+):
+    resp = await auth_admin_instructor_client.get(
+        "/instructor/source_assignments",
+        params={"course_name": SOURCE_COURSE},
+    )
+    rows = resp.json()["assignments"]
+    assert all(row["already_imported"] for row in rows)
+    assert all(row["imported_as"] for row in rows)
+
+
+async def test_copying_from_a_course_that_has_not_opted_in_is_refused(
+    auth_admin_instructor_client, closed_source_course
+):
+    """The old endpoint checked instructor access on the course; this one goes
+    through import_assignment, which asks whether the course shares at all."""
+    from rsptx.db.crud import fetch_assignments
+
+    assignments = await fetch_assignments("admin_copy_closed", fetch_all=True)
+    private = next(a for a in assignments if a.name == "copy_secret")
+
+    resp = await auth_admin_instructor_client.post(
+        "/instructor/copy_assignment",
+        json={"source_course_id": closed_source_course.id, "assignment_id": private.id},
+    )
+    # 404 rather than 403, so the response does not confirm it exists.
+    assert resp.status_code == 404
+    assert resp.json()["success"] is False

--- a/test/bases/rsptx/assignment_server_api/test_instructor_routes.py
+++ b/test/bases/rsptx/assignment_server_api/test_instructor_routes.py
@@ -409,3 +409,386 @@ async def test_student_scores_rejects_non_instructor(
         params={"username": "scored_student"},
     )
     assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Cross-course assignment sharing and import
+# ---------------------------------------------------------------------------
+
+
+async def _add_shareable_assignment(course_id, name, is_private):
+    return await create_assignment(
+        AssignmentValidator(
+            course=course_id,
+            name=name,
+            points=10,
+            released=False,
+            description="sharing route test assignment",
+            duedate=datetime.datetime(2099, 1, 1),
+            visible=True,
+            from_source=False,
+            is_peer=False,
+            current_index=0,
+            peer_async_visible=False,
+            kind="Regular",
+            is_private=is_private,
+        )
+    )
+
+
+@pytest.fixture(scope="session")
+async def foreign_course(instructor_user):
+    """A course the caller does not instruct, derived from a book.
+
+    Deliberately not a base course: assignments that live directly on a book
+    row have always been copyable by anyone, so one of those would pass the
+    authorization check for a reason unrelated to the sharing flag.
+    """
+    from rsptx.db.crud import create_course, create_course_attribute
+    from rsptx.db.models import CoursesValidator
+
+    existing = await fetch_course("route_foreign_course")
+    if existing:
+        return existing
+
+    await create_course(
+        CoursesValidator(
+            course_name="route_foreign_course",
+            base_course="overview",
+            term_start_date=datetime.date(2026, 1, 1),
+            login_required=False,
+            allow_pairs=False,
+            downloads_enabled=False,
+            courselevel="",
+            institution="Other University",
+            new_server=True,
+        )
+    )
+    course = await fetch_course("route_foreign_course")
+    await create_course_attribute(course.id, "share_assignments", "true")
+    return course
+
+
+@pytest.fixture(scope="session")
+async def foreign_shared_assignment(foreign_course):
+    """A shareable assignment in a course the caller does not instruct."""
+    return await _add_shareable_assignment(foreign_course.id, "route_shared_hw", False)
+
+
+@pytest.fixture(scope="session")
+async def closed_foreign_course(instructor_user):
+    """A foreign course that never opted in to sharing."""
+    from rsptx.db.crud import create_course
+    from rsptx.db.models import CoursesValidator
+
+    existing = await fetch_course("route_closed_course")
+    if existing:
+        return existing
+
+    await create_course(
+        CoursesValidator(
+            course_name="route_closed_course",
+            base_course="overview",
+            term_start_date=datetime.date(2026, 1, 1),
+            login_required=False,
+            allow_pairs=False,
+            downloads_enabled=False,
+            courselevel="",
+            institution="Other University",
+            new_server=True,
+        )
+    )
+    return await fetch_course("route_closed_course")
+
+
+@pytest.fixture(scope="session")
+async def foreign_private_assignment(closed_foreign_course):
+    """An assignment in a course that has not opted in to sharing.
+
+    Its own course rather than the shared one: opting in covers every assignment
+    in a course, so a single course cannot hold both cases.
+    """
+    return await _add_shareable_assignment(
+        closed_foreign_course.id, "route_private_hw", True
+    )
+
+
+@pytest.fixture(scope="session")
+async def base_course_private_assignment(instructor_user):
+    """A private assignment sitting directly on a book row."""
+    course = await fetch_course("overview")
+    return await _add_shareable_assignment(course.id, "route_book_private_hw", True)
+
+
+async def test_search_lists_a_shared_foreign_assignment(
+    auth_instructor_client, foreign_shared_assignment
+):
+    resp = await auth_instructor_client.post(
+        "/instructor/assignments/search", json={"page": 0, "limit": 50}
+    )
+    assert resp.status_code == 200
+    names = [a["name"] for a in resp.json()["detail"]["assignments"]]
+    assert "route_shared_hw" in names
+
+
+async def test_search_omits_a_course_that_has_not_opted_in(
+    auth_instructor_client, foreign_private_assignment
+):
+    """Sharing is off until a course turns it on."""
+    resp = await auth_instructor_client.post(
+        "/instructor/assignments/search", json={"page": 0, "limit": 50}
+    )
+    assert resp.status_code == 200
+    names = [a["name"] for a in resp.json()["detail"]["assignments"]]
+    assert "route_private_hw" not in names
+
+
+async def test_search_can_be_limited_to_the_callers_own_courses(
+    auth_instructor_client, foreign_shared_assignment
+):
+    """test_instructor teaches only the course being imported into.
+
+    Search already leaves that one out, so narrowing to their own courses has
+    to leave nothing -- and in particular must not fall back to showing
+    everything, which is how an empty "my courses" list could go wrong.
+    """
+    wide = await auth_instructor_client.post(
+        "/instructor/assignments/search", json={"page": 0, "limit": 50}
+    )
+    assert "route_shared_hw" in [a["name"] for a in wide.json()["detail"]["assignments"]]
+
+    narrowed = await auth_instructor_client.post(
+        "/instructor/assignments/search",
+        json={"page": 0, "limit": 50, "only_my_courses": True},
+    )
+    assert narrowed.status_code == 200
+    assert narrowed.json()["detail"]["assignments"] == []
+
+
+async def test_search_marks_an_assignment_the_caller_already_imported(
+    auth_instructor_client, foreign_course
+):
+    """Its own assignment, not the shared fixture, so test order cannot decide
+    whether the "before" case has already been imported."""
+    assignment = await _add_shareable_assignment(
+        foreign_course.id, "route_reimport_hw", False
+    )
+
+    async def search_row():
+        resp = await auth_instructor_client.post(
+            "/instructor/assignments/search",
+            json={
+                "page": 0,
+                "limit": 50,
+                "filters": {
+                    "name": {"value": "route_reimport_hw", "matchMode": "equals"}
+                },
+            },
+        )
+        assert resp.status_code == 200
+        return resp.json()["detail"]["assignments"][0]
+
+    assert (await search_row())["already_imported"] is False
+
+    imported = await auth_instructor_client.post(
+        f"/instructor/assignments/{assignment.id}/import"
+    )
+    assert imported.status_code == 201
+
+    row = await search_row()
+    assert row["already_imported"] is True
+    assert row["imported_as"] == imported.json()["detail"]["name"]
+
+
+async def test_search_lists_a_books_own_assignment(
+    auth_instructor_client, base_course_private_assignment
+):
+    """Official material needs no sharing flag, and says so in the row."""
+    resp = await auth_instructor_client.post(
+        "/instructor/assignments/search",
+        json={
+            "page": 0,
+            "limit": 50,
+            "filters": {
+                "name": {"value": "route_book_private_hw", "matchMode": "equals"}
+            },
+        },
+    )
+    assert resp.status_code == 200
+    rows = resp.json()["detail"]["assignments"]
+    assert [r["name"] for r in rows] == ["route_book_private_hw"]
+    assert rows[0]["is_official"] is True
+
+
+async def test_shareable_courses_lists_a_course_with_shared_assignments(
+    auth_instructor_client, foreign_shared_assignment
+):
+    resp = await auth_instructor_client.get("/instructor/shareable_courses")
+    assert resp.status_code == 200
+    detail = resp.json()["detail"]
+    names = [c["course_name"] for c in detail["courses"]]
+    assert "route_foreign_course" in names
+    assert detail["pagination"]["total"] >= 1
+
+
+async def test_shareable_tree_nests_assignments_under_their_course(
+    auth_instructor_client, foreign_shared_assignment
+):
+    """Exercises the real route, not just the query behind it.
+
+    Regression: this lived at /assignments/shareable_tree, which Starlette
+    matched against the much earlier /assignments/{assignment_id} and rejected
+    in int coercion. A CRUD-only test cannot see that.
+    """
+    resp = await auth_instructor_client.get("/instructor/shareable_tree")
+    assert resp.status_code == 200, resp.text
+
+    courses = resp.json()["detail"]["courses"]
+    source = next(c for c in courses if c["course_name"] == "route_foreign_course")
+    assert "route_shared_hw" in [a["name"] for a in source["assignments"]]
+
+
+async def test_shareable_tree_can_be_limited_to_this_book(
+    auth_instructor_client, foreign_shared_assignment
+):
+    """The caller's book is test_course_1; the shared course is on overview."""
+    resp = await auth_instructor_client.get(
+        "/instructor/shareable_tree", params={"use_base_course": True}
+    )
+    assert resp.status_code == 200
+    names = [c["course_name"] for c in resp.json()["detail"]["courses"]]
+    assert "route_foreign_course" not in names
+
+    wide = await auth_instructor_client.get("/instructor/shareable_tree")
+    assert "route_foreign_course" in [
+        c["course_name"] for c in wide.json()["detail"]["courses"]
+    ]
+
+
+async def test_import_course_takes_a_whole_courses_assignments(
+    auth_instructor_client, foreign_course
+):
+    """Bulk import, with its own course so the counts do not depend on which
+    other tests have already copied from the shared fixture."""
+    from rsptx.db.crud import fetch_course
+
+    source = await fetch_course("route_foreign_course")
+    await _add_shareable_assignment(source.id, "route_bulk_one", False)
+
+    resp = await auth_instructor_client.post(
+        "/instructor/assignments/import_course",
+        json={"source_course_id": source.id},
+    )
+    assert resp.status_code == 201, resp.text
+    detail = resp.json()["detail"]
+    assert "route_bulk_one" in detail["imported"]
+    assert detail["failed"] == []
+
+    # A second pass finds nothing new.
+    again = await auth_instructor_client.post(
+        "/instructor/assignments/import_course",
+        json={"source_course_id": source.id},
+    )
+    assert again.status_code == 201
+    assert again.json()["detail"]["imported"] == []
+    assert "route_bulk_one" in again.json()["detail"]["skipped_existing"]
+
+
+async def test_import_course_refuses_the_callers_own_course(
+    auth_instructor_client, instructor_user
+):
+    course = await fetch_course(instructor_user.course_name)
+    resp = await auth_instructor_client.post(
+        "/instructor/assignments/import_course",
+        json={"source_course_id": course.id},
+    )
+    assert resp.status_code == 400
+
+
+async def test_preview_of_a_shared_assignment_is_allowed(
+    auth_instructor_client, foreign_shared_assignment
+):
+    resp = await auth_instructor_client.get(
+        f"/instructor/assignments/{foreign_shared_assignment.id}/preview"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["detail"]["name"] == "route_shared_hw"
+
+
+async def test_preview_of_a_private_foreign_assignment_is_refused(
+    auth_instructor_client, foreign_private_assignment
+):
+    resp = await auth_instructor_client.get(
+        f"/instructor/assignments/{foreign_private_assignment.id}/preview"
+    )
+    assert resp.status_code == 404
+
+
+async def test_import_of_a_shared_assignment_succeeds(
+    auth_instructor_client, foreign_shared_assignment
+):
+    resp = await auth_instructor_client.post(
+        f"/instructor/assignments/{foreign_shared_assignment.id}/import"
+    )
+    assert resp.status_code == 201
+    detail = resp.json()["detail"]
+    assert detail["status"] == "success"
+    # The client tells the instructor what was left behind, so the count is
+    # part of the response even when nothing was.
+    assert detail["skipped_readings"] == 0
+
+
+async def test_import_of_a_private_foreign_assignment_is_refused(
+    auth_instructor_client, foreign_private_assignment
+):
+    resp = await auth_instructor_client.post(
+        f"/instructor/assignments/{foreign_private_assignment.id}/import"
+    )
+    assert resp.status_code == 404
+
+
+async def test_duplicate_refuses_an_assignment_from_another_course(
+    auth_instructor_client, foreign_private_assignment
+):
+    """Duplicate is a within-course operation.
+
+    Without this check it would copy any assignment by id, which is a way
+    around the sharing rules the import endpoint enforces -- and the import
+    browser now puts foreign ids in front of the caller.
+    """
+    resp = await auth_instructor_client.post(
+        f"/instructor/assignments/{foreign_private_assignment.id}/duplicate"
+    )
+    assert resp.status_code == 404
+
+
+async def test_delete_refuses_an_assignment_from_another_course(
+    auth_instructor_client, foreign_shared_assignment
+):
+    """Deleting keys off the id alone, so it has to be scoped to the course."""
+    resp = await auth_instructor_client.delete(
+        f"/instructor/assignments/{foreign_shared_assignment.id}"
+    )
+    assert resp.status_code == 404
+
+    # Still there.
+    still_there = await auth_instructor_client.get(
+        f"/instructor/assignments/{foreign_shared_assignment.id}/preview"
+    )
+    assert still_there.status_code == 200
+
+
+async def test_a_private_assignment_on_a_book_is_still_importable(
+    auth_instructor_client, base_course_private_assignment
+):
+    """Assignments that live directly on a book row stay copyable by anyone.
+
+    That is what the older Copy Assignments page has always allowed, so the
+    sharing flag does not take it away. Search agrees: a book's assignments are
+    listed without anyone opting in, since no book author has a UI for the flag
+    and requiring one would hide every official assignment there is.
+    """
+    resp = await auth_instructor_client.post(
+        f"/instructor/assignments/{base_course_private_assignment.id}/import"
+    )
+    assert resp.status_code == 201

--- a/test/components/rsptx/db/test_assignment_sharing.py
+++ b/test/components/rsptx/db/test_assignment_sharing.py
@@ -1,0 +1,1213 @@
+"""
+Tests for cross-course assignment sharing and import.
+
+A course's assignments are discoverable outside it only when the course has
+opted in on its Course Settings page, or when the course is a book -- a book's
+material needs no opt-in. Importing one copies the assignment into the target
+course and links its exercises where they already live -- the same thing adding an
+exercise from another course does. Readings do not survive a change of book,
+so a cross-book import leaves them behind.
+"""
+
+import datetime
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+from zoneinfo import ZoneInfo  # noqa: E402
+
+from rsptx.db.crud import (  # noqa: E402
+    create_assignment,
+    create_assignment_question,
+    create_course,
+    create_course_attribute,
+    create_instructor_course_entry,
+    create_question,
+    fetch_course,
+    import_assignment,
+    import_course_assignments,
+    search_assignments,
+    search_shareable_courses,
+    fetch_assignment_for_preview,
+    fetch_shareable_assignment_tree,
+    term_start_utc,
+)
+from rsptx.db.crud.user import create_user  # noqa: E402
+from rsptx.db.models import (  # noqa: E402
+    Assignment,
+    AssignmentQuestionValidator,
+    AssignmentValidator,
+    AuthUserValidator,
+    CoursesValidator,
+    Question,
+    QuestionValidator,
+)
+from rsptx.db.async_session import async_session  # noqa: E402
+from rsptx.validation.schemas import AssignmentsSearchRequest  # noqa: E402
+from rsptx.response_helpers.core import canonical_utcnow  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from sqlalchemy import func, select, update  # noqa: E402
+
+SRC_COURSE = "sharing_src_course"
+DST_COURSE = "sharing_dst_course"
+SAME_BOOK_COURSE = "sharing_same_book_course"
+CLOSED_COURSE = "sharing_closed_course"
+SRC_BOOK = "thinkcspy"
+DST_BOOK = "fopp"
+CHICAGO = "America/Chicago"
+
+
+async def _make_course(name, base_course, term_start, timezone=None):
+    await create_course(
+        CoursesValidator(
+            course_name=name,
+            base_course=base_course,
+            term_start_date=term_start,
+            login_required=False,
+            allow_pairs=False,
+            downloads_enabled=False,
+            courselevel="",
+            institution="Test University",
+            new_server=True,
+            timezone=timezone,
+        )
+    )
+    return await fetch_course(name)
+
+
+async def _share_assignments(course_id):
+    """Opt a course in to offering its assignments, as Course Settings does."""
+    await create_course_attribute(course_id, "share_assignments", "true")
+
+
+async def _make_user(username):
+    return await create_user(
+        AuthUserValidator(
+            username=username,
+            first_name="test",
+            last_name="user",
+            password="xxx",
+            email=f"{username}@example.com",
+            course_name="overview",
+            course_id=1,
+            donated=True,
+            active=True,
+            accept_tcp=True,
+            created_on=datetime.datetime(2020, 1, 1),
+            modified_on=datetime.datetime(2020, 1, 1),
+            registration_key="",
+            registration_id="",
+            reset_password_key="",
+        )
+    )
+
+
+async def _make_assignment(
+    course_id, name, is_private, duedate=None, points=10, from_source=False
+):
+    return await create_assignment(
+        AssignmentValidator(
+            course=course_id,
+            name=name,
+            points=points,
+            released=False,
+            description=f"{name} description",
+            duedate=duedate or datetime.datetime(2099, 1, 1),
+            visible=True,
+            from_source=from_source,
+            is_peer=False,
+            is_timed=False,
+            current_index=0,
+            peer_async_visible=False,
+            kind="Regular",
+            is_private=is_private,
+        )
+    )
+
+
+async def _make_question(base_course, name, question_type="mchoice"):
+    return await create_question(
+        QuestionValidator(
+            base_course=base_course,
+            name=name,
+            chapter="ch1",
+            subchapter="sub1",
+            author="sharing_owner",
+            question="Shared question?",
+            timestamp=canonical_utcnow(),
+            question_type=question_type,
+            is_private=False,
+            from_source=False,
+            review_flag=False,
+            htmlsrc="<p>hello</p>",
+        )
+    )
+
+
+async def _attach(assignment_id, question_id, points, priority, reading=False):
+    await create_assignment_question(
+        AssignmentQuestionValidator(
+            assignment_id=assignment_id,
+            question_id=question_id,
+            points=points,
+            activities_required=0,
+            reading_assignment=reading,
+            sorting_priority=priority,
+            which_to_grade="best_answer",
+            autograde="pct_correct",
+            timed=False,
+        )
+    )
+
+
+async def _question_count(base_course):
+    async with async_session() as session:
+        return (
+            await session.execute(
+                select(func.count())
+                .select_from(Question)
+                .where(Question.base_course == base_course)
+            )
+        ).scalar()
+
+
+@pytest.fixture(scope="session")
+async def sharing_world(init_test_db):
+    """Two instructors in unrelated courses that use different books.
+
+    ``src`` has opted in to sharing and ``closed`` has not, which is the whole
+    distinction now that the decision belongs to the course rather than to each
+    assignment. Neither is a base course: those have always been copyable by
+    anyone, so using one would mask the opt-in entirely.
+    """
+    owner = await _make_user("sharing_owner")
+    importer = await _make_user("sharing_importer")
+
+    src = await _make_course(SRC_COURSE, SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO)
+    closed = await _make_course(
+        CLOSED_COURSE, SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO
+    )
+    dst = await _make_course(DST_COURSE, DST_BOOK, datetime.date(2026, 8, 24), CHICAGO)
+    same_book = await _make_course(
+        SAME_BOOK_COURSE, SRC_BOOK, datetime.date(2026, 8, 24), CHICAGO
+    )
+
+    await create_instructor_course_entry(owner.id, src.id)
+    await create_instructor_course_entry(owner.id, closed.id)
+    await create_instructor_course_entry(importer.id, dst.id)
+    await create_instructor_course_entry(importer.id, same_book.id)
+
+    await _share_assignments(src.id)
+
+    shared = await _make_assignment(src.id, "Shared Homework", is_private=False)
+    # In a course that never opted in. Nobody outside it should see this.
+    unshared = await _make_assignment(closed.id, "Unshared Exam", is_private=True)
+
+    # The book's own course. Its assignments are "official": nobody opted in on
+    # its behalf, and nobody should have to for the book's material to be
+    # findable. The course is deliberately left without the sharing attribute,
+    # to prove the base-course exemption is what surfaces them.
+    book = await fetch_course(SRC_BOOK)
+    official = await _make_assignment(book.id, "Official Chapter 1", is_private=True)
+    generated = await _make_assignment(
+        book.id, "Official Timed Exam", is_private=False, from_source=True
+    )
+
+    question = await _make_question(SRC_BOOK, "sharing_q1")
+    await _attach(shared.id, question.id, points=7, priority=0)
+    await _attach(official.id, question.id, points=5, priority=0)
+
+    return {
+        "owner": owner,
+        "importer": importer,
+        "src": src,
+        "closed": closed,
+        "dst": dst,
+        "same_book": same_book,
+        "book": book,
+        "shared": shared,
+        "unshared": unshared,
+        "official": official,
+        "generated": generated,
+        "question": question,
+    }
+
+
+def _names(result):
+    return {a["name"] for a in result["assignments"]}
+
+
+def _row(result, name):
+    """The one result row with this name, so a test can read its flags.
+
+    Every assignment in this module gets a distinct name, which keeps a lookup
+    by name unambiguous even though the fixture is session-scoped and results
+    accumulate as the file runs.
+    """
+    return next(a for a in result["assignments"] if a["name"] == name)
+
+
+def _named(name, **kwargs):
+    """Search criteria scoped to a single assignment by name.
+
+    A test that asserts "this is visible" has to say which one it means. The
+    whole suite shares one database, ``test_course_1`` is seeded as a base
+    course, and a base course's assignments are visible to everyone -- so every
+    other test module's assignments are legitimately in these results, and an
+    unfiltered first page depends on which modules ran first. Scoping by name
+    keeps these assertions about visibility rather than about page size.
+    """
+    return AssignmentsSearchRequest(
+        filters={"name": {"value": name, "matchMode": "equals"}}, **kwargs
+    )
+
+
+async def _search_as_importer(sharing_world, name):
+    """Search for one assignment by name, targeting the importer's course."""
+    return await search_assignments(
+        _named(name),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+        target_course_id=sharing_world["dst"].id,
+    )
+
+
+# search_assignments
+# ------------------
+
+
+async def test_search_finds_a_shared_assignment_from_a_foreign_course(sharing_world):
+    result = await search_assignments(
+        _named("Shared Homework"),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Shared Homework" in _names(result)
+
+
+async def test_search_hides_a_course_that_has_not_opted_in(sharing_world):
+    """Sharing is off until a course turns it on, and it covers the course."""
+    result = await search_assignments(
+        _named("Unshared Exam"),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Unshared Exam" not in _names(result)
+
+
+async def test_search_still_shows_the_owner_their_own_unshared_course(sharing_world):
+    """Your own material never vanishes from your own search results."""
+    result = await search_assignments(
+        _named("Unshared Exam"),
+        user_id=sharing_world["owner"].id,
+    )
+    assert "Unshared Exam" in _names(result)
+
+
+async def test_search_excludes_the_requesters_current_course(sharing_world):
+    """The current course is where results land, so listing it is noise."""
+    await _make_assignment(
+        sharing_world["dst"].id, "Local Assignment", is_private=False
+    )
+    result = await search_assignments(
+        AssignmentsSearchRequest(),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Local Assignment" not in _names(result)
+
+
+async def test_search_can_be_limited_to_one_book(sharing_world):
+    result = await search_assignments(
+        _named("Shared Homework", base_course=DST_BOOK),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["same_book"].id,
+    )
+    assert "Shared Homework" not in _names(result)
+
+    result = await search_assignments(
+        _named("Shared Homework", base_course=SRC_BOOK),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Shared Homework" in _names(result)
+
+
+async def test_search_can_be_limited_to_my_own_courses(sharing_world):
+    """Material from courses you teach, rather than the whole platform.
+
+    Independent of the book filter: the importer's two courses are on different
+    books, so "mine" and "this book" are not the same set.
+    """
+    await _make_assignment(
+        sharing_world["same_book"].id, "Only Mine Homework", is_private=False
+    )
+
+    mine = await search_assignments(
+        AssignmentsSearchRequest(only_my_courses=True, limit=100),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Only Mine Homework" in _names(mine)
+    # From a course the importer has nothing to do with.
+    assert "Shared Homework" not in _names(mine)
+
+    everything = await search_assignments(
+        AssignmentsSearchRequest(limit=100),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Shared Homework" in _names(everything)
+
+
+async def test_only_my_courses_finds_nothing_for_someone_who_teaches_nothing(
+    sharing_world,
+):
+    """An empty course list has to mean "nothing", not "no filter"."""
+    stranger = await _make_user("sharing_stranger")
+
+    result = await search_assignments(
+        AssignmentsSearchRequest(only_my_courses=True, limit=100),
+        user_id=stranger.id,
+    )
+    assert result["assignments"] == []
+    assert result["pagination"]["total"] == 0
+
+
+async def test_search_filters_by_course_name(sharing_world):
+    result = await search_assignments(
+        AssignmentsSearchRequest(
+            filters={"course_name": {"value": SRC_COURSE, "matchMode": "equals"}}
+        ),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert _names(result) == {"Shared Homework"}
+
+
+async def test_global_filter_requires_every_term_to_match(sharing_world):
+    matching = await search_assignments(
+        AssignmentsSearchRequest(filters={"global": {"value": "Shared Homework"}}),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Shared Homework" in _names(matching)
+
+    # "Homework" matches but "nonsenseterm" does not, so neither should the row.
+    narrowed = await search_assignments(
+        AssignmentsSearchRequest(
+            filters={"global": {"value": "Homework nonsenseterm"}}
+        ),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Shared Homework" not in _names(narrowed)
+
+
+async def test_search_reports_question_count_and_book_title(sharing_world):
+    result = await search_assignments(
+        AssignmentsSearchRequest(
+            filters={"name": {"value": "Shared Homework", "matchMode": "equals"}}
+        ),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    row = result["assignments"][0]
+    assert row["question_count"] == 1
+    assert row["base_course"] == SRC_BOOK
+    assert row["course_name"] == SRC_COURSE
+
+
+async def test_search_paginates(sharing_world):
+    page = await search_assignments(
+        AssignmentsSearchRequest(limit=1, page=0),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert len(page["assignments"]) == 1
+    assert page["pagination"]["total"] >= 1
+    assert page["pagination"]["pages"] == page["pagination"]["total"]
+
+
+# Official (base course) assignments
+# ----------------------------------
+
+
+async def test_search_lists_a_books_own_assignment_without_a_sharing_flag(
+    sharing_world,
+):
+    """A book's material is findable without anyone opting in.
+
+    Requiring the flag would have kept every official assignment invisible: the
+    import path has always exempted base courses, but search did not, so they
+    were importable by id and unlistable -- and no book author has a UI to flip
+    the flag anyway.
+    """
+    official = await search_assignments(
+        _named("Official Chapter 1"),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Official Chapter 1" in _names(official)
+    assert _row(official, "Official Chapter 1")["is_official"] is True
+
+    # An ordinary shared assignment is not official just because it is listed.
+    shared = await search_assignments(
+        _named("Shared Homework"),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert _row(shared, "Shared Homework")["is_official"] is False
+
+
+async def test_search_hides_an_assignment_generated_from_the_book_source(sharing_world):
+    """``from_source`` rows are rebuilt from the book's markup on every build.
+
+    A copy is a snapshot that starts drifting the moment the book changes, so
+    they are not advertised -- even this one, which is marked shareable.
+    """
+    result = await search_assignments(
+        AssignmentsSearchRequest(limit=100),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert "Official Timed Exam" not in _names(result)
+
+
+async def test_the_callers_own_books_official_assignments_lead(sharing_world):
+    """The elevation itself, and its limit.
+
+    Only the caller's own book leads. Elevating every book's official set would
+    put nineteen other books' material ahead of what an instructor's colleagues
+    actually share, which is the opposite of not losing things.
+    """
+    other_book = await fetch_course(DST_BOOK)
+    await _make_assignment(other_book.id, "Other Book Official", is_private=True)
+
+    result = await search_assignments(
+        AssignmentsSearchRequest(limit=100, sorting={"field": "name", "order": 1}),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+        prefer_base_course=SRC_BOOK,
+    )
+    rows = result["assignments"]
+    leads = [row["is_official"] and row["base_course"] == SRC_BOOK for row in rows]
+
+    assert leads[0] is True
+    # Every row from the caller's book comes before every other row.
+    assert leads == sorted(leads, reverse=True)
+
+    # Official, but from a book this instructor does not teach, so it waits its
+    # turn with everything else.
+    other = next(r for r in rows if r["name"] == "Other Book Official")
+    assert other["is_official"] is True
+    assert leads[rows.index(other)] is False
+
+
+async def test_preview_marks_an_official_assignment(sharing_world):
+    preview = await fetch_assignment_for_preview(
+        sharing_world["official"].id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+    )
+    assert preview["is_official"] is True
+
+
+# import_assignment
+# -----------------
+
+
+async def test_import_links_the_source_question_across_books(sharing_world):
+    """The exercise is referred to where it lives, not duplicated.
+
+    Copying it was the earlier design, and it could not work: the div id that
+    identifies an exercise in the DOM, in useinfo and in grading is baked into
+    the stored HTML, which a copy does not rewrite.
+    """
+    result = await import_assignment(
+        source_assignment_id=sharing_world["shared"].id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    preview = await fetch_assignment_for_preview(
+        result.assignment.id, user_id=sharing_world["importer"].id
+    )
+    assert preview["question_count"] == 1
+    linked = preview["questions"][0]
+    assert linked["id"] == sharing_world["question"].id
+    # The source's per-question points survive the trip.
+    assert linked["points"] == 7
+    assert result.name == "Shared Homework"
+    assert result.skipped_readings == 0
+
+
+async def test_import_reuses_the_question_when_the_book_is_the_same(sharing_world):
+    result = await import_assignment(
+        source_assignment_id=sharing_world["shared"].id,
+        target_course=sharing_world["same_book"],
+        importing_user=sharing_world["importer"],
+    )
+
+    preview = await fetch_assignment_for_preview(
+        result.assignment.id, user_id=sharing_world["importer"].id
+    )
+    assert preview["questions"][0]["id"] == sharing_world["question"].id
+
+
+async def test_import_adds_no_questions_to_the_target_book(sharing_world):
+    """Nothing new lands in the importer's book.
+
+    Copies used to accumulate there -- one duplicate per import, left orphaned
+    in the book's exercise pool when the imported assignment was deleted.
+    """
+    before = await _question_count(DST_BOOK)
+
+    await import_assignment(
+        source_assignment_id=sharing_world["shared"].id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    assert await _question_count(DST_BOOK) == before
+
+
+async def test_imported_assignment_is_hidden_and_not_reshared(sharing_world):
+    result = await import_assignment(
+        source_assignment_id=sharing_world["shared"].id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+    assert result.assignment.visible is False
+    # Importing something shared does not sign you up for sharing it onward.
+    assert result.assignment.is_private is True
+
+
+async def test_importing_twice_does_not_collide_on_name(sharing_world):
+    first = await import_assignment(
+        source_assignment_id=sharing_world["shared"].id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+    second = await import_assignment(
+        source_assignment_id=sharing_world["shared"].id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+    assert first.name != second.name
+    assert second.name.startswith("Shared Homework (Copy")
+
+    # Both point at the one question; the second import has nothing to rename.
+    for imported in (first, second):
+        preview = await fetch_assignment_for_preview(
+            imported.assignment.id, user_id=sharing_world["importer"].id
+        )
+        assert preview["questions"][0]["id"] == sharing_world["question"].id
+
+
+async def test_import_shifts_the_due_date_by_the_offset_from_term_start(sharing_world):
+    """The copy keeps its local wall clock time across a DST change.
+
+    The source term starts in January (CST) and the target in August (CDT); a
+    naive subtraction lands an hour off and can roll onto the next day.
+    """
+    stored = (
+        datetime.datetime(2026, 1, 20, 23, 59, tzinfo=ZoneInfo(CHICAGO))
+        .astimezone(datetime.timezone.utc)
+        .replace(tzinfo=None)
+    )
+    source_assignment = await _make_assignment(
+        sharing_world["src"].id, "Dated Homework", is_private=False, duedate=stored
+    )
+
+    imported = (
+        await import_assignment(
+            source_assignment_id=source_assignment.id,
+            target_course=sharing_world["dst"],
+            importing_user=sharing_world["importer"],
+        )
+    ).assignment
+
+    local = (
+        imported.duedate.replace(tzinfo=datetime.timezone.utc)
+        .astimezone(ZoneInfo(CHICAGO))
+        .strftime("%Y-%m-%d %H:%M")
+    )
+    assert local == "2026-09-01 23:59"
+
+    offset = imported.duedate - term_start_utc(
+        sharing_world["dst"].term_start_date, CHICAGO
+    )
+    assert offset == stored - term_start_utc(
+        sharing_world["src"].term_start_date, CHICAGO
+    )
+
+
+# Already imported
+# ----------------
+
+
+async def test_import_records_where_the_copy_came_from(sharing_world):
+    """The breadcrumb everything below reads back."""
+    source = await _make_assignment(
+        sharing_world["src"].id, "Traceable Homework", is_private=False
+    )
+
+    result = await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+    assert result.assignment.imported_from_assignment_id == source.id
+
+
+async def test_search_marks_an_assignment_already_imported_here(sharing_world):
+    source = await _make_assignment(
+        sharing_world["src"].id, "Marked Homework", is_private=False
+    )
+
+    before = _row(
+        await _search_as_importer(sharing_world, "Marked Homework"), "Marked Homework"
+    )
+    assert before["already_imported"] is False
+    assert before["imported_as"] is None
+
+    imported = await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    after = _row(
+        await _search_as_importer(sharing_world, "Marked Homework"), "Marked Homework"
+    )
+    assert after["already_imported"] is True
+    # Named so the instructor can go find the copy they already have.
+    assert after["imported_as"] == imported.name
+
+
+async def test_the_mark_survives_renaming_the_copy(sharing_world):
+    """Why this keys off a stored source id and not the name.
+
+    Renaming an imported assignment is the first thing an instructor is likely
+    to do to it, and name matching would lose track of it immediately.
+    """
+    source = await _make_assignment(
+        sharing_world["src"].id, "Renamed Homework", is_private=False
+    )
+    imported = await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    async with async_session.begin() as session:
+        await session.execute(
+            update(Assignment)
+            .where(Assignment.id == imported.assignment.id)
+            .values(name="Week 4, revised")
+        )
+
+    row = _row(
+        await _search_as_importer(sharing_world, "Renamed Homework"), "Renamed Homework"
+    )
+    assert row["already_imported"] is True
+    assert row["imported_as"] == "Week 4, revised"
+
+
+async def test_the_mark_is_scoped_to_the_course_being_imported_into(sharing_world):
+    """A copy in one of your courses says nothing about another of them."""
+    source = await _make_assignment(
+        sharing_world["src"].id, "Per Course Homework", is_private=False
+    )
+    await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    criteria = AssignmentsSearchRequest(
+        filters={"name": {"value": "Per Course Homework", "matchMode": "equals"}}
+    )
+    other_course = await search_assignments(
+        criteria,
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["same_book"].id,
+        target_course_id=sharing_world["same_book"].id,
+    )
+    assert _row(other_course, "Per Course Homework")["already_imported"] is False
+
+
+async def test_search_marks_nothing_without_a_target_course(sharing_world):
+    """No course to have imported into, so the question does not arise."""
+    result = await search_assignments(
+        AssignmentsSearchRequest(limit=100),
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+    )
+    assert all(a["already_imported"] is False for a in result["assignments"])
+
+
+async def test_preview_says_when_a_copy_is_already_in_your_course(sharing_world):
+    source = await _make_assignment(
+        sharing_world["src"].id, "Previewed Twice", is_private=False
+    )
+
+    before = await fetch_assignment_for_preview(
+        source.id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+    )
+    assert before["already_imported"] is False
+
+    imported = await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    after = await fetch_assignment_for_preview(
+        source.id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+    )
+    assert after["already_imported"] is True
+    assert after["imported_as"] == imported.name
+
+    # Browsing with no target course: nothing to have imported into.
+    untargeted = await fetch_assignment_for_preview(
+        source.id, user_id=sharing_world["importer"].id
+    )
+    assert untargeted["already_imported"] is False
+    assert untargeted["imported_as"] is None
+
+
+# Readings
+# --------
+
+
+async def _assignment_with_a_reading(sharing_world, name):
+    """A source assignment holding one exercise and one reading."""
+    assignment = await _make_assignment(sharing_world["src"].id, name, is_private=False)
+    exercise = await _make_question(SRC_BOOK, f"{name} exercise")
+    page = await _make_question(SRC_BOOK, f"{name} page", question_type="page")
+    await _attach(assignment.id, exercise.id, points=3, priority=0)
+    await _attach(assignment.id, page.id, points=4, priority=1, reading=True)
+    return assignment
+
+
+async def test_a_cross_book_import_leaves_readings_behind(sharing_world):
+    """A reading names a subchapter of its own book.
+
+    Linked into a course reading a different book, it would point students at a
+    page they do not have and would be graded by counting activity that can
+    never happen there.
+    """
+    source = await _assignment_with_a_reading(sharing_world, "Mixed Homework")
+
+    result = await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+    assert result.skipped_readings == 1
+
+    preview = await fetch_assignment_for_preview(
+        result.assignment.id, user_id=sharing_world["importer"].id
+    )
+    assert [q["name"] for q in preview["questions"]] == ["Mixed Homework exercise"]
+    # Points follow what actually came across, not the source's total of 7.
+    assert result.assignment.points == 3
+
+
+async def test_a_same_book_import_keeps_readings(sharing_world):
+    source = await _assignment_with_a_reading(sharing_world, "Mixed Homework 2")
+
+    result = await import_assignment(
+        source_assignment_id=source.id,
+        target_course=sharing_world["same_book"],
+        importing_user=sharing_world["importer"],
+    )
+    assert result.skipped_readings == 0
+
+    preview = await fetch_assignment_for_preview(
+        result.assignment.id, user_id=sharing_world["importer"].id
+    )
+    assert len(preview["questions"]) == 2
+    assert result.assignment.points == 7
+
+
+# search_shareable_courses
+# ------------------------
+
+
+def _course_names(result):
+    return [c["course_name"] for c in result["courses"]]
+
+
+def _course(result, name):
+    return next(c for c in result["courses"] if c["course_name"] == name)
+
+
+async def test_shareable_courses_lists_courses_with_something_to_offer(sharing_world):
+    result = await search_shareable_courses(
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+        limit=100,
+    )
+    assert SRC_COURSE in _course_names(result)
+    assert _course(result, SRC_COURSE)["shareable_count"] >= 1
+    assert _course(result, SRC_COURSE)["is_official"] is False
+
+
+async def test_shareable_courses_puts_the_callers_book_first(sharing_world):
+    """An instructor looking for material for their book should not have to
+    search for the book itself."""
+    result = await search_shareable_courses(
+        user_id=sharing_world["importer"].id,
+        prefer_base_course=SRC_BOOK,
+        exclude_course_id=sharing_world["dst"].id,
+        limit=100,
+    )
+    assert _course_names(result)[0] == SRC_BOOK
+    assert _course(result, SRC_BOOK)["is_official"] is True
+
+
+async def test_shareable_courses_counts_only_what_can_be_taken(sharing_world):
+    """The build-generated assignment is excluded here too, so the count is not
+    a promise the course page then breaks."""
+    result = await search_shareable_courses(
+        user_id=sharing_world["importer"].id,
+        exclude_course_id=sharing_world["dst"].id,
+        limit=100,
+    )
+    # "Official Chapter 1" counts; "Official Timed Exam" does not.
+    assert _course(result, SRC_BOOK)["shareable_count"] == 1
+
+
+async def test_shareable_courses_searches_name_and_institution(sharing_world):
+    matching = await search_shareable_courses(
+        user_id=sharing_world["importer"].id,
+        search="sharing_src",
+        limit=100,
+    )
+    assert _course_names(matching) == [SRC_COURSE]
+
+    missing = await search_shareable_courses(
+        user_id=sharing_world["importer"].id,
+        search="sharing_src nonsenseterm",
+        limit=100,
+    )
+    assert missing["courses"] == []
+
+
+async def test_shareable_courses_can_be_limited_to_my_own(sharing_world):
+    result = await search_shareable_courses(
+        user_id=sharing_world["importer"].id,
+        only_my_courses=True,
+        exclude_course_id=sharing_world["dst"].id,
+        limit=100,
+    )
+    assert SAME_BOOK_COURSE in _course_names(result)
+    assert SRC_COURSE not in _course_names(result)
+
+
+# fetch_shareable_assignment_tree
+# -------------------------------
+
+
+def _tree_course(result, name):
+    return next(c for c in result["courses"] if c["course_name"] == name)
+
+
+async def test_tree_nests_assignments_under_their_course(sharing_world):
+    """Both levels in one response, so expanding a course is not a round trip."""
+    result = await fetch_shareable_assignment_tree(
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+        search=SRC_COURSE,
+        limit=100,
+    )
+    course = _tree_course(result, SRC_COURSE)
+    assert "Shared Homework" in [a["name"] for a in course["assignments"]]
+    assert course["shareable_count"] == len(course["assignments"])
+
+
+async def test_tree_marks_what_is_already_imported(sharing_world):
+    source = await _make_course(
+        "sharing_tree_source", SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO
+    )
+    await _share_assignments(source.id)
+    assignment = await _make_assignment(source.id, "Tree Homework", is_private=False)
+
+    before = await fetch_shareable_assignment_tree(
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+        search="sharing_tree_source",
+        limit=100,
+    )
+    assert (
+        _tree_course(before, "sharing_tree_source")["assignments"][0][
+            "already_imported"
+        ]
+        is False
+    )
+
+    await import_assignment(
+        source_assignment_id=assignment.id,
+        target_course=sharing_world["dst"],
+        importing_user=sharing_world["importer"],
+    )
+
+    after = await fetch_shareable_assignment_tree(
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+        search="sharing_tree_source",
+        limit=100,
+    )
+    row = _tree_course(after, "sharing_tree_source")["assignments"][0]
+    assert row["already_imported"] is True
+    assert row["imported_as"] == "Tree Homework"
+
+
+async def test_tree_puts_the_callers_own_book_first(sharing_world):
+    """Only the caller's book. Another book's official set is no more relevant
+    to this instructor than a colleague's course."""
+    result = await fetch_shareable_assignment_tree(
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["same_book"],
+        limit=100,
+    )
+    assert result["courses"][0]["course_name"] == SRC_BOOK
+
+
+# import_course_assignments
+# -------------------------
+
+
+async def test_bulk_import_takes_a_whole_course(sharing_world):
+    """The reason this page exists: a colleague's semester in one action."""
+    source = await _make_course(
+        "sharing_bulk_source", SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO
+    )
+    target = await _make_course(
+        "sharing_bulk_target", SRC_BOOK, datetime.date(2026, 8, 24), CHICAGO
+    )
+    await _share_assignments(source.id)
+    await create_instructor_course_entry(sharing_world["importer"].id, target.id)
+    for name in ("Bulk One", "Bulk Two", "Bulk Three"):
+        await _make_assignment(source.id, name, is_private=False)
+
+    result = await import_course_assignments(
+        source_course_id=source.id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+    )
+    assert sorted(result.imported) == ["Bulk One", "Bulk Three", "Bulk Two"]
+    assert result.skipped_existing == []
+    assert result.failed == []
+
+
+async def test_bulk_import_skips_what_you_already_took(sharing_world):
+    """Re-running after the source course adds one should take the new one only."""
+    source = await _make_course(
+        "sharing_bulk_source2", SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO
+    )
+    target = await _make_course(
+        "sharing_bulk_target2", SRC_BOOK, datetime.date(2026, 8, 24), CHICAGO
+    )
+    await _share_assignments(source.id)
+    await create_instructor_course_entry(sharing_world["importer"].id, target.id)
+    await _make_assignment(source.id, "Bulk Original", is_private=False)
+
+    first = await import_course_assignments(
+        source_course_id=source.id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+    )
+    assert first.imported == ["Bulk Original"]
+
+    await _make_assignment(source.id, "Bulk Added Later", is_private=False)
+
+    second = await import_course_assignments(
+        source_course_id=source.id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+    )
+    assert second.imported == ["Bulk Added Later"]
+    assert second.skipped_existing == ["Bulk Original"]
+
+
+async def test_bulk_import_can_be_told_not_to_skip(sharing_world):
+    source = await _make_course(
+        "sharing_bulk_source3", SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO
+    )
+    target = await _make_course(
+        "sharing_bulk_target3", SRC_BOOK, datetime.date(2026, 8, 24), CHICAGO
+    )
+    await _share_assignments(source.id)
+    await create_instructor_course_entry(sharing_world["importer"].id, target.id)
+    await _make_assignment(source.id, "Bulk Again", is_private=False)
+
+    await import_course_assignments(
+        source_course_id=source.id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+    )
+    second = await import_course_assignments(
+        source_course_id=source.id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+        skip_existing=False,
+    )
+    assert second.skipped_existing == []
+    # Name de-duplication is import_assignment's, not this function's.
+    assert second.imported[0].startswith("Bulk Again (Copy")
+
+
+async def test_opting_in_shares_the_whole_course(sharing_world):
+    """All or nothing, which is the cost of moving the decision to the course.
+
+    ``is_private`` no longer withholds an assignment from a course that has
+    opted in -- the exam comes across with everything else. That is why the
+    Course Settings copy says so in as many words.
+    """
+    source = await _make_course(
+        "sharing_bulk_source4", SRC_BOOK, datetime.date(2026, 1, 12), CHICAGO
+    )
+    target = await _make_course(
+        "sharing_bulk_target4", SRC_BOOK, datetime.date(2026, 8, 24), CHICAGO
+    )
+    await _share_assignments(source.id)
+    await create_instructor_course_entry(sharing_world["importer"].id, target.id)
+    await _make_assignment(source.id, "Bulk Shared", is_private=False)
+    await _make_assignment(source.id, "Bulk Exam", is_private=True)
+    await _make_assignment(
+        source.id, "Bulk Generated", is_private=False, from_source=True
+    )
+
+    result = await import_course_assignments(
+        source_course_id=source.id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+    )
+    # Generated from the book source, so still left behind.
+    assert sorted(result.imported) == ["Bulk Exam", "Bulk Shared"]
+
+
+async def test_bulk_import_takes_a_books_official_set(sharing_world):
+    """Starting a course from the book's own assignments."""
+    target = await _make_course(
+        "sharing_bulk_official", SRC_BOOK, datetime.date(2026, 8, 24), CHICAGO
+    )
+    await create_instructor_course_entry(sharing_world["importer"].id, target.id)
+
+    result = await import_course_assignments(
+        source_course_id=sharing_world["book"].id,
+        target_course=target,
+        importing_user=sharing_world["importer"],
+    )
+    assert "Official Chapter 1" in result.imported
+    # Generated from the book source, so not taken even in bulk.
+    assert "Official Timed Exam" not in result.imported
+
+
+async def test_bulk_import_refuses_to_import_a_course_into_itself(sharing_world):
+    with pytest.raises(HTTPException) as excinfo:
+        await import_course_assignments(
+            source_course_id=sharing_world["dst"].id,
+            target_course=sharing_world["dst"],
+            importing_user=sharing_world["importer"],
+        )
+    assert excinfo.value.status_code == 400
+
+
+# Authorization
+# -------------
+
+
+async def test_importing_from_a_course_that_has_not_opted_in_is_rejected(sharing_world):
+    with pytest.raises(HTTPException) as excinfo:
+        await import_assignment(
+            source_assignment_id=sharing_world["unshared"].id,
+            target_course=sharing_world["dst"],
+            importing_user=sharing_world["importer"],
+        )
+    # 404 rather than 403 so the response does not confirm the assignment exists.
+    assert excinfo.value.status_code == 404
+
+
+async def test_previewing_from_a_course_that_has_not_opted_in_is_rejected(
+    sharing_world,
+):
+    with pytest.raises(HTTPException) as excinfo:
+        await fetch_assignment_for_preview(
+            sharing_world["unshared"].id, user_id=sharing_world["importer"].id
+        )
+    assert excinfo.value.status_code == 404
+
+
+async def test_the_owner_may_still_import_from_their_own_unshared_course(sharing_world):
+    """Instructing the source course is enough, opted in or not."""
+    result = await import_assignment(
+        source_assignment_id=sharing_world["unshared"].id,
+        target_course=sharing_world["src"],
+        importing_user=sharing_world["owner"],
+    )
+    assert result.assignment.id is not None
+
+
+# Preview
+# -------
+
+
+async def test_preview_marks_a_cross_book_import(sharing_world):
+    cross_book = await fetch_assignment_for_preview(
+        sharing_world["shared"].id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+    )
+    assert cross_book["is_cross_book"] is True
+    # Exercises cross book boundaries, so an exercise-only assignment loses
+    # nothing -- the flag alone is not a warning that something is missing.
+    assert cross_book["skipped_readings"] == 0
+    assert all(q["will_import"] for q in cross_book["questions"])
+
+    same_book = await fetch_assignment_for_preview(
+        sharing_world["shared"].id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["same_book"],
+    )
+    assert same_book["is_cross_book"] is False
+
+
+async def test_preview_flags_the_readings_a_cross_book_import_will_drop(sharing_world):
+    """Said before importing, so the gap is a choice rather than a surprise."""
+    source = await _assignment_with_a_reading(sharing_world, "Mixed Homework 3")
+
+    cross_book = await fetch_assignment_for_preview(
+        source.id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["dst"],
+    )
+    assert cross_book["skipped_readings"] == 1
+    assert [q["will_import"] for q in cross_book["questions"]] == [True, False]
+
+    same_book = await fetch_assignment_for_preview(
+        source.id,
+        user_id=sharing_world["importer"].id,
+        target_course=sharing_world["same_book"],
+    )
+    assert same_book["skipped_readings"] == 0
+    assert all(q["will_import"] for q in same_book["questions"])
+
+
+async def test_preview_without_a_target_course_drops_nothing(sharing_world):
+    """The browsing case: no target yet, so no book to compare against."""
+    source = await _assignment_with_a_reading(sharing_world, "Mixed Homework 4")
+
+    preview = await fetch_assignment_for_preview(
+        source.id, user_id=sharing_world["importer"].id
+    )
+    assert preview["is_cross_book"] is False
+    assert preview["skipped_readings"] == 0


### PR DESCRIPTION
This implements a broader assignment copy/import feature.  Uses all the old mechanisms for copying assignments, but allows any instructor to mark their assignments as public for other instructors to import (even if they use a different base course).

Added a import selector from the "Create Assignment" page.  You can filter by just your own courses (which you can always import from) or just courses that use the same book.  

Similar features are available from the Copy Assignments page.

Happy to tweak if you have suggestions.

BTW, Claude did most of the work here, with some heavy steering and a few manual fixes.