### PR TITLE
Mchoice accessibility fixes

### DIFF
--- a/bases/rsptx/interactives/runestone/mchoice/css/mchoice.css
+++ b/bases/rsptx/interactives/runestone/mchoice/css/mchoice.css
@@ -39,3 +39,7 @@ label.mchoice-option {
     margin-top: 10px;
     margin-bottom: 0;
 }
+
+.mchoice-feedback-icon {
+    display: block;
+}

--- a/bases/rsptx/interactives/runestone/mchoice/css/mchoice.css
+++ b/bases/rsptx/interactives/runestone/mchoice/css/mchoice.css
@@ -20,6 +20,10 @@
     display: inline;
 }
 
+.multiplechoice_section label > span[aria-hidden="true"] > .para {
+    display: inline;
+}
+
 /* The timed assessment strips off the container with the .multiplechoice_section class,
    so we need to apply the same styles to the .timedAssessment class */
 .timedAssessment .mchoice label > .para {

--- a/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
+++ b/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
@@ -12,6 +12,10 @@
 ==========================================*/
 
 import RunestoneBase from "../../common/js/runestonebase.js";
+import {
+    disableMathJaxTabStops,
+    getAccessibleElementText,
+} from "../../common/js/mathjax-a11y.js";
 //import "./../styles/runestone.css";
 import "../css/mchoice.css";
 
@@ -53,7 +57,10 @@ export default class MultipleChoice extends RunestoneBase {
         // https://docs.mathjax.org/en/latest/options/startup/startup.html
         // https://docs.mathjax.org/en/latest/web/configuration.html#startup-action
         // runestoneMathReady is defined in the preamble for all PTX authored books
-        this.queueMathJax(this.containerDiv);
+        this.queueMathJax(this.containerDiv).then(() => {
+            this.updateMathJaxOptionLabels();
+            this.disableOptionMathJaxTabStops();
+        });
         if (typeof Prism !== "undefined") {
             Prism.highlightAllUnder(this.containerDiv);
         }
@@ -208,12 +215,9 @@ export default class MultipleChoice extends RunestoneBase {
     }
 
     renderMCFormOpts() {
-        // creates input DOM elements
-        this.optionArray = []; // array with an object for each option containing the input and label for that option
-        var input_type = "radio";
-        if (this.multipleanswers) {
-            input_type = "checkbox";
-        }
+        // Creates input DOM elements.
+        this.optionArray = []; // Array with an object for each option containing its input and content div.
+        const inputType = this.multipleanswers ? "checkbox" : "radio";
         // this.indexArray is used to index through the answers
         // it is just 0-n normally, but the order is shuffled if the random option is present
         this.indexArray = [];
@@ -229,32 +233,75 @@ export default class MultipleChoice extends RunestoneBase {
         };
         for (var j = 0; j < this.answerList.length; j++) {
             var k = this.indexArray[j];
-            var optid = this.divid + "_opt_" + k;
-            // Create the label for the input
-            var label = document.createElement("label");
-            label.className = "mchoice-option";
-            // If the content begins with a ``<p>``, put the label inside of it. (Sphinx 2.0 puts all content in a ``<p>``, while Sphinx 1.8 doesn't).
-            var content = this.answerList[k].content;
-            var prefix = "";
-            if (content.startsWith("<p>")) {
-                prefix = "<p>";
-                content = content.slice(3);
-            }
-            label.innerHTML =
-                `${prefix}<input type="${input_type}" name="group1" value="${k}" id="${optid}" class="mchoice-input">` +
-                `${String.fromCharCode("A".charCodeAt(0) + j)}. ${content}`;
-            // create the object to store in optionArray
-            var inputEl = label.querySelector("input");
-            var optObj = {
-                input: inputEl,
-                label: label,
-            };
-            optObj.input.onclick = answerFunc;
+            const optObj = this.createMCOption(k, j, inputType, answerFunc);
 
             this.optionArray.push(optObj);
             // add the option to the form
-            this.optsFieldSet.appendChild(label);
+            this.optsFieldSet.appendChild(optObj.label);
         }
+    }
+
+    createMCOption(answerIndex, displayIndex, inputType, answerFunc) {
+        const optionId = this.divid + "_opt_" + answerIndex;
+        const optionLetter = String.fromCharCode(
+            "A".charCodeAt(0) + displayIndex,
+        );
+        const content = this.answerList[answerIndex].content;
+        const label = document.createElement("label");
+        label.className = "mchoice-option";
+
+        let input;
+        let accessibleText;
+        let visibleContent;
+        if (this.containsMathJax(content)) {
+            input = document.createElement("input");
+            input.type = inputType;
+            input.name = "group1";
+            input.value = answerIndex;
+            input.id = optionId;
+            input.className = "mchoice-input";
+
+            accessibleText = document.createElement("span");
+            accessibleText.className = "visuallyhidden";
+            accessibleText.textContent = `Option ${optionLetter}. Content follows.`;
+
+            visibleContent = document.createElement("span");
+            visibleContent.innerHTML = `${optionLetter}. ${content}`;
+            label.append(input, accessibleText, visibleContent);
+        } else {
+            let labelContent = content;
+            let prefix = "";
+            if (labelContent.startsWith("<p>")) {
+                prefix = "<p>";
+                labelContent = labelContent.slice(3);
+            }
+            label.innerHTML =
+                `${prefix}<input type="${inputType}" name="group1" value="${answerIndex}" id="${optionId}" class="mchoice-input">` +
+                `${optionLetter}. ${labelContent}`;
+            input = label.querySelector("input");
+        }
+
+        input.onclick = answerFunc;
+        return { input, label, accessibleText, visibleContent };
+    }
+
+    updateMathJaxOptionLabels() {
+        for (const option of this.optionArray) {
+            if (!option.accessibleText) {
+                continue;
+            }
+            option.accessibleText.textContent =
+                `Option ${getAccessibleElementText(option.visibleContent)}`;
+            option.visibleContent.setAttribute("aria-hidden", "true");
+        }
+    }
+
+    containsMathJax(content) {
+        return /MathJax|mjx-container|process-math/.test(content);
+    }
+
+    disableOptionMathJaxTabStops() {
+        disableMathJaxTabStops(this.containerDiv, [".mchoice-option"]);
     }
 
     renderMCFormButtons() {

--- a/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
+++ b/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
@@ -565,10 +565,10 @@ export default class MultipleChoice extends RunestoneBase {
         var numNeeded = this.correctList.length;
         var feedbackText = this.feedbackString;
         if (this.correct) {
-            this.feedBackDiv.innerHTML = `✔️ <ol type="A">${feedbackText}</ul>`;
+            this.feedBackDiv.innerHTML = `<span class="visuallyhidden">Feedback: Correct</span><span class="material-symbols-outlined mchoice-feedback-icon" aria-hidden="true">check_circle</span> <ol type="A">${feedbackText}</ol>`;
             this.feedBackDiv.className = "alert alert-info";
         } else {
-            this.feedBackDiv.innerHTML = `✖️ You gave ${numGiven} ${answerStr} and got ${numCorrect} correct of ${numNeeded} needed.<ol type="A">${feedbackText}</ul>`;
+            this.feedBackDiv.innerHTML = `<span class="visuallyhidden">Feedback: Incorrect</span><span class="material-symbols-outlined mchoice-feedback-icon" aria-hidden="true">error</span> You gave ${numGiven} ${answerStr} and got ${numCorrect} correct of ${numNeeded} needed.<ol type="A">${feedbackText}</ol>`;
             this.feedBackDiv.className = "alert alert-danger";
         }
         this.queueMathJax(this.feedBackDiv);
@@ -649,13 +649,13 @@ export default class MultipleChoice extends RunestoneBase {
         let feedbackText = this.singlefeedback;
 
         if (correct) {
-            this.feedBackDiv.innerHTML = "✔️ " + feedbackText;
-            this.feedBackDiv.className = "alert alert-info"; // use blue for better red/green blue color blindness
+            this.feedBackDiv.innerHTML = `<span class="visuallyhidden">Feedback: Correct</span><span class="material-symbols-outlined mchoice-feedback-icon" aria-hidden="true">check_circle</span> ` + feedbackText;
+            this.feedBackDiv.className = "alert alert-info";
         } else {
             if (feedbackText == null) {
                 feedbackText = "";
             }
-            this.feedBackDiv.innerHTML = "✖️ " + feedbackText;
+            this.feedBackDiv.innerHTML = `<span class="visuallyhidden">Feedback: Incorrect</span><span class="material-symbols-outlined mchoice-feedback-icon" aria-hidden="true">error</span> ` + feedbackText;
             this.feedBackDiv.className = "alert alert-danger";
         }
         this.queueMathJax(this.feedBackDiv);

--- a/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
+++ b/bases/rsptx/interactives/runestone/mchoice/js/mchoice.js
@@ -181,18 +181,18 @@ export default class MultipleChoice extends RunestoneBase {
         this.optsForm.onsubmit = function () {
             return false;
         };
-        // Add fieldset and legend for accessibility
+        // Add fieldset and legend for accessibility - legend must come before the options
+        // so screen readers read the legend first.
         this.optsFieldSet = document.createElement("fieldset");
-        this.optsFieldSet.setAttribute("role", "radiogroup");
+        this.optsFieldSet.setAttribute(
+            "role",
+            this.multipleanswers ? "group" : "radiogroup",
+        );
         this.optsFieldSet.setAttribute(
             "aria-labelledby",
             this.divid + "_prompt",
         );
         this.optsForm.appendChild(this.optsFieldSet);
-        // generate form options
-        this.renderMCFormOpts();
-        this.renderMCFormButtons();
-        // Append the form to the container
         let legend = document.createElement("legend");
         if (this.multipleanswers) {
             legend.textContent = "Choose all that apply";
@@ -200,6 +200,10 @@ export default class MultipleChoice extends RunestoneBase {
             legend.textContent = "Choose one";
         }
         this.optsFieldSet.appendChild(legend);
+        // generate form options
+        this.renderMCFormOpts();
+        this.renderMCFormButtons();
+        // Append the form to the container
         this.containerDiv.appendChild(this.optsForm);
     }
 

--- a/bases/rsptx/interactives/runestone/mchoice/test/mchoice.test.js
+++ b/bases/rsptx/interactives/runestone/mchoice/test/mchoice.test.js
@@ -59,6 +59,28 @@ describe("construction", () => {
         expect(mc.correctIndexList).toEqual([0]);
         expect(mc.optionArray.map((o) => o.input.value)).toEqual(["0", "1"]);
     });
+
+    it("builds a MathJax option label from MathJax speech text", () => {
+        const mc = makeMC();
+        mc.answerList[1].content = `<span class="process-math">\\(x^2\\)</span>`;
+        const option = mc.createMCOption(1, 1, "radio", vi.fn());
+        const mathContent = option.visibleContent.querySelector(".process-math");
+        mathContent.innerHTML = `<mjx-container aria-label="x squared"></mjx-container>`;
+        mc.optionArray = [option];
+
+        mc.optsFieldSet.appendChild(option.label);
+        mc.updateMathJaxOptionLabels();
+
+        expect(option.label.tagName).toBe("LABEL");
+        expect(option.label.getAttribute("aria-label")).toBeNull();
+        expect(option.accessibleText.textContent).toBe("Option B. x squared");
+        expect(option.visibleContent.getAttribute("aria-hidden")).toBe("true");
+
+        option.label.click();
+        mc.disableOptionMathJaxTabStops();
+        expect(mathContent.firstElementChild.getAttribute("tabindex")).toBe("-1");
+        expect(option.input.checked).toBe(true);
+    });
 });
 
 describe("logging a first-choice answer (issue #1319)", () => {

--- a/bases/rsptx/interactives/runestone/mchoice/test/mchoice.test.js
+++ b/bases/rsptx/interactives/runestone/mchoice/test/mchoice.test.js
@@ -103,9 +103,9 @@ describe("restoring a first-choice answer", () => {
         mc.restoreAnswers({ answer: "0", correct: true });
         expect(optWithValue(mc, 0).input.checked).toBe(true);
         // Correct answers use the blue info alert; a blanked answer would fall
-        // through to alert-danger (the pink ✖️ box from the bug report).
+        // through to alert-danger with error symbol.
         expect(mc.feedBackDiv.className).toContain("alert-info");
-        expect(mc.feedBackDiv.innerHTML).toContain("✔️");
+        expect(mc.feedBackDiv.innerHTML).toContain(`<span class="material-symbols-outlined mchoice-feedback-icon" aria-hidden="true">check_circle</span>`);
     });
 
     it("round-trips: what gets logged for choice 0 restores correctly", async () => {


### PR DESCRIPTION
Changes for mchoice screen reader accessibility.

General lessons:
* Legends need to be first thing in fieldsets.
* Unicode characters like the purple check and X provide issues visually (contrast) and for screen readers. The "X" is pronounced "multiplied". 
* MathJax does not work correctly inside native labels.