### PR TITLE
Ensure webwork js on assignment pages even using pretext templates

### DIFF
--- a/bases/rsptx/assignment_server_api/routers/student.py
+++ b/bases/rsptx/assignment_server_api/routers/student.py
@@ -1008,6 +1008,11 @@ async def doAssignment(
         del course_attrs["ptx_js_version"]
     else:
         ptx_js_version = "0.2"
+    # A book built without WeBWorK does not load pretext-webwork.js in its
+    # generated _base.html, but an assignment may include WeBWorK questions
+    # borrowed from another book.  Let the template know it must load the
+    # WeBWorK support itself in that case.
+    needs_webwork = any(q["question_type"] == "webwork" for q in questionslist)
     context = dict(  # This is all the variables that will be used in the doAssignment.html document
         course=course,
         request=request,
@@ -1036,6 +1041,7 @@ async def doAssignment(
         enforce_pastdue=enforce_pastdue,
         ptx_js_version=ptx_js_version,
         webwork_js_version=webwork_js_version,
+        needs_webwork=needs_webwork,
         latex_preamble_dict=preambles,
         wp_imports=get_webpack_static_imports(course),
         settings=settings,

--- a/components/rsptx/templates/assignment/student/doAssignment.html
+++ b/components/rsptx/templates/assignment/student/doAssignment.html
@@ -14,6 +14,31 @@ Do Assignment
     {% if origin == "PreTeXt" and using_ptx_base != "true" %}
     <link href="/ns/books/published/{{ course.base_course }}/_static/pretext/css/theme.css" rel="stylesheet" />
     {% endif %}
+
+    {# A book built without WeBWorK does not load pretext-webwork.js in its
+       generated _base.html, so an assignment that borrows WeBWorK questions
+       from another book has no handleWW() to activate them.  Load the support
+       here when the assignment needs it and nothing upstream supplied it.
+       handleWW() is only reached from the Activate button's onclick, so the
+       injected scripts have until the first click to arrive. #}
+    {% if needs_webwork %}
+    <script>
+        (function () {
+            var load = function (src) {
+                var s = document.createElement("script");
+                s.src = src;
+                document.head.appendChild(s);
+            };
+            if (typeof handleWW === "undefined") {
+                load("/ns/books/published/{{ course.course_name }}/_static/pretext/js/dist/pretext-webwork.js");
+            }
+            // handleWW() calls iFrameResize() on the problem iframe.
+            if (typeof iFrameResize === "undefined") {
+                load("https://webwork.runestone.academy/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.min.js");
+            }
+        })();
+    </script>
+    {% endif %}
 {% endblock %}
 
 

--- a/components/rsptx/templates/assignment/student/doAssignment.html
+++ b/components/rsptx/templates/assignment/student/doAssignment.html
@@ -24,17 +24,23 @@ Do Assignment
     {% if needs_webwork %}
     <script>
         (function () {
+            // A dynamically inserted script defaults to async, so two of them
+            // execute in whatever order they finish downloading.  Setting
+            // async = false puts them on the in-order list instead, which is
+            // what keeps the pair below in dependency order.
             var load = function (src) {
                 var s = document.createElement("script");
+                s.async = false;
                 s.src = src;
                 document.head.appendChild(s);
             };
-            if (typeof handleWW === "undefined") {
-                load("/ns/books/published/{{ course.course_name }}/_static/pretext/js/dist/pretext-webwork.js");
-            }
-            // handleWW() calls iFrameResize() on the problem iframe.
+            // The resizer goes first: handleWW() calls iFrameResize() on the
+            // iframe it builds for the problem.
             if (typeof iFrameResize === "undefined") {
                 load("https://webwork.runestone.academy/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.min.js");
+            }
+            if (typeof handleWW === "undefined") {
+                load("/ns/books/published/{{ course.course_name }}/_static/pretext/js/dist/pretext-webwork.js");
             }
         })();
     </script>


### PR DESCRIPTION
Currently if a book doesn't contain any WeBWorK questions and the instructor has the "Use PreTeXt based student pages" selected, there is no pretext-webwork.js loaded on the doAssignment page.  This PR fixes that (as well as the resizer which is also missing).  Assignments are checked for whether they contain any WeBWorK questions, and if so, we add the additional js (if it isn't already loaded).