### PR TITLE
Remove hardcoded background colors from shortanswer input

### DIFF
--- a/bases/rsptx/interactives/runestone/shortanswer/css/shortanswer.css
+++ b/bases/rsptx/interactives/runestone/shortanswer/css/shortanswer.css
@@ -25,8 +25,6 @@ div.journal div.latexoutput {
     line-height: 1.5;
 
     border-radius: 8px;
-    border: 1px solid #d0d7de;
-    background-color: #fff;
 
     transition:
         border-color 0.15s ease,
@@ -37,9 +35,6 @@ div.journal div.latexoutput {
 
     font-family: system-ui, -apple-system, BlinkMacSystemFont,
                  "Segoe UI", Roboto, sans-serif;
-    background:
-        linear-gradient(#fff, #fff) padding-box,
-        linear-gradient(to right, #eaeef2, #eaeef2) border-box;
 }
 
 .journal textarea:focus {


### PR DESCRIPTION
Removes hard coded white background color from short answer inputs.

Assuming claude did the work there... something to watch for - make sure interactives don't get hard coded colors that don't make sense in dark mode.

If needed CSS vars can be used to switch colors for light/dark, but here I think we are better off just letting the input handle its own color. 