### PR TITLE
Matching: override PTX SVG background color

### DIFF
--- a/bases/rsptx/interactives/runestone/matching/css/matching.css
+++ b/bases/rsptx/interactives/runestone/matching/css/matching.css
@@ -145,6 +145,8 @@
     height: 100%;
     pointer-events: none;
     z-index: 0;
+    /* fix for overzealous PTX image background color */
+    --ptx-image-bg: transparent;
 }
 
 .line {


### PR DESCRIPTION
Fix for issue reported by Sean for matching questions in PTX dark mode.