### PR TITLE
Strengthen password validation

### DIFF
--- a/bases/rsptx/admin_server_api/routers/instructor.py
+++ b/bases/rsptx/admin_server_api/routers/instructor.py
@@ -64,7 +64,11 @@ from rsptx.db.crud import (
 from rsptx.auth.session import auth_manager
 from rsptx.auth.email import send_welcome_email
 from rsptx.templates import get_shared_templates
-from rsptx.validation.fields import clean_text, validate_text_field
+from rsptx.validation.fields import (
+    clean_text,
+    validate_password,
+    validate_text_field,
+)
 from rsptx.validation.schemas import AssignmentsSearchRequest
 from rsptx.configuration import settings
 from rsptx.endpoint_validators import with_course, instructor_role_required
@@ -1047,7 +1051,9 @@ async def enroll_students(
         # Spreadsheet exports routinely carry stray whitespace -- most painfully a
         # newline inside a cell, which used to be stored verbatim and then break
         # eBookConfig (and therefore every component) on the student's pages.
-        row = [field.strip() for field in row]
+        row = [
+            field.strip() if index != 4 else field for index, field in enumerate(row)
+        ]
         if not any(row):
             # A blank line, e.g. the trailing newline at the end of the file.
             continue
@@ -1075,6 +1081,17 @@ async def enroll_students(
             row = row[:6]  # Only take the first 6 columns
             mess = "Row has more than 6 columns, truncating."
             rslogger.warning(f"Row has more than 6 columns, truncating: {row}")
+        password_error = validate_password(row[4])
+        if password_error:
+            results.append(
+                {
+                    "username": row[0],
+                    "status": f"error: {password_error}",
+                    "category": "error",
+                }
+            )
+            failed += 1
+            continue
         try:
             user_data = AuthUserValidator(
                 username=row[0],

--- a/components/rsptx/validation/fields.py
+++ b/components/rsptx/validation/fields.py
@@ -49,7 +49,7 @@ def validate_text_field(
     return None
 
 
-def validate_password(password: str, min_length: int = 6) -> str | None:
+def validate_password(password: str, min_length: int = 10) -> str | None:
     """Validate a password without altering it.
 
     Passwords are deliberately not stripped -- leading or trailing spaces can be

--- a/test/components/rsptx/validation/test_fields.py
+++ b/test/components/rsptx/validation/test_fields.py
@@ -60,11 +60,21 @@ def test_password_rejects_whitespace_only(password):
     assert validate_password(password) == "Password is required."
 
 
-def test_password_rejects_short():
-    assert validate_password("abc") == "Password must be at least 6 characters."
+@pytest.mark.parametrize("password", ["a", "abcdefghi"])
+def test_password_rejects_short(password):
+    assert validate_password(password) == "Password must be at least 10 characters."
 
 
-@pytest.mark.parametrize("password", ["correct horse", "abcdef", "  pad  d  "])
+@pytest.mark.parametrize(
+    "password",
+    [
+        "abcdefghij",
+        "correct horse",
+        "abcdef1234",
+        "  pad  d  ",
+        "P@ssw0rd!x",
+    ],
+)
 def test_password_accepts_valid(password):
     """Passwords are not stripped -- internal and edge spaces are legitimate."""
     assert validate_password(password) is None


### PR DESCRIPTION
## Summary
- Increase the minimum password length from 6 to 10 characters.
- Enforce the shared password validator for instructor CSV student enrollment.
- Preserve leading and trailing password spaces while trimming other CSV fields.
- Update password validation tests for the new policy.

## Testing
- 30 password validation tests passed.
- Ruff checks passed.
- Ruff formatting check passed.
- git diff --check passed.

Closes #1307