### PR TITLE
Fix CodeTailor Parsons puzzle asymmetric block indentation

### DIFF
--- a/bases/rsptx/book_server_api/routers/coach.py
+++ b/bases/rsptx/book_server_api/routers/coach.py
@@ -189,7 +189,7 @@ def _build_static_parsons_response(
     """Return the ||split|| response string for a pre-defined (non-LLM) backup Parsons problem."""
     parsons_html = f"""
             <pre class="parsonsblocks" data-question_label="1" data-numbered="left" {parsons_attrs} style="visibility: hidden;">
-            {parsonsexample_code}
+{parsonsexample_code}
             </pre>
             """
     return (
@@ -509,7 +509,7 @@ async def parsons_scaffolding(
             example_block = re.sub(r"<(?=\S)", "< ", example_block)
             parsons_html = f"""
             <pre class="parsonsblocks" data-question_label="1" data-numbered="left" {parsons_attrs} style="visibility: hidden;">
-            {example_block}
+{example_block}
             </pre>
             """
             return (
@@ -563,7 +563,7 @@ async def parsons_scaffolding(
             )
             personalized_Parsons_html = f"""
             <pre class="parsonsblocks" data-question_label="1" data-numbered="left" {parsons_attrs} style="visibility: hidden;">
-            {personalized_Parsons_block}
+{personalized_Parsons_block}
             </pre>
             """
             print(

--- a/bases/rsptx/book_server_api/routers/personalized_parsons/generate_parsons_blocks.py
+++ b/bases/rsptx/book_server_api/routers/personalized_parsons/generate_parsons_blocks.py
@@ -439,7 +439,8 @@ def aggregate_code_to_Parsons_block_with_distractor(blocks):
                 )
                 if count_fixed == 0:
                     # then this is just a start of a distractor block stack, moved what we have stored in the block stack to the all_Parsons_blocks first
-                    all_Parsons_blocks[block_stack[0][0]] = block_stack
+                    for stacked_index, stacked_content in block_stack:
+                        all_Parsons_blocks[stacked_index] = stacked_content
                 # then continue
                 fixed_line_block, distractor_block = extract_distractor_Parsons_block(
                     block_stack
@@ -464,7 +465,8 @@ def aggregate_code_to_Parsons_block_with_distractor(blocks):
                     )
                     if count_fixed == 0:
                         # then this is just a start of a distractor block stack, moved what we have stored in the block stack to the all_Parsons_blocks first
-                        all_Parsons_blocks[block_stack[0][0]] = block_stack
+                        for stacked_index, stacked_content in block_stack:
+                            all_Parsons_blocks[stacked_index] = stacked_content
                     # then continue
                     (
                         fixed_line_block,


### PR DESCRIPTION
The first block of a generated Parsons puzzle was sitting on the same source line as the {personalized_Parsons_block} placeholder in coach.py's f-string templates, so it inherited that line's own Python-source indentation while every other block (after an embedded newline) didn't -- producing a spurious indentation requirement on every block but the first, even for flat, unnested code.

Also fix a related crash: aggregate_code_to_Parsons_block_with_distractor stored the raw block_stack list instead of flushing each item as a string when a settled/unchanged run preceded a paired-distractor block whose matched-fixed line hadn't been seen yet, causing check_settled_tag to throw TypeError: expected string or bytes-like object, got 'list'.