### PR TITLE
Report assignment-download timestamps in the instructor's local time

### DIFF
--- a/bases/rsptx/assignment_server_api/routers/instructor.py
+++ b/bases/rsptx/assignment_server_api/routers/instructor.py
@@ -1514,22 +1514,25 @@ async def do_download_assignment(
             detail=f"Assignment questions for {assignment_id} not found",
         )
 
+    # ``tz_offset`` is UTC minus local time in hours (Date.getTimezoneOffset() / 60),
+    # and useinfo timestamps are stored as naive UTC, so local time is the stored
+    # timestamp *minus* the offset -- as in analytics.py and rsptx.practice.core.
+    tz_offset_hours = 0.0
     if RS_info:
         rslogger.debug(f"RS_info Cookie {RS_info}")
         # Note that to get to the value of the cookie you must use ``.value``
         try:
-            parsed_js = json.loads(RS_info)
+            tz_offset_hours = float(json.loads(RS_info).get("tz_offset", 0))
         except Exception:
-            parsed_js = {}
+            rslogger.warning("Could not parse RS_info cookie for tz_offset")
 
-    tzoffset = parsed_js.get("tz_offset", None)
-    dd = datetime.timedelta(hours=int(tzoffset) if tzoffset is not None else 0)
+    dd = datetime.timedelta(hours=tz_offset_hours)
 
     csv_buffer = io.StringIO()
     csv_writer = csv.writer(csv_buffer)
     csv_writer.writerow(["Timestamp", "SID", "Div ID", "Event", "Act"])
     for row in res:
-        csv_row = [row.ts + dd, row.sid, row.name, row.event, row.act]
+        csv_row = [row.ts - dd, row.sid, row.name, row.event, row.act]
         csv_writer.writerow(csv_row)
     csv_buffer.seek(0)
 

--- a/test/bases/rsptx/assignment_server_api/test_instructor_routes.py
+++ b/test/bases/rsptx/assignment_server_api/test_instructor_routes.py
@@ -107,7 +107,10 @@ async def test_course_roster_rejects_non_instructor(auth_student_client):
 # GET /instructor/assignments/{id}/late_students
 # ---------------------------------------------------------------------------
 
+import csv  # noqa: E402
 import datetime  # noqa: E402
+import io  # noqa: E402
+import json  # noqa: E402
 
 from rsptx.db.crud import (  # noqa: E402
     create_assignment,
@@ -792,3 +795,77 @@ async def test_a_private_assignment_on_a_book_is_still_importable(
         f"/instructor/assignments/{base_course_private_assignment.id}/import"
     )
     assert resp.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# GET /instructor/download_assignment/{id}
+# ---------------------------------------------------------------------------
+
+# useinfo timestamps are naive UTC (canonical_utcnow), and the RS_info cookie's
+# ``tz_offset`` is UTC minus local time in hours, the way bookfuncs.js sends it
+# (Date.getTimezoneOffset() / 60: +5 for US Eastern, -5.5 for India). So the
+# instructor's local time is the stored timestamp minus the offset.
+DOWNLOAD_UTC_TS = datetime.datetime(2026, 3, 10, 2, 0, 0)
+
+
+@pytest.fixture(scope="session")
+async def download_assignment(instructor_user):
+    """An assignment with a single submission logged at a known UTC time."""
+    course = await fetch_course(LATE_COURSE)
+    q = await _add_question("download_route_q1")
+    assignment = await _add_assignment(course.id, "download_route_assignment", False)
+    await _link_question(assignment.id, q.id)
+    await _add_useinfo("download_student", "download_route_q1", DOWNLOAD_UTC_TS)
+    return assignment
+
+
+async def _download_rows(client, assignment_id, rs_info=None):
+    headers = {"Cookie": f"RS_info={rs_info}"} if rs_info is not None else {}
+    resp = await client.get(
+        f"/instructor/download_assignment/{assignment_id}", headers=headers
+    )
+    assert resp.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(resp.text)))
+    return [r for r in rows if r["SID"] == "download_student"]
+
+
+@pytest.mark.parametrize(
+    "tz_offset,expected_local",
+    [
+        # US Eastern, UTC-5: 02:00 UTC is 21:00 the previous day.
+        (5.0, "2026-03-09 21:00:00"),
+        # India, UTC+5:30: 02:00 UTC is 07:30 the same day. Half-hour zones only
+        # come out right if the offset keeps its fractional part.
+        (-5.5, "2026-03-10 07:30:00"),
+        # UTC instructor: unchanged.
+        (0, "2026-03-10 02:00:00"),
+    ],
+)
+async def test_download_assignment_reports_the_instructors_local_time(
+    auth_instructor_client, download_assignment, tz_offset, expected_local
+):
+    """The CSV shows local time, matching what the analytics reports show.
+
+    Reported by instructors as downloaded logfiles disagreeing with the
+    on-screen reports for the same submissions.
+    """
+    rows = await _download_rows(
+        auth_instructor_client,
+        download_assignment.id,
+        json.dumps({"tz_offset": tz_offset, "timezone": "test"}),
+    )
+    assert len(rows) == 1
+    assert rows[0]["Timestamp"] == expected_local
+
+
+async def test_download_assignment_without_an_rs_info_cookie(
+    auth_instructor_client, download_assignment
+):
+    """An instructor who never loaded a book page has no RS_info cookie.
+
+    The offset is then unknown, so the stored UTC timestamp is reported as-is
+    rather than the request failing.
+    """
+    rows = await _download_rows(auth_instructor_client, download_assignment.id)
+    assert len(rows) == 1
+    assert rows[0]["Timestamp"] == "2026-03-10 02:00:00"


### PR DESCRIPTION
`download_assignment` adds the timezone offset where every other reader subtracts it, so the CSV lands **two offsets away** from the truth: for a US Eastern instructor a 02:00 UTC submission is written as `07:00` instead of `21:00` the day before.

`tz_offset` is `Date.getTimezoneOffset() / 60` from `bookfuncs.js`, i.e. UTC minus local (`+5` EST, `-5.5` IST), and `useinfo.timestamp` is naive UTC from `canonical_utcnow()`. So local time is the stored timestamp *minus* the offset — what `analytics.py` does at all ten of its conversion sites (`x - tdoff`) and what `rsptx/practice/core.py:39` does. `instructor.py` is the one site in eleven that adds, so the downloaded logfile disagrees with the Chapter Activity and Assignment Overview reports the same instructor sees in the same session.

Two smaller defects on the same four lines:

- `int(tzoffset)` is the only `int` cast among the six readers of this field; the rest use `float(...)` and the schema declares it `float`. Half-hour zones (India, South Australia, Newfoundland) silently lose 30 minutes.
- `parsed_js` is assigned inside `if RS_info:` but read unconditionally below it, so an instructor with no `RS_info` cookie gets an `UnboundLocalError`. It is the only one of nine inline `json.loads(RS_info)` sites with no initializer.

The patch adopts the block `analytics.py` already uses, which closes all three.

**Tests.** Four cases asserting the timestamp in the CSV rather than the offset: EST, IST, UTC, no cookie. Three fail on current `main` (`07:00:00`, `21:00:00`, a crash); the UTC case passes in both trees. Fixing only the cast leaves both offset cases red, only the sign leaves the half-hour case red, both leaves the no-cookie case red. Full suite 553 before, 557 after. Nothing covered this route previously — the file stops after `duplicate`/`delete`.

Not done here: the conversion is hand-written at eleven sites and `json.loads(RS_info)` at nine, with no shared helper, which is how a new report can re-derive the rule backwards. A `tz_offset_from_cookie()` / `to_local()` pair in `rsptx.response_helpers.core` would close that, but it spans two servers. Happy to follow up if you want it.