### PR TITLE
Fix CodeTailor Parsons blocks mangling comparison operators

### DIFF
--- a/bases/rsptx/book_server_api/routers/coach.py
+++ b/bases/rsptx/book_server_api/routers/coach.py
@@ -170,6 +170,25 @@ def extract_parsons_solution(parsonsexample_code):
     return "\n".join(clean_lines)
 
 
+def _escape_parsons_block_markup(block_markup):
+    """
+    The generated "---"-separated block markup is about to be embedded into a
+    <pre class="parsonsblocks"> element and re-parsed from innerHTML by
+    parsons.js, so a bare "<" in the code (e.g. "if hours <= 1:") would be
+    misread as the start of an HTML tag. HTML-escape it -- the Parsons widget
+    renders entities back to their literal characters, the same way it already
+    handles the escaped DB-authored markup (see extract_parsons_code).
+
+    "<" is the only character that actually breaks parsing here -- ">" is plain
+    data in element content and "&" only matters before a valid entity name --
+    but html.escape covers "&"/">" too, which round-trip harmlessly through the
+    widget. A previous version instead inserted a space after "<", which turned
+    every "<="/"<" in the code into "< ="/"< ". The generated code never
+    contains pre-existing entities, so escaping is safe to apply unconditionally.
+    """
+    return html.escape(block_markup, quote=False)
+
+
 def _extract_suffix_code_from_htmlsrc(htmlsrc):
     """
     Book-authored activecode questions never get question_json.suffix_code
@@ -518,7 +537,7 @@ async def parsons_scaffolding(
                 [],
                 {},
             )
-            example_block = re.sub(r"<(?=\S)", "< ", example_block)
+            example_block = _escape_parsons_block_markup(example_block)
             parsons_html = f"""
             <pre class="parsonsblocks" data-question_label="1" data-numbered="left" {parsons_attrs} style="visibility: hidden;">
 {example_block}
@@ -570,8 +589,8 @@ async def parsons_scaffolding(
                 + personalized_generation_result_type
             )
         else:
-            personalized_Parsons_block = re.sub(
-                r"<(?=\S)", "< ", personalized_Parsons_block
+            personalized_Parsons_block = _escape_parsons_block_markup(
+                personalized_Parsons_block
             )
             personalized_Parsons_html = f"""
             <pre class="parsonsblocks" data-question_label="1" data-numbered="left" {parsons_attrs} style="visibility: hidden;">


### PR DESCRIPTION
Before embedding the generated "---"-separated block markup into a <pre class="parsonsblocks"> element, coach.py ran
re.sub(r"<(?=\S)", "< ", block) to keep a bare "<" in the code from being misread as an HTML tag when parsons.js re-parses the element's innerHTML. That regex fired on every "<" followed by a non-space, so Python comparison operators were corrupted in the puzzle: "hours <= 1" rendered (and got dragged into the assembled solution) as "hours < = 1", and the code no longer ran.

Escape "<" to "&lt;" instead. The Parsons widget already renders escaped entities back to their literal characters (that's how DB-authored markup survives extract_parsons_code), so the blocks now show "<=" correctly with no tag-injection risk. Only "<" is escaped, matching the original scope -- bare "&"/">" were never touched and render fine inside <pre>.

The clipboard "copy answer" path is unaffected: it uses the separate first ||split|| segment (the plain code solution), not the escaped block markup.