### PR TITLE
Fix CodeTailor question lookup failing in cloned courses

### DIFF
--- a/bases/rsptx/book_server_api/routers/coach.py
+++ b/bases/rsptx/book_server_api/routers/coach.py
@@ -397,6 +397,18 @@ async def parsons_scaffolding(
         basecourse = getattr(course, "base_course", None)
         question = await fetch_question(problem_id, basecourse=basecourse)
         if not question:
+            # A cloned course keeps the original book's base_course on its
+            # question rows, and selectquestion can pull an exercise from
+            # another book, so the base-course-scoped lookup misses even
+            # though the question exists. Fall back to a global name match --
+            # the same resolution get_question_source and /htmlsrc use.
+            question = await fetch_question(problem_id)
+            if question:
+                rslogger.warning(
+                    f"CodeTailor: '{problem_id}' not in base course '{basecourse}' "
+                    f"(likely a cloned course); resolved via global name match"
+                )
+        if not question:
             rslogger.error(
                 f"CodeTailor: no question found for problem_id '{problem_id}'"
             )


### PR DESCRIPTION
parsons_scaffolding resolved the activecode's question row with fetch_question(problem_id, basecourse=course.base_course). A cloned course keeps the original book's base_course on its question rows, and selectquestion can pull an exercise from another book, so that base-course-scoped lookup returns nothing and the endpoint 400s with "question '<id>' not found" -- the student's "get help" button is dead.

Fall back to a global name match (fetch_question(problem_id) with no basecourse) when the scoped lookup misses, the same resolution get_question_source and /htmlsrc already use. The scoped lookup still runs first so the single-book case is unchanged, and a warning is logged when the fallback fires so a genuine duplicate div_id across books stays diagnosable.